### PR TITLE
Add density controls and dynamic tile scaling

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionTileRenderer.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionTileRenderer.java
@@ -7,17 +7,33 @@ import java.awt.*;
 
 /** Rendu "carte" riche pour une intervention (vue Planning). */
 final class InterventionTileRenderer {
-  /** Hauteur standard de la carte. */
-  int height(){ return PlanningUx.TILE_CARD_H; }
+  private static final int CHIP_H = 24;
+  private static final int CHIP_GAP = 8;
+  private boolean compact = false;
+  private PlanningBoard.Density density = PlanningBoard.Density.NORMAL;
+  private double scaleY = 1.0;
+
+  int heightBase(){ return (int)Math.round(PlanningUx.TILE_CARD_H * scaleY); }
+  int height(){ return heightBase(); }
   void setCompact(boolean c){ compact = c; }
+  void setDensity(PlanningBoard.Density d){
+    density = d;
+    scaleY = switch(d){
+      case COMPACT -> 0.88;
+      case ROOMY -> 1.15;
+      default -> 1.0;
+    };
+  }
   int heightFor(Intervention it, int widthPx){
-    int base = compact? 84 : PlanningUx.TILE_CARD_H;
-    int lines = chipLines(it, widthPx);
-    return base + (lines>1? 30*(lines-1) : 0);
+    int base = compact? (int)Math.round(84 * scaleY) : heightBase();
+    base += wrappedTextExtraHeight(it, widthPx);
+    int chips = chipLines(it, widthPx);
+    return base + (chips>0? (CHIP_H + CHIP_GAP)*(chips-1) : 0);
   }
 
+  private int wrappedTextExtraHeight(Intervention it, int widthPx){ return 0; }
+
   private static final int GAP = 10;
-  private boolean compact = false;
   void paint(Graphics2D g2, Rectangle r, Intervention it, boolean hover, boolean selected){
     if (compact){
       paintCompact(g2, r, it, hover, selected);
@@ -169,7 +185,7 @@ final class InterventionTileRenderer {
     for (String s : labels){
       int w = approxChipWidth(s);
       if (x>0 && x + w > max){ line++; x=0; }
-      x += (x==0? w : w + 8);
+      x += (x==0? w : w + CHIP_GAP);
     }
     return line;
   }

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
@@ -114,15 +114,22 @@ public class PlanningPanel extends JPanel {
     JLabel granL = new JLabel("Pas:");
     JComboBox<String> gran = new JComboBox<>(new String[]{"5 min","10 min","15 min","30 min","60 min"});
     gran.setSelectedItem(board.getSlotMinutes()+" min");
-    JToggleButton compact = new JToggleButton("Mode compact");
+    JLabel densL = new JLabel("Densité:");
+    JComboBox<String> density = new JComboBox<>(new String[]{"Compact","Normal","Spacieux"});
     JToggleButton mode = new JToggleButton("Agenda");
     conflictsBtn = new JButton("Conflits (0)");
     JButton addI = new JButton("+ Intervention");
 
     mode.addActionListener(e -> switchMode(mode.isSelected()));
     conflictsBtn.addActionListener(e -> openConflictsDialog());
-    compact.addActionListener(e -> {
-      board.setCompact(compact.isSelected());
+    density.setSelectedIndex(1);
+    density.addActionListener(e -> {
+      String sel = String.valueOf(density.getSelectedItem());
+      switch (sel){
+        case "Compact" -> board.setDensity(PlanningBoard.Density.COMPACT);
+        case "Spacieux" -> board.setDensity(PlanningBoard.Density.ROOMY);
+        default -> board.setDensity(PlanningBoard.Density.NORMAL);
+      }
       revalidate(); repaint();
     });
 
@@ -147,7 +154,7 @@ public class PlanningPanel extends JPanel {
     bar.add(prev); bar.add(next); bar.add(today); bar.add(mode);
     bar.add(Box.createHorizontalStrut(16)); bar.add(zoomL); bar.add(zoom);
     bar.add(Box.createHorizontalStrut(12)); bar.add(granL); bar.add(gran);
-    bar.add(Box.createHorizontalStrut(12)); bar.add(compact);
+    bar.add(Box.createHorizontalStrut(12)); bar.add(densL); bar.add(density);
     bar.add(Box.createHorizontalStrut(8)); bar.add(conflictsBtn);
     bar.add(Box.createHorizontalStrut(16)); bar.add(addI);
     return bar;


### PR DESCRIPTION
## Summary
- Replace compact toggle with density selector
- Support density levels in planning board with virtualized painting
- Scale intervention tiles based on density

## Testing
- `mvn -q -pl client test` *(fails: Non-resolvable import POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c42713d3f8833083c57dba924c9f06