### PR TITLE
feat: enrich planning cards with detailed data

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/model/Intervention.java
+++ b/client/src/main/java/com/materiel/suite/client/model/Intervention.java
@@ -13,6 +13,20 @@ public class Intervention {
   private LocalDateTime dateHeureFin;
   private String color; // hex
 
+  // Champs enrichis pour rendu "carte"
+  private String clientName;
+  private String siteLabel;
+  private String craneName;
+  private String truckName;
+  private String driverName;
+  private String agency;
+  private String status; // PLANNED, CONFIRMED, DONE, CANCELED...
+  private boolean favorite;
+  private String quoteNumber;
+  private String orderNumber;
+  private String deliveryNumber;
+  private String invoiceNumber;
+
   public Intervention(){}
   public Intervention(UUID id, UUID resourceId, String label, LocalDate start, LocalDate end, String color){
     this(id, resourceId, label, start.atStartOfDay(), end.atTime(LocalTime.of(18,0)), color);
@@ -42,4 +56,43 @@ public class Intervention {
 
   public String getColor(){ return color; }
   public void setColor(String color){ this.color = color; }
+
+  public String getClientName(){ return clientName; }
+  public void setClientName(String clientName){ this.clientName = clientName; }
+  public String getSiteLabel(){ return siteLabel; }
+  public void setSiteLabel(String siteLabel){ this.siteLabel = siteLabel; }
+  public String getCraneName(){ return craneName; }
+  public void setCraneName(String craneName){ this.craneName = craneName; }
+  public String getTruckName(){ return truckName; }
+  public void setTruckName(String truckName){ this.truckName = truckName; }
+  public String getDriverName(){ return driverName; }
+  public void setDriverName(String driverName){ this.driverName = driverName; }
+  public String getAgency(){ return agency; }
+  public void setAgency(String agency){ this.agency = agency; }
+  public String getStatus(){ return status; }
+  public void setStatus(String status){ this.status = status; }
+  public boolean isFavorite(){ return favorite; }
+  public void setFavorite(boolean favorite){ this.favorite = favorite; }
+  public String getQuoteNumber(){ return quoteNumber; }
+  public void setQuoteNumber(String quoteNumber){ this.quoteNumber = quoteNumber; }
+  public String getOrderNumber(){ return orderNumber; }
+  public void setOrderNumber(String orderNumber){ this.orderNumber = orderNumber; }
+  public String getDeliveryNumber(){ return deliveryNumber; }
+  public void setDeliveryNumber(String deliveryNumber){ this.deliveryNumber = deliveryNumber; }
+  public String getInvoiceNumber(){ return invoiceNumber; }
+  public void setInvoiceNumber(String invoiceNumber){ this.invoiceNumber = invoiceNumber; }
+
+  /** Heures lisibles pour la carte (08:00–17:00). */
+  public String prettyTimeRange(){
+    LocalTime s = dateHeureDebut != null ? dateHeureDebut.toLocalTime() : LocalTime.of(8,0);
+    LocalTime e = dateHeureFin != null ? dateHeureFin.toLocalTime() : LocalTime.of(17,0);
+    return String.format("%02d:%02d–%02d:%02d", s.getHour(), s.getMinute(), e.getHour(), e.getMinute());
+  }
+  public String driverInitials(){
+    if (driverName==null || driverName.isBlank()) return "";
+    String[] p = driverName.trim().split("\\s+");
+    String a = p[0].substring(0,1).toUpperCase();
+    String b = p.length>1? p[p.length-1].substring(0,1).toUpperCase() : "";
+    return a+b;
+  }
 }

--- a/client/src/main/java/com/materiel/suite/client/service/mock/MockPlanningService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/mock/MockPlanningService.java
@@ -21,14 +21,35 @@ public class MockPlanningService implements PlanningService {
       Resource r3 = new Resource(UUID.randomUUID(), "Nacelle 18m");
       resources.put(r1.getId(), r1); resources.put(r2.getId(), r2); resources.put(r3.getId(), r3);
       LocalDate base = LocalDate.now().with(java.time.DayOfWeek.MONDAY);
-      add(new Intervention(UUID.randomUUID(), r1.getId(), "Chantier Alpha", base.plusDays(0), base.plusDays(2), "#5E81AC"));
-      add(new Intervention(UUID.randomUUID(), r1.getId(), "Charpente Beta", base.plusDays(1), base.plusDays(3), "#A3BE8C"));
-      add(new Intervention(UUID.randomUUID(), r1.getId(), "Levage Gamma", base.plusDays(2), base.plusDays(2), "#EBCB8B"));
+      add(fillCard(new Intervention(UUID.randomUUID(), r1.getId(), "Chantier Alpha", base.plusDays(0), base.plusDays(2), "#5E81AC"),
+          "Durand BTP","Pont Anne-de-Bretagne","GMK4100L-1","Actros 26t","Bernard","Agence 1","PLANNED",true,
+          "Q-2025-014","C-2025-003",null,null,
+          LocalDateTime.of(base.plusDays(0), java.time.LocalTime.of(8,0)),
+          LocalDateTime.of(base.plusDays(0), java.time.LocalTime.of(12,30))));
+      add(fillCard(new Intervention(UUID.randomUUID(), r1.getId(), "Charpente Beta", base.plusDays(1), base.plusDays(3), "#A3BE8C"),
+          "BTP Construction","Hall logistique","LTM 1050","Actros 26t","Bruno","Agence 1","CONFIRMED",false,
+          "Q-2025-018",null,null,null,
+          LocalDateTime.of(base.plusDays(1), java.time.LocalTime.of(9,0)),
+          LocalDateTime.of(base.plusDays(1), java.time.LocalTime.of(17,0))));
+      add(fillCard(new Intervention(UUID.randomUUID(), r1.getId(), "Levage Gamma", base.plusDays(2), base.plusDays(2), "#EBCB8B"),
+          "Trx Publics","Passerelle Ouest","AC 100","—","Camille","Agence 2","PLANNED",false,
+          null,null,"BL-1023",null,
+          LocalDateTime.of(base.plusDays(2), java.time.LocalTime.of(7,30)),
+          LocalDateTime.of(base.plusDays(2), java.time.LocalTime.of(15,45))));
       add(new Intervention(UUID.randomUUID(), r2.getId(), "Usine Delta", base.plusDays(0), base.plusDays(0), "#88C0D0"));
       add(new Intervention(UUID.randomUUID(), r2.getId(), "Entretien", base.plusDays(4), base.plusDays(5), "#BF616A"));
     }
   }
   private void add(Intervention i){ interventions.put(i.getId(), i); }
+  private Intervention fillCard(Intervention i, String client, String site, String crane, String truck, String driver, String agency,
+                                String status, boolean fav, String quote, String order, String dn, String inv,
+                                LocalDateTime deb, LocalDateTime fin){
+    i.setClientName(client); i.setSiteLabel(site); i.setCraneName(crane); i.setTruckName(truck);
+    i.setDriverName(driver); i.setAgency(agency); i.setStatus(status); i.setFavorite(fav);
+    i.setQuoteNumber(quote); i.setOrderNumber(order); i.setDeliveryNumber(dn); i.setInvoiceNumber(inv);
+    i.setDateHeureDebut(deb); i.setDateHeureFin(fin);
+    return i;
+  }
 
   @Override public List<Resource> listResources(){ return new ArrayList<>(resources.values()); }
   @Override public Resource saveResource(Resource r){ if(r.getId()==null) r.setId(UUID.randomUUID()); resources.put(r.getId(), r); return r; }

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionTileRenderer.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionTileRenderer.java
@@ -1,0 +1,164 @@
+package com.materiel.suite.client.ui.planning;
+
+import com.materiel.suite.client.model.Intervention;
+
+import java.awt.*;
+
+/** Rendu "carte" riche pour une intervention (vue Planning). */
+final class InterventionTileRenderer {
+  /** Hauteur standard de la carte. */
+  int height(){ return PlanningUx.TILE_CARD_H; }
+
+  void paint(Graphics2D g2, Rectangle r, Intervention it, boolean hover, boolean selected){
+    // Ombre
+    g2.setColor(PlanningUx.TILE_SHADOW);
+    g2.fillRoundRect(r.x+3,r.y+3,r.width-6,r.height-6, PlanningUx.RADIUS, PlanningUx.RADIUS);
+    // Fond
+    g2.setColor(Color.WHITE);
+    g2.fillRoundRect(r.x,r.y,r.width,r.height, PlanningUx.RADIUS, PlanningUx.RADIUS);
+    g2.setColor(new Color(0xDADEE3));
+    g2.drawRoundRect(r.x,r.y,r.width,r.height, PlanningUx.RADIUS, PlanningUx.RADIUS);
+
+    // Barre accent à gauche
+    Color accent = PlanningUx.colorOr(it.getColor(), new Color(0x3B82F6));
+    g2.setColor(accent);
+    g2.fillRoundRect(r.x-8, r.y+8, 10, r.height-16, 6, 6);
+
+    // Overlays hover/selected
+    if (hover || selected){
+      g2.setColor(hover? PlanningUx.TILE_HOVER : PlanningUx.TILE_SELECT);
+      g2.fillRoundRect(r.x,r.y,r.width,r.height, PlanningUx.RADIUS, PlanningUx.RADIUS);
+    }
+
+    int x = r.x + 16;
+    int y = r.y + 14;
+
+    // Ligne 1 : heure, status, favoris, agence, menu
+    Font f0 = g2.getFont();
+    g2.setFont(f0.deriveFont(Font.BOLD, 18f));
+    String time = it.prettyTimeRange();
+    g2.setColor(new Color(0x0F172A));
+    g2.drawString(time, x, y+2);
+    g2.setFont(f0);
+
+    int right = r.x + r.width - 12;
+    // menu (3 points)
+    g2.setColor(new Color(0x8A8FA0));
+    int dotY = y-6;
+    for (int i=0;i<3;i++) g2.fillOval(right - i*10, dotY, 4,4);
+
+    // Favori (étoile simple)
+    int starX = x + 160;
+    paintStar(g2, starX, y-10, 16, new Color(0x1F2937));
+
+    // Status pill
+    String status = it.getStatus()==null? "PLANNED" : it.getStatus().toUpperCase();
+    Color sBg = switch(status){
+      case "CONFIRMED" -> new Color(0xD1FAE5);
+      case "DONE"      -> new Color(0xDBEAFE);
+      case "CANCELED"  -> new Color(0xFEE2E2);
+      default          -> new Color(0xE5E7EB);
+    };
+    Color sFg = new Color(0x0F172A);
+    int wStatus = Math.max(96, g2.getFontMetrics().stringWidth(status)+24);
+    PlanningUx.pill(g2, new Rectangle(x+92, y-18, wStatus, 28), sBg, sFg, status);
+
+    // Agence pill
+    String agency = it.getAgency()==null? "Agence ?" : it.getAgency();
+    int wAgency = Math.max(80, g2.getFontMetrics().stringWidth(agency)+24);
+    PlanningUx.pill(g2, new Rectangle(x+92+wStatus+8, y-18, wAgency, 28), new Color(0xEEF2FF), new Color(0x0F172A), agency);
+
+    // Ligne 2 : client
+    y += 24;
+    g2.setFont(f0.deriveFont(Font.BOLD, 16f));
+    String client = it.getClientName()==null? (it.getLabel()==null? "—" : it.getLabel()) : it.getClientName();
+    g2.setColor(new Color(0x111827));
+    g2.drawString(client, x, y+18);
+
+    // Ligne 3 : chantier
+    y += 22;
+    g2.setFont(f0.deriveFont(Font.PLAIN, 16f));
+    String site = "Chantier : " + (it.getSiteLabel()==null? "—" : it.getSiteLabel());
+    g2.setColor(new Color(0x1F2937));
+    g2.drawString(site, x, y+18);
+
+    // Séparateur
+    y += 28;
+    g2.setColor(new Color(0xE5E7EB));
+    g2.drawLine(x, y, r.x + r.width - 16, y);
+
+    // Ligne 4 : grue / camion
+    y += 10;
+    int colW = (r.width - 48)/2;
+    paintCraneIcon(g2, x, y+4);
+    g2.setColor(new Color(0x111827));
+    g2.drawString("Grue : " + nullToDash(it.getCraneName()), x+28, y+8);
+    paintTruckIcon(g2, x + colW, y+4);
+    g2.drawString("Camion : " + nullToDash(it.getTruckName()), x+colW+28, y+8);
+
+    // Séparateur 2
+    y += 22;
+    g2.setColor(new Color(0xE5E7EB));
+    g2.drawLine(x, y, r.x + r.width - 16, y);
+
+    // Ligne 5 : chauffeur + initiales
+    y += 10;
+    paintBadge(g2, x, y, it.driverInitials());
+    g2.setColor(new Color(0x1F2937));
+    g2.drawString("Chauffeur : " + nullToDash(it.getDriverName()), x+40, y+8);
+
+    // Ligne 6 : chips documents
+    y += 26;
+    int cx = x;
+    cx = chip(g2, cx, y, it.getQuoteNumber(), new Color(0xD1FAE5), new Color(0x176E43), "Devis ");
+    cx = chip(g2, cx+8, y, it.getOrderNumber(), new Color(0xFEF3C7), new Color(0xA16207), "Commande ");
+    cx = chip(g2, cx+8, y, it.getDeliveryNumber(), new Color(0xE5E7EB), new Color(0x374151), "BL ");
+    cx = chip(g2, cx+8, y, it.getInvoiceNumber(), new Color(0xE5E7EB), new Color(0x374151), "Fact. ");
+  }
+
+  /* Helpers de rendu */
+  private static String nullToDash(String s){ return (s==null || s.isBlank())? "—" : s; }
+
+  private static void paintStar(Graphics2D g2, int cx, int cy, int r, Color c){
+    Polygon p = new Polygon();
+    for (int i=0;i<5;i++){
+      double a = Math.toRadians(-90 + i*72);
+      double a2 = Math.toRadians(-90 + i*72 + 36);
+      p.addPoint((int)(cx + r*Math.cos(a)), (int)(cy + r*Math.sin(a)));
+      p.addPoint((int)(cx + (r/2.2)*Math.cos(a2)), (int)(cy + (r/2.2)*Math.sin(a2)));
+    }
+    g2.setColor(c);
+    g2.drawPolygon(p);
+  }
+  private static void paintCraneIcon(Graphics2D g2, int x, int y){
+    g2.setColor(new Color(0x0F172A));
+    g2.drawRect(x, y, 16, 12);
+    g2.drawLine(x+2, y+8, x+14, y+8);
+    g2.fillOval(x+2, y+12, 4,4);
+    g2.fillOval(x+10, y+12, 4,4);
+  }
+  private static void paintTruckIcon(Graphics2D g2, int x, int y){
+    g2.setColor(new Color(0x0F172A));
+    g2.drawRect(x+6, y, 16, 10);
+    g2.drawRect(x, y+4, 8, 8);
+    g2.fillOval(x+4, y+12, 4,4);
+    g2.fillOval(x+18, y+12, 4,4);
+  }
+  private static void paintBadge(Graphics2D g2, int x, int y, String txt){
+    int w = Math.max(28, g2.getFontMetrics().stringWidth(txt)+14);
+    g2.setColor(new Color(0xE5E7EB));
+    g2.fillOval(x, y-2, w, 22);
+    g2.setColor(new Color(0x9CA3AF));
+    g2.drawOval(x, y-2, w, 22);
+    g2.setColor(new Color(0x111827));
+    int tx = x + (w - g2.getFontMetrics().stringWidth(txt))/2;
+    int ty = y + g2.getFontMetrics().getAscent()/2 + 2;
+    g2.drawString(txt, tx, ty);
+  }
+  private static int chip(Graphics2D g2, int x, int y, String value, Color bg, Color fg, String prefix){
+    String text = prefix + (value==null? "—" : value);
+    int w = Math.max(90, g2.getFontMetrics().stringWidth(text)+24);
+    PlanningUx.pill(g2, new Rectangle(x, y, w, 28), bg, fg, text);
+    return x + w;
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
@@ -87,9 +87,9 @@ public class PlanningPanel extends JPanel {
       private int boardRowHeight(Resource r){
         var list = ServiceFactory.planning().listInterventions(board.getStartDate(), board.getStartDate().plusDays(6));
         list.removeIf(it -> !it.getResourceId().equals(r.getId()));
-        var lanes = LaneLayout.computeLanes(list, Intervention::getDateDebut, Intervention::getDateFin);
+        var lanes = LaneLayout.computeLanes(list, Intervention::getDateHeureDebut, Intervention::getDateHeureFin);
         int lanesCount = lanes.values().stream().mapToInt(l -> l.index).max().orElse(-1) + 1;
-        return Math.max(PlanningUx.TILE_H, lanesCount * (PlanningUx.TILE_H + PlanningUx.LANE_GAP)) + PlanningUx.ROW_GAP;
+        return Math.max(board.tileHeight(), lanesCount * (board.tileHeight() + PlanningUx.LANE_GAP)) + PlanningUx.ROW_GAP;
       }
     };
     scroll.setRowHeaderView(rowHeader);

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningUx.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningUx.java
@@ -23,7 +23,8 @@ final class PlanningUx {
   // Métriques
   static final int COL_MIN = 80;
   static final int COL_MAX = 220;
-  static final int TILE_H = 26;
+  static final int TILE_H = 26;        // tuile compacte (agenda, liste)
+  static final int TILE_CARD_H = 108;   // tuile "carte" du planning
   static final int LANE_GAP = 6;
   static final int ROW_GAP = 8;
   static final int RADIUS = 10;
@@ -72,5 +73,18 @@ final class PlanningUx {
       b.append(s.charAt(i));
     }
     return b.toString() + ell;
+  }
+
+  /** Pastille arrondie (status / agence / chips). */
+  static void pill(Graphics2D g2, Rectangle r, Color bg, Color fg, String text){
+    g2.setColor(bg);
+    g2.fillRoundRect(r.x, r.y, r.width, r.height, r.height, r.height);
+    g2.setColor(new Color(bg.darker().getRGB() & 0x33FFFFFF, true));
+    g2.drawRoundRect(r.x, r.y, r.width, r.height, r.height, r.height);
+    g2.setColor(fg);
+    FontMetrics fm = g2.getFontMetrics();
+    int tx = r.x + (r.width - fm.stringWidth(text))/2;
+    int ty = r.y + (r.height + fm.getAscent())/2 - 2;
+    g2.drawString(text, tx, ty);
   }
 }


### PR DESCRIPTION
## Summary
- add richer Intervention model fields (client, equipment, documents) and helper methods
- seed mock service with detailed card data
- implement card-style tile renderer and update planning board logic

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c40c1f80dc83308048da1dbf6cdb7a