### PR TITLE
feat: add responsive tile tiers

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionTileRenderer.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionTileRenderer.java
@@ -1,20 +1,32 @@
 package com.materiel.suite.client.ui.planning;
 
 import com.materiel.suite.client.model.Intervention;
+import java.awt.*;
+import java.util.ArrayList;
 import java.util.List;
 
-import java.awt.*;
-
-/** Rendu "carte" riche pour une intervention (vue Planning). */
+/** Rendu d'une intervention dans la grille du planning. */
 final class InterventionTileRenderer {
+  private static final int PAD = PlanningUx.PAD;
+  private static final int R = PlanningUx.RADIUS;
   private static final int CHIP_H = 24;
   private static final int CHIP_GAP = 8;
   private boolean compact = false;
   private PlanningBoard.Density density = PlanningBoard.Density.NORMAL;
   private double scaleY = 1.0;
 
+  // Tiers de rendu selon l'espace disponible
+  enum Tier { XS, SM, MD, LG }
+  private Tier tierFor(Rectangle r){
+    int w = r.width;
+    int h = r.height;
+    if (w < 240 || h < 110) return Tier.XS;
+    if (w < 320) return Tier.SM;
+    if (w < 420) return Tier.MD;
+    return Tier.LG;
+  }
+
   int heightBase(){ return (int)Math.round(PlanningUx.TILE_CARD_H * scaleY); }
-  int height(){ return heightBase(); }
   void setCompact(boolean c){ compact = c; }
   void setDensity(PlanningBoard.Density d){
     density = d;
@@ -24,163 +36,30 @@ final class InterventionTileRenderer {
       default -> 1.0;
     };
   }
+
+  /** Calcul de hauteur dynamique (wrap + chips). */
   int heightFor(Intervention it, int widthPx){
-    int base = compact? (int)Math.round(84 * scaleY) : heightBase();
-    base += wrappedTextExtraHeight(it, widthPx);
-    int chips = chipLines(it, widthPx);
-    return base + (chips>0? (CHIP_H + CHIP_GAP)*(chips-1) : 0);
+    int base = compact ? (int)Math.round(84 * scaleY) : heightBase();
+    Tier t = (widthPx < 240)? Tier.XS : (widthPx<320? Tier.SM : (widthPx<420? Tier.MD : Tier.LG));
+    boolean showDetails = !compact && (t==Tier.MD || t==Tier.LG);
+    int extraWrap = showDetails ? wrappedTextExtraHeight(it, widthPx)
+        : wrappedTextExtraHeightCompact(it, widthPx);
+    base += extraWrap;
+    int allowedChips = (t==Tier.XS? 0 : t==Tier.SM? 1 : t==Tier.MD? 2 : Integer.MAX_VALUE);
+    int chips = chipLines(it, widthPx, allowedChips);
+    return base + (chips>0? (CHIP_H + 8) * (chips-1) : 0);
   }
 
-  private int wrappedTextExtraHeight(Intervention it, int widthPx){ return 0; }
-
-  private static final int GAP = 10;
-  void paint(Graphics2D g2, Rectangle r, Intervention it, boolean hover, boolean selected){
-    if (compact){
-      paintCompact(g2, r, it, hover, selected);
-      return;
+  private int chipLines(Intervention it, int widthPx){ return chipLines(it, widthPx, Integer.MAX_VALUE); }
+  private int chipLines(Intervention it, int widthPx, int limit){
+    String[] all = chipsFor(it);
+    String[] labels = all;
+    if (limit < all.length){
+      labels = new String[limit];
+      System.arraycopy(all, 0, labels, 0, limit);
     }
-    g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-    g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-
-    // Police harmonisée
-    g2.setFont(PlanningUx.fontRegular(g2));
-
-    // Ombre
-    g2.setColor(PlanningUx.TILE_SHADOW);
-    g2.fillRoundRect(r.x+3,r.y+3,r.width-6,r.height-6, PlanningUx.RADIUS, PlanningUx.RADIUS);
-    // Fond
-    g2.setColor(Color.WHITE);
-    g2.fillRoundRect(r.x,r.y,r.width,r.height, PlanningUx.RADIUS, PlanningUx.RADIUS);
-    g2.setColor(new Color(0xDADEE3));
-    g2.drawRoundRect(r.x,r.y,r.width,r.height, PlanningUx.RADIUS, PlanningUx.RADIUS);
-
-    // Barre accent à gauche
-    Color accent = PlanningUx.colorOr(it.getColor(), new Color(0x3B82F6));
-    g2.setColor(accent);
-    g2.fillRoundRect(r.x-8, r.y+8, 10, r.height-16, 6, 6);
-
-    // Overlays hover/selected
-    if (hover || selected){
-      g2.setColor(hover? PlanningUx.TILE_HOVER : PlanningUx.TILE_SELECT);
-      g2.fillRoundRect(r.x,r.y,r.width,r.height, PlanningUx.RADIUS, PlanningUx.RADIUS);
-    }
-
-    int x = r.x + 16;
-    int y = r.y + 14;
-
-    // Ligne 1 : heure, status, favoris, agence, menu
-    Font f0 = g2.getFont();
-    Font fTime = PlanningUx.fontLarge(g2);
-    g2.setFont(fTime);
-    String time = it.prettyTimeRange()==null? "—" : it.prettyTimeRange();
-    g2.setColor(new Color(0x0F172A));
-    g2.drawString(time, x, y+2);
-    int timeW = g2.getFontMetrics().stringWidth(time);
-    g2.setFont(f0);
-
-    int right = r.x + r.width - 12;
-    // menu (3 points)
-    g2.setColor(new Color(0x8A8FA0));
-    int dotY = y-6;
-    for (int i=0;i<3;i++) g2.fillOval(right - i*10, dotY, 4,4);
-
-    // Favori (étoile simple)
-    int starX = x + 160;
-    paintStar(g2, starX, y-10, 16, new Color(0x1F2937));
-
-    // Status pill
-    String status = it.getStatus()==null? "PLANNED" : it.getStatus().toUpperCase();
-    Color sBg = switch(status){
-      case "CONFIRMED" -> new Color(0xD1FAE5);
-      case "DONE"      -> new Color(0xDBEAFE);
-      case "CANCELED"  -> new Color(0xFEE2E2);
-      default          -> new Color(0xE5E7EB);
-    };
-    Color sFg = new Color(0x0F172A);
-    int wStatus = Math.max(96, g2.getFontMetrics().stringWidth(status)+24);
-    int statusX = x + timeW + GAP;
-
-    // Agence pill
-    String agency = it.getAgency()==null? "Agence ?" : it.getAgency();
-    int wAgency = Math.max(80, g2.getFontMetrics().stringWidth(agency)+24);
-    int agencyX = statusX + wStatus + GAP;
-
-    // Wrap si collision avec bord droit
-    int rightLimit = r.x + r.width - 80;
-    boolean wrap = agencyX + wAgency > rightLimit;
-    if (wrap){ statusX = x; agencyX = x + wStatus + GAP; y += 22; }
-
-    PlanningUx.pill(g2, new Rectangle(statusX, y-18, wStatus, 28), sBg, sFg, status);
-
-    PlanningUx.pill(g2, new Rectangle(agencyX, y-18, wAgency, 28), new Color(0xEEF2FF), new Color(0x0F172A), agency);
-
-    // Ligne 2 : client
-    y += 24;
-    g2.setFont(f0.deriveFont(Font.BOLD, 16f));
-    String client = it.getClientName()==null? (it.getLabel()==null? "—" : it.getLabel()) : it.getClientName();
-    g2.setColor(new Color(0x111827));
-    g2.drawString(client, x, y);
-    y += 18;
-    g2.setFont(PlanningUx.fontRegular(g2));
-
-    g2.setColor(new Color(0x374151));
-    g2.drawString("Chantier : " + nullToDash(it.getSiteLabel()), x, y);
-    y += 16;
-
-    // Séparateur
-    g2.setColor(new Color(0xE5E7EB));
-    g2.drawLine(x, y, r.x + r.width - 16, y);
-
-    // Ligne 4 : grue / camion
-    y += 10;
-    int colW = (r.width - 48)/2;
-    paintCraneIcon(g2, x, y+4);
-    g2.setColor(new Color(0x111827));
-    g2.drawString("Grue : " + nullToDash(it.getCraneName()), x+28, y+8);
-    paintTruckIcon(g2, x + colW, y+4);
-    g2.drawString("Camion : " + nullToDash(it.getTruckName()), x+colW+28, y+8);
-
-    // Séparateur 2
-    y += 22;
-    g2.setColor(new Color(0xE5E7EB));
-    g2.drawLine(x, y, r.x + r.width - 16, y);
-
-    // Ligne 5 : chauffeur + initiales
-    y += 10;
-    paintBadge(g2, x, y, it.driverInitials());
-    g2.setColor(new Color(0x1F2937));
-    g2.drawString("Chauffeur : " + nullToDash(it.getDriverName()), x+40, y+8);
-
-    // Ligne 6 : chips documents
-    y += 26;
-    wrapChips(g2, r, x, y, List.of(
-        chipSpec(it.getQuoteNumber(), new Color(0xD1FAE5), new Color(0x176E43), "Devis "),
-        chipSpec(it.getOrderNumber(), new Color(0xFEF3C7), new Color(0xA16207), "Commande "),
-        chipSpec(it.getDeliveryNumber(), new Color(0xE5E7EB), new Color(0x374151), "BL "),
-        chipSpec(it.getInvoiceNumber(), new Color(0xE5E7EB), new Color(0x374151), "Fact. ")
-    ));
-  }
-
-  private record Chip(String text, Color bg, Color fg){}
-  private Chip chipSpec(String value, Color bg, Color fg, String prefix){
-    String text = prefix + ((value==null || value.isBlank())? "—" : value);
-    return new Chip(text, bg, fg);
-  }
-  private void wrapChips(Graphics2D g2, Rectangle r, int x, int y, List<Chip> chips){
-    int cx = x, cy = y;
-    int maxX = r.x + r.width - 16;
-    for (Chip c : chips){
-      int w = Math.max(90, g2.getFontMetrics().stringWidth(c.text)+24);
-      if (cx + w > maxX){ cx = x; cy += 30; }
-      PlanningUx.pill(g2, new Rectangle(cx, cy, w, 28), c.bg, c.fg, c.text);
-      cx += w + 8;
-    }
-  }
-
-  private int chipLines(Intervention it, int widthPx){
-    String[] labels = chipLabels(it);
     if (labels.length==0) return 0;
-    int max = Math.max(80, widthPx - 32);
+    int max = Math.max(80, widthPx - 2*PAD);
     int line=1, x=0;
     for (String s : labels){
       int w = approxChipWidth(s);
@@ -190,42 +69,85 @@ final class InterventionTileRenderer {
     return line;
   }
 
-  private String[] chipLabels(Intervention it){
-    return new String[]{
-        "Devis " + nullToDash(it.getQuoteNumber()),
-        "Commande " + nullToDash(it.getOrderNumber()),
-        "BL " + nullToDash(it.getDeliveryNumber()),
-        "Fact. " + nullToDash(it.getInvoiceNumber())
-    };
+  private static int approxCharW(boolean bold){ return bold ? 8 : 7; }
+  private static int lineH(boolean bold){ return bold ? 18 : 16; }
+
+  private int wrappedTextExtraHeight(Intervention it, int widthPx){
+    int max = Math.max(120, widthPx - 2*PAD);
+    String client = it.getClientName()==null? (it.getLabel()==null? "—" : it.getLabel()) : it.getClientName();
+    int linesClient = wrapCount(client, max, true);
+    int extra = 0;
+    if (linesClient > 1) extra += (linesClient-1) * lineH(true);
+    String site = "Chantier : " + nullToDash(it.getSiteLabel());
+    int linesSite = wrapCount(site, max, false);
+    if (!compact && linesSite > 1) extra += (linesSite-1) * lineH(false);
+    return extra;
   }
 
-  private int approxChipWidth(String s){
-    int text = (s==null? 1 : Math.max(1, s.length()));
-    return Math.max(90, text*7 + 24);
+  private int wrappedTextExtraHeightCompact(Intervention it, int widthPx){
+    int max = Math.max(120, widthPx - 2*PAD);
+    String client = it.getClientName()==null? (it.getLabel()==null? "—" : it.getLabel()) : it.getClientName();
+    String combined = client + (it.getSiteLabel()==null? "" : " — " + it.getSiteLabel());
+    int lines = wrapCount(combined, max, true);
+    int extra = 0;
+    if (lines > 1) extra += (lines-1) * lineH(true);
+    return extra;
   }
 
-  private void paintCompact(Graphics2D g2, Rectangle r, Intervention it, boolean hover, boolean selected){
+  private static String ellipsis(Graphics2D g2, String s, int maxWidth){
+    if (s==null) return "—";
+    if (g2.getFontMetrics().stringWidth(s) <= maxWidth) return s;
+    String dots = "…";
+    int wDots = g2.getFontMetrics().stringWidth(dots);
+    StringBuilder b = new StringBuilder();
+    for (char c : s.toCharArray()){
+      if (g2.getFontMetrics().stringWidth(b.toString()+c) > maxWidth - wDots) break;
+      b.append(c);
+    }
+    return b.toString()+dots;
+  }
+
+  private int wrapCount(String s, int maxWidth, boolean bold){
+    if (s==null) return 1;
+    int w = approxCharW(bold);
+    int est = Math.max(1, (int)Math.ceil((s.length()*w) / (double)maxWidth));
+    return est;
+  }
+
+  private String[] wrapText(Graphics2D g2, String s, int maxWidth, boolean bold){
+    if (s==null) return new String[]{ "—" };
+    Font f = bold? g2.getFont().deriveFont(Font.BOLD, 16f) : g2.getFont();
+    FontMetrics fm = g2.getFontMetrics(f);
+    List<String> lines = new ArrayList<>();
+    String[] words = s.split(" ");
+    StringBuilder line = new StringBuilder();
+    for (String word : words){
+      String candidate = line.length()==0? word : line + " " + word;
+      if (fm.stringWidth(candidate) > maxWidth && line.length()>0){
+        lines.add(line.toString());
+        line = new StringBuilder(word);
+      } else {
+        if (line.length()>0) line.append(" ");
+        line.append(word);
+      }
+    }
+    if (line.length()>0) lines.add(line.toString());
+    return lines.toArray(new String[0]);
+  }
+
+  void paint(Graphics2D g2, Intervention it, Rectangle r){
     g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
     g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-    g2.setFont(PlanningUx.fontRegular(g2));
+    Tier tier = tierFor(r);
 
-    g2.setColor(PlanningUx.TILE_SHADOW);
-    g2.fillRoundRect(r.x+3,r.y+3,r.width-6,r.height-6, PlanningUx.RADIUS, PlanningUx.RADIUS);
-    g2.setColor(Color.WHITE);
-    g2.fillRoundRect(r.x,r.y,r.width,r.height, PlanningUx.RADIUS, PlanningUx.RADIUS);
-    g2.setColor(new Color(0xDADEE3));
-    g2.drawRoundRect(r.x,r.y,r.width,r.height, PlanningUx.RADIUS, PlanningUx.RADIUS);
-    Color accent = PlanningUx.colorOr(it.getColor(), new Color(0x3B82F6));
-    g2.setColor(accent);
-    g2.fillRoundRect(r.x-8, r.y+8, 10, r.height-16, 6, 6);
-    if (hover || selected){
-      g2.setColor(hover? PlanningUx.TILE_HOVER : PlanningUx.TILE_SELECT);
-      g2.fillRoundRect(r.x,r.y,r.width,r.height, PlanningUx.RADIUS, PlanningUx.RADIUS);
-    }
+    // Carte
+    g2.setColor(PlanningUx.TILE_BG);
+    PlanningUx.roundRect(g2, r);
+    g2.setColor(PlanningUx.TILE_BORDER);
+    PlanningUx.strokeRound(g2, r);
 
-    int x = r.x + 16;
-    int y = r.y + 14;
-
+    int x = r.x + PAD;
+    int y = r.y + PAD + 12;
     Font f0 = g2.getFont();
     Font fTime = PlanningUx.fontLarge(g2);
     g2.setFont(fTime);
@@ -235,83 +157,120 @@ final class InterventionTileRenderer {
     int timeW = g2.getFontMetrics().stringWidth(time);
     g2.setFont(f0);
 
-    String status = it.getStatus()==null? "PLANNED" : it.getStatus().toUpperCase();
-    Color sBg = switch(status){
-      case "CONFIRMED" -> new Color(0xD1FAE5);
-      case "DONE"      -> new Color(0xDBEAFE);
-      case "CANCELED"  -> new Color(0xFEE2E2);
-      default          -> new Color(0xE5E7EB);
-    };
-    Color sFg = new Color(0x0F172A);
-    int wStatus = Math.max(96, g2.getFontMetrics().stringWidth(status)+24);
-    int statusX = x + timeW + GAP;
+    // Pills status / agence si place
+    int cursorX = x + (tier==Tier.XS? 8 : timeW + 12);
+    cursorX = paintPill(g2, cursorX, y-10, it.getStatus()==null? "PLANNED" : it.getStatus(),
+        new Color(0xE5F0FF), new Color(0x1F4FD8));
+    cursorX = paintPill(g2, cursorX, y-10, it.getAgency(),
+        new Color(0xEEF2FF), new Color(0x0F172A));
 
-    String agency = it.getAgency()==null? "Agence ?" : it.getAgency();
-    int wAgency = Math.max(80, g2.getFontMetrics().stringWidth(agency)+24);
-    int agencyX = statusX + wStatus + GAP;
-    int rightLimit = r.x + r.width - 80;
-    boolean wrap = agencyX + wAgency > rightLimit;
-    if (wrap){ statusX = x; agencyX = x + wStatus + GAP; y += 22; }
-
-    PlanningUx.pill(g2, new Rectangle(statusX, y-18, wStatus, 28), sBg, sFg, status);
-    PlanningUx.pill(g2, new Rectangle(agencyX, y-18, wAgency, 28), new Color(0xEEF2FF), new Color(0x0F172A), agency);
-
-    y += 24;
-    g2.setFont(f0.deriveFont(Font.BOLD, 15f));
+    // Contenu principal
+    x = r.x + PAD; y = r.y + 44;
     String client = it.getClientName()==null? (it.getLabel()==null? "—" : it.getLabel()) : it.getClientName();
-    g2.setColor(new Color(0x111827));
-    String line = client;
-    String site = it.getSiteLabel()==null? "" : " — " + it.getSiteLabel();
-    int space = r.width - 32;
-    if (g2.getFontMetrics().stringWidth(line + site) < space){ line += site; }
-    g2.drawString(line, x, y);
-    y += 18;
+    int maxTextW = r.width - 2*PAD;
 
-    wrapChips(g2, r, x, y, List.of(
-        chipSpec(it.getQuoteNumber(), new Color(0xD1FAE5), new Color(0x176E43), "Devis "),
-        chipSpec(it.getOrderNumber(), new Color(0xFEF3C7), new Color(0xA16207), "Commande "),
-        chipSpec(it.getDeliveryNumber(), new Color(0xE5E7EB), new Color(0x374151), "BL "),
-        chipSpec(it.getInvoiceNumber(), new Color(0xE5E7EB), new Color(0x374151), "Fact. ")
-    ));
+    switch (tier){
+      case XS -> {
+        g2.setFont(f0.deriveFont(Font.BOLD, 15f));
+        g2.setColor(new Color(0x111827));
+        String line = ellipsis(g2, client, maxTextW);
+        g2.drawString(line, x, y);
+        y += 18;
+        g2.setFont(PlanningUx.fontRegular(g2));
+        g2.setColor(new Color(0x6B7280));
+        String site = nullToDash(it.getSiteLabel());
+        g2.drawString(ellipsis(g2, site, maxTextW), x, y);
+        y += 14;
+      }
+      case SM -> {
+        g2.setFont(f0.deriveFont(Font.BOLD, 16f));
+        g2.setColor(new Color(0x111827));
+        for (String ln : wrapText(g2, client, maxTextW, true)){
+          g2.drawString(ln, x, y); y += 18;
+        }
+        g2.setFont(PlanningUx.fontRegular(g2));
+        g2.setColor(new Color(0x374151));
+        String site = "Chantier : " + nullToDash(it.getSiteLabel());
+        g2.drawString(ellipsis(g2, site, maxTextW), x, y); y += 16;
+      }
+      case MD, LG -> {
+        g2.setFont(f0.deriveFont(Font.BOLD, 16f));
+        g2.setColor(new Color(0x111827));
+        for (String ln : wrapText(g2, client, maxTextW, true)){
+          g2.drawString(ln, x, y); y += 18;
+        }
+        g2.setFont(PlanningUx.fontRegular(g2));
+        g2.setColor(new Color(0x374151));
+        String site = "Chantier : " + nullToDash(it.getSiteLabel());
+        for (String ln : wrapText(g2, site, maxTextW, false)){
+          g2.drawString(ln, x, y); y += 16;
+        }
+        g2.setColor(new Color(0x374151));
+        g2.drawString("Grue : " + nullToDash(it.getCraneName()), x, y);
+        int x2 = x + Math.max(120, g2.getFontMetrics().stringWidth("Grue : XXXXXXX")+10);
+        g2.drawString("Camion : " + nullToDash(it.getTruckName()), x2, y);
+        y += 16;
+        g2.drawString("Chauffeur : " + nullToDash(it.getDriverName()), x, y);
+        y += 18;
+      }
+    }
+
+    int allow = switch (tier){
+      case XS -> 0;
+      case SM -> 1;
+      case MD -> 2;
+      case LG -> Integer.MAX_VALUE;
+    };
+    paintChipsWrapped(g2, it, x, y, r.width - 2*PAD, allow);
   }
 
   /* Helpers de rendu */
   private static String nullToDash(String s){ return (s==null || s.isBlank())? "—" : s; }
 
-  private static void paintStar(Graphics2D g2, int cx, int cy, int r, Color c){
-    Polygon p = new Polygon();
-    for (int i=0;i<5;i++){
-      double a = Math.toRadians(-90 + i*72);
-      double a2 = Math.toRadians(-90 + i*72 + 36);
-      p.addPoint((int)(cx + r*Math.cos(a)), (int)(cy + r*Math.sin(a)));
-      p.addPoint((int)(cx + (r/2.2)*Math.cos(a2)), (int)(cy + (r/2.2)*Math.sin(a2)));
+  private String[] chipsFor(Intervention it){
+    List<String> list = new ArrayList<>();
+    if (it.getQuoteNumber()!=null && !it.getQuoteNumber().isBlank())
+      list.add("Devis " + it.getQuoteNumber());
+    if (it.getOrderNumber()!=null && !it.getOrderNumber().isBlank())
+      list.add("Commande " + it.getOrderNumber());
+    if (it.getDeliveryNumber()!=null && !it.getDeliveryNumber().isBlank())
+      list.add("BL " + it.getDeliveryNumber());
+    if (it.getInvoiceNumber()!=null && !it.getInvoiceNumber().isBlank())
+      list.add("Fact. " + it.getInvoiceNumber());
+    return list.toArray(new String[0]);
+  }
+
+  private int approxChipWidth(String s){
+    int text = (s==null? 1 : Math.max(1, s.length()));
+    return Math.min(320, text*7 + 28); // padding + coins arrondis
+  }
+
+  private int paintPill(Graphics2D g2, int x, int y, String text, Color bg, Color fg){
+    if (text==null || text.isBlank()) return x;
+    int w = approxChipWidth(text);
+    PlanningUx.pill(g2, new Rectangle(x, y, w, CHIP_H), bg, fg, text);
+    return x + w + CHIP_GAP;
+  }
+
+  private void paintChipsWrapped(Graphics2D g2, Intervention it, int x, int y, int maxWidth, int limit){
+    String[] labels = chipsFor(it);
+    if (limit < labels.length){
+      String[] cut = new String[limit];
+      System.arraycopy(labels, 0, cut, 0, limit);
+      labels = cut;
     }
-    g2.setColor(c);
-    g2.drawPolygon(p);
-  }
-  private static void paintCraneIcon(Graphics2D g2, int x, int y){
-    g2.setColor(new Color(0x0F172A));
-    g2.drawRect(x, y, 16, 12);
-    g2.drawLine(x+2, y+8, x+14, y+8);
-    g2.fillOval(x+2, y+12, 4,4);
-    g2.fillOval(x+10, y+12, 4,4);
-  }
-  private static void paintTruckIcon(Graphics2D g2, int x, int y){
-    g2.setColor(new Color(0x0F172A));
-    g2.drawRect(x+6, y, 16, 10);
-    g2.drawRect(x, y+4, 8, 8);
-    g2.fillOval(x+4, y+12, 4,4);
-    g2.fillOval(x+18, y+12, 4,4);
-  }
-  private static void paintBadge(Graphics2D g2, int x, int y, String txt){
-    int w = Math.max(28, g2.getFontMetrics().stringWidth(txt)+14);
-    g2.setColor(new Color(0xE5E7EB));
-    g2.fillOval(x, y-2, w, 22);
-    g2.setColor(new Color(0x9CA3AF));
-    g2.drawOval(x, y-2, w, 22);
-    g2.setColor(new Color(0x111827));
-    int tx = x + (w - g2.getFontMetrics().stringWidth(txt))/2;
-    int ty = y + g2.getFontMetrics().getAscent()/2 + 2;
-    g2.drawString(txt, tx, ty);
+    if (labels.length==0) return;
+    int curX = x, curY = y;
+    for (String s : labels){
+      int w = approxChipWidth(s);
+      if (curX > x && curX + w > x + maxWidth){
+        curX = x;
+        curY += CHIP_H + CHIP_GAP;
+      }
+      PlanningUx.pill(g2, new Rectangle(curX, curY, w, CHIP_H),
+          new Color(0xE5E7EB), new Color(0x374151), s);
+      curX += w + CHIP_GAP;
+    }
   }
 }
+

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningBoard.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningBoard.java
@@ -103,14 +103,6 @@ public class PlanningBoard extends JComponent {
     return menu;
   }
 
-  @Override public String getToolTipText(MouseEvent e){
-    Intervention hit = hitTile(e.getPoint());
-    if (hit==null) return null;
-    return String.format("<html><b>%s</b><br>%s → %s</html>",
-        safeLabel(hit),
-        hit.getDateDebut(), hit.getDateFin());
-  }
-
   // API publique
   /** Expose les ressources visibles pour synchroniser le RowHeader. */
   public java.util.List<Resource> getResourcesList(){ return resources; }
@@ -429,12 +421,16 @@ public class PlanningBoard extends JComponent {
   private void onMove(MouseEvent e){
     int y=0;
     hovered = null;
+    boolean anyHover = false;
     for (Resource r : resources){
       int rowH = rowHeights.getOrDefault(r.getId(), tile.heightBase()+rowGap);
       for (Intervention it : byResource.getOrDefault(r.getId(), List.of())){
         Rectangle rect = rectOf(it, y);
         if (rect.contains(e.getPoint())){
           hovered = it;
+          setToolTipText("<html><b>"+safe(it.getClientName())+"</b><br/>Chantier : "
+              +safe(it.getSiteLabel())+"<br/>"+safe(it.prettyTimeRange())+"</html>");
+          anyHover = true;
           if (Math.abs(e.getX()-rect.x) < PlanningUx.HANDLE || Math.abs(e.getX()-(rect.x+rect.width))<PlanningUx.HANDLE){
             setCursor(Cursor.getPredefinedCursor(Cursor.E_RESIZE_CURSOR));
           } else {
@@ -446,9 +442,12 @@ public class PlanningBoard extends JComponent {
       }
       y+=rowH;
     }
+    if (!anyHover) setToolTipText(null);
     setCursor(Cursor.getDefaultCursor());
     repaint();
   }
+
+  private static String safe(String s){ return (s==null? "—" : s); }
 
   private void onClick(MouseEvent e){
     if (e.getButton()==MouseEvent.BUTTON1 && e.getClickCount()==1){

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningUx.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningUx.java
@@ -19,6 +19,8 @@ final class PlanningUx {
   static final Color TILE_HOVER = new Color(0,0,0,20);
   static final Color TILE_SELECT = new Color(0,0,0,24);
   static final Color HATCH = new Color(0,0,0,36);
+  static final Color TILE_BG = Color.WHITE;
+  static final Color TILE_BORDER = new Color(0xDADEE3);
 
   // Métriques
   static final int COL_MIN = 80;
@@ -91,5 +93,13 @@ final class PlanningUx {
     int tx = r.x + (r.width - fm.stringWidth(text))/2;
     int ty = r.y + (r.height + fm.getAscent())/2 - 2;
     g2.drawString(text, tx, ty);
+  }
+
+  static void roundRect(Graphics2D g2, Rectangle r){
+    g2.fillRoundRect(r.x, r.y, r.width, r.height, RADIUS, RADIUS);
+  }
+
+  static void strokeRound(Graphics2D g2, Rectangle r){
+    g2.drawRoundRect(r.x, r.y, r.width, r.height, RADIUS, RADIUS);
   }
 }


### PR DESCRIPTION
## Summary
- implement tiered intervention tiles with adaptive text wrapping and chip limits
- show rich tooltip on hover in planning board
- add tile colors and helpers to planning UI utilities

## Testing
- `mvn -q -pl client -am test` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d9e653cc83309ba557c2cac529f7