### PR TITLE
feat: add planning backend and adjustable slot grid

### DIFF
--- a/backend/src/main/java/com/materiel/suite/backend/config/WebConfig.java
+++ b/backend/src/main/java/com/materiel/suite/backend/config/WebConfig.java
@@ -1,0 +1,17 @@
+package com.materiel.suite.backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry.addMapping("/api/**")
+        .allowedMethods("GET","POST","PUT","DELETE","OPTIONS")
+        .allowedOrigins("*")
+        .allowedHeaders("*");
+  }
+}
+

--- a/backend/src/main/java/com/materiel/suite/backend/planning/InMemoryPlanningService.java
+++ b/backend/src/main/java/com/materiel/suite/backend/planning/InMemoryPlanningService.java
@@ -1,0 +1,64 @@
+package com.materiel.suite.backend.planning;
+
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.time.LocalDate;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class InMemoryPlanningService implements PlanningService {
+  private final Map<UUID, ResourceDto> resources = new ConcurrentHashMap<>();
+  private final Map<UUID, InterventionDto> interventions = new ConcurrentHashMap<>();
+
+  @PostConstruct
+  public void seed(){
+    if (!resources.isEmpty()) return;
+    ResourceDto r1 = new ResourceDto(UUID.randomUUID(), "Grue A");
+    ResourceDto r2 = new ResourceDto(UUID.randomUUID(), "Grue B");
+    ResourceDto r3 = new ResourceDto(UUID.randomUUID(), "Nacelle 18m");
+    resources.put(r1.id(), r1); resources.put(r2.id(), r2); resources.put(r3.id(), r3);
+
+    LocalDate base = LocalDate.now().with(java.time.DayOfWeek.MONDAY);
+    add(new InterventionDto(UUID.randomUUID(), r1.id(), "BTP Construction",
+        "Pont Anne-de-Bretagne", "GMK4100L-1", "Actros 26t", "Bruno", "Agence 1", "CONFIRMED",
+        false, "Q-2025-018", "C-2025-003", "BL-1023", null, "#7CB9E8", false,
+        base.atTime(9,0), base.atTime(17,0)));
+    add(new InterventionDto(UUID.randomUUID(), r1.id(), "Durand BTP",
+        "Passerelle Ouest", "AC 100", null, null, "Agence 2", "PLANNED",
+        false, null, null, null, null, "#A3BE8C", false,
+        base.plusDays(1).atTime(8,0), base.plusDays(1).atTime(12,30)));
+  }
+  private void add(InterventionDto d){ interventions.put(d.id(), d); }
+
+  @Override public List<ResourceDto> listResources(){ return new ArrayList<>(resources.values()); }
+  @Override public ResourceDto saveResource(ResourceDto r){
+    UUID id = r.id()==null? UUID.randomUUID() : r.id();
+    ResourceDto s = new ResourceDto(id, r.name());
+    resources.put(id, s);
+    return s;
+  }
+  @Override public void deleteResource(UUID id){ resources.remove(id); }
+
+  @Override public List<InterventionDto> listInterventions(LocalDate from, LocalDate to){
+    List<InterventionDto> list = new ArrayList<>();
+    for (var i : interventions.values()){
+      LocalDate sd = i.dateHeureDebut().toLocalDate();
+      LocalDate ed = i.dateHeureFin().toLocalDate();
+      if (!(ed.isBefore(from) || sd.isAfter(to))) list.add(i);
+    }
+    list.sort(Comparator.comparing(InterventionDto::dateHeureDebut));
+    return list;
+  }
+  @Override public InterventionDto saveIntervention(InterventionDto i){
+    UUID id = i.id()==null? UUID.randomUUID() : i.id();
+    InterventionDto s = new InterventionDto(id, i.resourceId(), i.clientName(), i.siteLabel(), i.craneName(),
+        i.truckName(), i.driverName(), i.agency(), i.status(), i.favorite(), i.quoteNumber(), i.orderNumber(),
+        i.deliveryNumber(), i.invoiceNumber(), i.color(), i.locked(), i.dateHeureDebut(), i.dateHeureFin());
+    interventions.put(id, s);
+    return s;
+  }
+  @Override public void deleteIntervention(UUID id){ interventions.remove(id); }
+}
+

--- a/backend/src/main/java/com/materiel/suite/backend/planning/InterventionDto.java
+++ b/backend/src/main/java/com/materiel/suite/backend/planning/InterventionDto.java
@@ -1,0 +1,26 @@
+package com.materiel.suite.backend.planning;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record InterventionDto(
+    UUID id,
+    UUID resourceId,
+    String clientName,
+    String siteLabel,
+    String craneName,
+    String truckName,
+    String driverName,
+    String agency,
+    String status,
+    boolean favorite,
+    String quoteNumber,
+    String orderNumber,
+    String deliveryNumber,
+    String invoiceNumber,
+    String color,
+    boolean locked,
+    LocalDateTime dateHeureDebut,
+    LocalDateTime dateHeureFin
+) {}
+

--- a/backend/src/main/java/com/materiel/suite/backend/planning/PlanningController.java
+++ b/backend/src/main/java/com/materiel/suite/backend/planning/PlanningController.java
@@ -1,0 +1,37 @@
+package com.materiel.suite.backend.planning;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api")
+@CrossOrigin(origins = "*")
+public class PlanningController {
+  private final PlanningService service;
+  public PlanningController(PlanningService service){ this.service = service; }
+
+  // Ressources
+  @GetMapping("/resources")
+  public List<ResourceDto> listResources(){ return service.listResources(); }
+  @PostMapping("/resources")
+  public ResourceDto saveResource(@RequestBody ResourceDto r){ return service.saveResource(r); }
+  @DeleteMapping("/resources/{id}")
+  public void deleteResource(@PathVariable UUID id){ service.deleteResource(id); }
+
+  // Interventions
+  @GetMapping("/interventions")
+  public List<InterventionDto> listInterventions(
+      @RequestParam @DateTimeFormat(iso= DateTimeFormat.ISO.DATE) LocalDate from,
+      @RequestParam @DateTimeFormat(iso= DateTimeFormat.ISO.DATE) LocalDate to){
+    return service.listInterventions(from, to);
+  }
+  @PostMapping("/interventions")
+  public InterventionDto saveIntervention(@RequestBody InterventionDto i){ return service.saveIntervention(i); }
+  @DeleteMapping("/interventions/{id}")
+  public void deleteIntervention(@PathVariable UUID id){ service.deleteIntervention(id); }
+}
+

--- a/backend/src/main/java/com/materiel/suite/backend/planning/PlanningService.java
+++ b/backend/src/main/java/com/materiel/suite/backend/planning/PlanningService.java
@@ -1,0 +1,16 @@
+package com.materiel.suite.backend.planning;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+public interface PlanningService {
+  List<ResourceDto> listResources();
+  ResourceDto saveResource(ResourceDto r);
+  void deleteResource(UUID id);
+
+  List<InterventionDto> listInterventions(LocalDate from, LocalDate to);
+  InterventionDto saveIntervention(InterventionDto i);
+  void deleteIntervention(UUID id);
+}
+

--- a/backend/src/main/java/com/materiel/suite/backend/planning/ResourceDto.java
+++ b/backend/src/main/java/com/materiel/suite/backend/planning/ResourceDto.java
@@ -1,0 +1,9 @@
+package com.materiel.suite.backend.planning;
+
+import java.util.UUID;
+
+public record ResourceDto(
+    UUID id,
+    String name
+) {}
+

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,6 +1,11 @@
 server:
   port: 8080
 spring:
+  application:
+    name: gestion-materiel-backend
+  jackson:
+    serialization:
+      WRITE_DATES_AS_TIMESTAMPS: false
   datasource:
     url: jdbc:h2:mem:testdb
     driverClassName: org.h2.Driver

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/DayHeader.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/DayHeader.java
@@ -23,15 +23,15 @@ public class DayHeader extends JComponent {
     int x=0, dayW = board.getDayPixelWidth();
     LocalDate d = board.getStartDate();
     for (int i=0;i<getWidth()/dayW+1;i++){
+      int slotW = board.getSlotWidth();
       g2.setColor(PlanningUx.GRID);
       g2.drawLine(x,0,x,getHeight());
       g2.setColor(PlanningUx.HEADER_TX);
       g2.drawString(DF.format(d.plusDays(i)), x+8, 14);
       g2.setFont(getFont().deriveFont(11f));
       g2.setColor(new Color(0x4B5563));
-      int sph = board.getSlotsPerDay()/24; // slots per hour
       for (int h=0; h<24; h+=2){
-        int px = x + h*sph*board.getSlotWidth();
+        int px = x + h*(60/board.getSlotMinutes())*slotW;
         String label = (h<10? "0":"")+h+":00";
         g2.drawString(label, px+4, getHeight()-12);
       }

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningBoard.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningBoard.java
@@ -107,7 +107,9 @@ public class PlanningBoard extends JComponent {
   public java.util.List<Resource> getResourcesList(){ return resources; }
   /** Hauteur d'une ligne (ressource). */
   public int rowHeight(UUID resId){ return rowHeights.getOrDefault(resId, tile.height() + PlanningUx.ROW_GAP); }
-  /** Largeur d'un slot (15 min). */
+  /** Durée d'un slot en minutes. */
+  public int getSlotMinutes(){ return slotMinutes; }
+  /** Largeur d'un slot en pixels. */
   public int getSlotWidth(){ return slotWidth; }
   /** Nombre de slots par jour. */
   public int getSlotsPerDay(){ return slotsPerDay; }
@@ -127,12 +129,13 @@ public class PlanningBoard extends JComponent {
   public void setDays(int d){ days = d; reload(); }
   public void setShowIndispo(boolean b){ showIndispo = b; repaint(); }
   public void setResourceNameFilter(String f){ resourceFilter = f==null? "" : f.toLowerCase(); reload(); }
-  public void setSnapMinutes(int m){
-    slotMinutes = Math.max(5, Math.min(60, m));
+  public void setSlotMinutes(int minutes){
+    slotMinutes = Math.max(5, Math.min(60, minutes));
     slotsPerDay = (60/slotMinutes)*24;
     revalidate(); repaint();
     firePropertyChange("layout", 0, 1);
   }
+  public void setSnapMinutes(int m){ setSlotMinutes(m); }
   public int tileHeight(){ return tile.height(); }
 
   public void reload(){

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
@@ -29,11 +29,9 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSlider;
-import javax.swing.JSpinner;
 import javax.swing.JTextField;
 import javax.swing.JToggleButton;
 import javax.swing.KeyStroke;
-import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 
@@ -111,9 +109,11 @@ public class PlanningPanel extends JPanel {
     JButton prev = new JButton("◀ Semaine");
     JButton next = new JButton("Semaine ▶");
     JButton today = new JButton("Aujourd'hui");
-    JLabel zoomL = new JLabel("Zoom:");
-    JSlider zoom = new JSlider(PlanningUx.COL_MIN, PlanningUx.COL_MAX, 120);
-    JSpinner snap = new JSpinner(new SpinnerNumberModel(15,5,60,5));
+    JLabel zoomL = new JLabel("Zoom (slot):");
+    JSlider zoom = new JSlider(6,24,board.getSlotWidth());
+    JLabel granL = new JLabel("Pas:");
+    JComboBox<String> gran = new JComboBox<>(new String[]{"5 min","10 min","15 min","30 min","60 min"});
+    gran.setSelectedItem(board.getSlotMinutes()+" min");
     JToggleButton mode = new JToggleButton("Agenda");
     conflictsBtn = new JButton("Conflits (0)");
     JButton addI = new JButton("+ Intervention");
@@ -124,13 +124,24 @@ public class PlanningPanel extends JPanel {
     prev.addActionListener(e -> { board.setStartDate(board.getStartDate().minusDays(7)); agenda.setStartDate(board.getStartDate()); });
     next.addActionListener(e -> { board.setStartDate(board.getStartDate().plusDays(7)); agenda.setStartDate(board.getStartDate()); });
     today.addActionListener(e -> { board.setStartDate(LocalDate.now().with(java.time.DayOfWeek.MONDAY)); agenda.setStartDate(board.getStartDate()); });
-    zoom.addChangeListener(e -> { board.setZoom(zoom.getValue()); agenda.setDayWidth(zoom.getValue()); revalidate(); repaint(); });
-    snap.addChangeListener(e -> { board.setSnapMinutes((Integer) snap.getValue()); agenda.setSnapMinutes((Integer) snap.getValue()); });
+    zoom.addChangeListener(e -> {
+      int w = zoom.getValue();
+      board.setZoom(w);
+      agenda.setDayWidth(w*10);
+      revalidate(); repaint();
+    });
+    gran.addActionListener(e -> {
+      String s = String.valueOf(gran.getSelectedItem());
+      int m = Integer.parseInt(s.replace(" min",""));
+      board.setSlotMinutes(m);
+      agenda.setSnapMinutes(m);
+      revalidate(); repaint();
+    });
     addI.addActionListener(e -> addInterventionDialog());
 
     bar.add(prev); bar.add(next); bar.add(today); bar.add(mode);
     bar.add(Box.createHorizontalStrut(16)); bar.add(zoomL); bar.add(zoom);
-    bar.add(new JLabel("Snap (min):")); bar.add(snap);
+    bar.add(Box.createHorizontalStrut(12)); bar.add(granL); bar.add(gran);
     bar.add(Box.createHorizontalStrut(8)); bar.add(conflictsBtn);
     bar.add(Box.createHorizontalStrut(16)); bar.add(addI);
     return bar;


### PR DESCRIPTION
## Summary
- expose in-memory planning REST API for resources and interventions
- allow planning board to change slot size and granularity via toolbar controls
- configure CORS and Spring app metadata

## Testing
- `mvn -q test` *(fails: Network is unreachable for Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c4182a0eec8330bac610055ad2b96f