### PR TITLE
Refine planning UI typography and colors

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/ui/planning/DayHeader.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/DayHeader.java
@@ -16,6 +16,8 @@ public class DayHeader extends JComponent {
   }
   @Override protected void paintComponent(Graphics g){
     Graphics2D g2 = (Graphics2D) g;
+    g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+    g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
     g2.setColor(PlanningUx.HEADER_BG);
     g2.fillRect(0,0,getWidth(),getHeight());
     g2.setColor(PlanningUx.GRID);
@@ -23,17 +25,32 @@ public class DayHeader extends JComponent {
     int x=0, dayW = board.getDayPixelWidth();
     LocalDate d = board.getStartDate();
     for (int i=0;i<getWidth()/dayW+1;i++){
-      int slotW = board.getSlotWidth();
+      final int slotW = board.getSlotWidth();
       g2.setColor(PlanningUx.GRID);
       g2.drawLine(x,0,x,getHeight());
-      g2.setColor(PlanningUx.HEADER_TX);
-      g2.drawString(DF.format(d.plusDays(i)), x+8, 14);
+      // Libellé du jour
+      g2.setColor(new Color(0x111827));
+      g2.setFont(getFont().deriveFont(Font.BOLD, 12f));
+      g2.drawString(DF.format(d.plusDays(i)), x+8, 13);
+
+      // Heures adaptatives : espace minimal 48 px entre libellés
+      int minutes = board.getSlotMinutes();
+      int pxPerHour = (60/minutes) * slotW;
+      int minSpacing = 48; // px
+      int[] steps = {1,2,3,4,6,12};
+      int stepH = 2;
+      for (int s : steps){ if (pxPerHour * s >= minSpacing){ stepH = s; break; } }
+
       g2.setFont(getFont().deriveFont(11f));
       g2.setColor(new Color(0x4B5563));
-      for (int h=0; h<24; h+=2){
-        int px = x + h*(60/board.getSlotMinutes())*slotW;
+      for (int h=0; h<24; h+=stepH){
+        int px = x + h*(60/minutes)*slotW;
         String label = (h<10? "0":"")+h+":00";
-        g2.drawString(label, px+4, getHeight()-12);
+        int w = g2.getFontMetrics().stringWidth(label) + 6;
+        g2.setColor(PlanningUx.HEADER_BG);
+        g2.fillRoundRect(px+2, getHeight()-18, w, 16, 8, 8);
+        g2.setColor(new Color(0x4B5563));
+        g2.drawString(label, px+5, getHeight()-6);
       }
       x+=dayW;
     }

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionTileRenderer.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionTileRenderer.java
@@ -12,6 +12,12 @@ final class InterventionTileRenderer {
 
   private static final int GAP = 10;
   void paint(Graphics2D g2, Rectangle r, Intervention it, boolean hover, boolean selected){
+    g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+    g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+
+    // Police harmonisée
+    g2.setFont(PlanningUx.fontRegular(g2));
+
     // Ombre
     g2.setColor(PlanningUx.TILE_SHADOW);
     g2.fillRoundRect(r.x+3,r.y+3,r.width-6,r.height-6, PlanningUx.RADIUS, PlanningUx.RADIUS);
@@ -37,9 +43,9 @@ final class InterventionTileRenderer {
 
     // Ligne 1 : heure, status, favoris, agence, menu
     Font f0 = g2.getFont();
-    Font fTime = f0.deriveFont(Font.BOLD, 18f);
+    Font fTime = PlanningUx.fontLarge(g2);
     g2.setFont(fTime);
-    String time = it.prettyTimeRange();
+    String time = it.prettyTimeRange()==null? "—" : it.prettyTimeRange();
     g2.setColor(new Color(0x0F172A));
     g2.drawString(time, x, y+2);
     int timeW = g2.getFontMetrics().stringWidth(time);
@@ -86,17 +92,15 @@ final class InterventionTileRenderer {
     g2.setFont(f0.deriveFont(Font.BOLD, 16f));
     String client = it.getClientName()==null? (it.getLabel()==null? "—" : it.getLabel()) : it.getClientName();
     g2.setColor(new Color(0x111827));
-    g2.drawString(client, x, y+18);
+    g2.drawString(client, x, y);
+    y += 18;
+    g2.setFont(PlanningUx.fontRegular(g2));
 
-    // Ligne 3 : chantier
-    y += 22;
-    g2.setFont(f0.deriveFont(Font.PLAIN, 16f));
-    String site = "Chantier : " + (it.getSiteLabel()==null? "—" : it.getSiteLabel());
-    g2.setColor(new Color(0x1F2937));
-    g2.drawString(site, x, y+18);
+    g2.setColor(new Color(0x374151));
+    g2.drawString("Chantier : " + nullToDash(it.getSiteLabel()), x, y);
+    y += 16;
 
     // Séparateur
-    y += 28;
     g2.setColor(new Color(0xE5E7EB));
     g2.drawLine(x, y, r.x + r.width - 16, y);
 

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningUx.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningUx.java
@@ -11,14 +11,14 @@ final class PlanningUx {
   static final Color BG_ALT1 = new Color(0xFAFAFA);
   static final Color BG_ALT2 = new Color(0xF2F2F2);
   static final Color GRID = new Color(0xDDDDDD);
-  static final Color HEADER_BG = new Color(0xF6F7F9);
+  static final Color HEADER_BG = new Color(0xF5F5F5);
   static final Color HEADER_TX = new Color(0x2D2D2D);
   static final Color ROW_DIV = new Color(0xE6E6E6);
   static final Color TILE_TX = new Color(0x111111);
-  static final Color TILE_SHADOW = new Color(0,0,0,35);
+  static final Color TILE_SHADOW = new Color(0,0,0,18);
   static final Color TILE_HOVER = new Color(0,0,0,20);
-  static final Color TILE_SELECT = new Color(0,0,0,28);
-  static final Color HATCH = new Color(0,0,0,50);
+  static final Color TILE_SELECT = new Color(0,0,0,24);
+  static final Color HATCH = new Color(0,0,0,36);
 
   // Métriques
   static final int COL_MIN = 80;
@@ -32,6 +32,11 @@ final class PlanningUx {
   static final int HANDLE = 6;
   static final int DRAG_THRESHOLD = 6;
   static final int CREATE_THRESHOLD = 12;
+
+  // Typo (utilise police par défaut mais harmonise les tailles)
+  static java.awt.Font fontRegular(java.awt.Graphics2D g){ return g.getFont().deriveFont(13f); }
+  static java.awt.Font fontSmall(java.awt.Graphics2D g){ return g.getFont().deriveFont(12f); }
+  static java.awt.Font fontLarge(java.awt.Graphics2D g){ return g.getFont().deriveFont(java.awt.Font.BOLD, 18f); }
 
   static Font uiFont(Component c){
     Font f = c.getFont();


### PR DESCRIPTION
## Summary
- Lighten planning color palette and add font helpers for consistent text sizing
- Enhance day header with antialiased text and adaptive hour labels
- Harmonize intervention tile typography and gracefully handle missing times

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c41fd131448330a6e0a95a22ab5737