### PR TITLE
Improve planning board layout and snapping

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningUx.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningUx.java
@@ -23,8 +23,8 @@ final class PlanningUx {
   // Métriques
   static final int COL_MIN = 80;
   static final int COL_MAX = 220;
-  static final int TILE_H = 26;        // tuile compacte (agenda, liste)
-  static final int TILE_CARD_H = 108;   // tuile "carte" du planning
+  static final int TILE_H = 26;         // tuile compacte (agenda, liste)
+  static final int TILE_CARD_H = 132;   // tuile "carte" du planning (plus grande, meilleure lisibilité)
   static final int LANE_GAP = 6;
   static final int ROW_GAP = 8;
   static final int RADIUS = 10;


### PR DESCRIPTION
## Summary
- Increase planning card tile height for better readability
- Expose planning board resources and row heights to sync row header
- Implement robust column snapping during drag and resize operations
- Keep row header updated when layout changes

## Testing
- `mvn -q -pl client -am test` *(failed: Non-resolvable import POM: Could not transfer artifact, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c412f79ff88330b946e08515c1a884