### PR TITLE
feat: add lock state for interventions

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/model/Intervention.java
+++ b/client/src/main/java/com/materiel/suite/client/model/Intervention.java
@@ -22,6 +22,7 @@ public class Intervention {
   private String agency;
   private String status; // PLANNED, CONFIRMED, DONE, CANCELED...
   private boolean favorite;
+  private boolean locked;
   private String quoteNumber;
   private String orderNumber;
   private String deliveryNumber;
@@ -73,6 +74,8 @@ public class Intervention {
   public void setStatus(String status){ this.status = status; }
   public boolean isFavorite(){ return favorite; }
   public void setFavorite(boolean favorite){ this.favorite = favorite; }
+  public boolean isLocked(){ return locked; }
+  public void setLocked(boolean locked){ this.locked = locked; }
   public String getQuoteNumber(){ return quoteNumber; }
   public void setQuoteNumber(String quoteNumber){ this.quoteNumber = quoteNumber; }
   public String getOrderNumber(){ return orderNumber; }
@@ -82,11 +85,15 @@ public class Intervention {
   public String getInvoiceNumber(){ return invoiceNumber; }
   public void setInvoiceNumber(String invoiceNumber){ this.invoiceNumber = invoiceNumber; }
 
-  /** Heures lisibles pour la carte (08:00–17:00). */
+  /** Libellé heure pour rendu. */
   public String prettyTimeRange(){
-    LocalTime s = dateHeureDebut != null ? dateHeureDebut.toLocalTime() : LocalTime.of(8,0);
-    LocalTime e = dateHeureFin != null ? dateHeureFin.toLocalTime() : LocalTime.of(17,0);
-    return String.format("%02d:%02d–%02d:%02d", s.getHour(), s.getMinute(), e.getHour(), e.getMinute());
+    if (dateHeureDebut!=null && dateHeureFin!=null){
+      LocalTime s = dateHeureDebut.toLocalTime();
+      LocalTime e = dateHeureFin.toLocalTime();
+      return String.format("%02d:%02d–%02d:%02d", s.getHour(), s.getMinute(), e.getHour(), e.getMinute());
+    }
+    return (getDateDebut()!=null? getDateDebut().toString() : "—")+
+        " → "+(getDateFin()!=null? getDateFin().toString() : "—");
   }
   public String driverInitials(){
     if (driverName==null || driverName.isBlank()) return "";

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionAgendaRenderer.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionAgendaRenderer.java
@@ -93,7 +93,7 @@ final class InterventionAgendaRenderer {
     ));
 
     // Cadenas si verrouillé
-    if (it.isLocked()){
+    if (it.isLocked()) {
       g2.setColor(new Color(0x374151));
       paintLock(g2, r.x+8, r.y+8);
     }


### PR DESCRIPTION
## Summary
- add locked flag and accessors to Intervention model
- improve pretty time range fallback logic
- render lock icon for locked interventions

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68c418b90950833097b772a395f81a2e