### PR TITLE
Add fallback-aware start/end datetimes for interventions

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/model/Intervention.java
+++ b/client/src/main/java/com/materiel/suite/client/model/Intervention.java
@@ -58,6 +58,26 @@ public class Intervention {
   public String getColor(){ return color; }
   public void setColor(String color){ this.color = color; }
 
+  /** Start/End en LocalDateTime, toujours non-nulls (avec fallback raisonnable). */
+  public LocalDateTime getStartDateTime(){
+    if (dateHeureDebut != null) return dateHeureDebut;
+    LocalDate d = getDateDebut();
+    if (d != null) return d.atStartOfDay();
+    // Fallback minimal : maintenant
+    return LocalDateTime.now();
+  }
+
+  public LocalDateTime getEndDateTime(){
+    if (dateHeureFin != null) return dateHeureFin;
+    LocalDate d = getDateFin();
+    if (d != null){
+      // Inclusif journée : fin = début de jour suivant
+      return d.plusDays(1).atStartOfDay();
+    }
+    // Fallback : +1h après le début pour rester valide
+    return getStartDateTime().plusHours(1);
+  }
+
   public String getClientName(){ return clientName; }
   public void setClientName(String clientName){ this.clientName = clientName; }
   public String getSiteLabel(){ return siteLabel; }

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningBoard.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningBoard.java
@@ -162,7 +162,7 @@ public class PlanningBoard extends JComponent {
     for (Resource r : resources){
       List<Intervention> list = byResource.getOrDefault(r.getId(), List.of());
       Map<Intervention, LaneLayout.Lane> m = LaneLayout.computeLanes(list,
-          Intervention::getDateDebut, Intervention::getDateFin);
+          Intervention::getStartDateTime, Intervention::getEndDateTime);
       lanes.putAll(m);
       int lanesCount = m.values().stream().mapToInt(l -> l.index).max().orElse(-1) + 1;
       int rowH = Math.max(tile.height(), lanesCount * (tile.height() + PlanningUx.LANE_GAP)) + PlanningUx.ROW_GAP;


### PR DESCRIPTION
## Summary
- Add utility methods to always provide start/end datetimes with reasonable fallbacks
- Use new helpers when computing lanes on the planning board

## Testing
- `mvn -q -pl client test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c41c88abb483309e972d3ac5a71aab