### PR TITLE
Add quote API and change feed with OpenAPI spec

### DIFF
--- a/backend/src/main/java/com/materiel/suite/backend/v1/api/OpenApiController.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/api/OpenApiController.java
@@ -1,0 +1,26 @@
+package com.materiel.suite.backend.v1.api;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/api/v1")
+public class OpenApiController {
+
+  @GetMapping(value = "/openapi.yaml", produces = "application/yaml")
+  public ResponseEntity<byte[]> openapiYaml() throws IOException {
+    var res = new ClassPathResource("openapi/openapi-v1.yaml");
+    byte[] bytes = res.getInputStream().readAllBytes();
+    return ResponseEntity.ok()
+        .header(HttpHeaders.CACHE_CONTROL, "no-store")
+        .contentType(MediaType.parseMediaType("application/yaml"))
+        .body(bytes);
+  }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/v1/api/QuoteController.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/api/QuoteController.java
@@ -1,0 +1,189 @@
+package com.materiel.suite.backend.v1.api;
+
+import com.materiel.suite.backend.v1.domain.DocLine;
+import com.materiel.suite.backend.v1.domain.DocumentStatus;
+import com.materiel.suite.backend.v1.domain.Quote;
+import com.materiel.suite.backend.v1.service.ChangeFeedService;
+import com.materiel.suite.backend.v1.service.IdempotencyService;
+import com.materiel.suite.backend.v1.service.TotalsCalculator;
+import com.materiel.suite.backend.v1.util.Etags;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/v1/quotes")
+public class QuoteController {
+
+  private final Map<UUID, Quote> store = new ConcurrentHashMap<>();
+  private final TotalsCalculator totals = new TotalsCalculator();
+  private final IdempotencyService idem;
+  private final ChangeFeedService changes;
+
+  public QuoteController(IdempotencyService idem, ChangeFeedService changes){
+    this.idem = idem;
+    this.changes = changes;
+  }
+
+  /* ===== LIST / GET ===== */
+  @GetMapping
+  public ResponseEntity<List<Quote>> list(
+      @RequestParam(value = "q", required = false) String q,
+      @RequestParam(value = "status", required = false) String status){
+    var all = new ArrayList<>(store.values());
+    if (StringUtils.hasText(q)){
+      String qq = q.toLowerCase(Locale.ROOT);
+      all.removeIf(qu -> (qu.getCustomerName()==null? "":qu.getCustomerName()).toLowerCase(Locale.ROOT).contains(qq) == false
+          && (qu.getNumber()==null? "":qu.getNumber()).toLowerCase(Locale.ROOT).contains(qq) == false);
+    }
+    if (StringUtils.hasText(status)){
+      DocumentStatus st = DocumentStatus.valueOf(status.toUpperCase(Locale.ROOT));
+      all.removeIf(qu -> qu.getStatus()!=st);
+    }
+    all.sort(Comparator.comparing(Quote::getUpdatedAt).reversed());
+    return ResponseEntity.ok().header(HttpHeaders.CACHE_CONTROL, "no-store").body(all);
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<Quote> get(@PathVariable UUID id){
+    Quote q = store.get(id);
+    if (q==null) return ResponseEntity.notFound().build();
+    return ResponseEntity.ok()
+        .eTag(Etags.weakOfVersion(q.getVersion()))
+        .header(HttpHeaders.CACHE_CONTROL, "no-store")
+        .body(q);
+  }
+
+  /* ===== CREATE (POST) avec Idempotency-Key ===== */
+  @PostMapping
+  public ResponseEntity<Quote> create(@RequestHeader(value = "Idempotency-Key", required = false) String idk,
+                                      @RequestBody Quote q){
+    // Idempotency : si même clé + même route → renvoyer la ressource existante
+    if (StringUtils.hasText(idk)){
+      var existing = idem.findExisting("POST:/api/v1/quotes", idk, Quote.class);
+      if (existing!=null){
+        return ResponseEntity.status(HttpStatus.OK)
+            .eTag(Etags.weakOfVersion(existing.getVersion()))
+            .header(HttpHeaders.CACHE_CONTROL, "no-store")
+            .body(existing);
+      }
+    }
+    if (q.getId()==null) q.setId(UUID.randomUUID());
+    if (q.getStatus()==null) q.setStatus(DocumentStatus.DRAFT);
+    if (q.getLines()==null) q.setLines(new ArrayList<>());
+    sanitizeLines(q.getLines());
+    totals.recomputeTotals(q);
+    q.setVersion(q.getVersion()+1);
+    q.setUpdatedAt(Instant.now());
+    store.put(q.getId(), q);
+    changes.emit("QUOTE_CREATED", q.getId().toString(), Map.of("number", q.getNumber()));
+    if (StringUtils.hasText(idk)){
+      idem.remember("POST:/api/v1/quotes", idk, q);
+    }
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .eTag(Etags.weakOfVersion(q.getVersion()))
+        .header(HttpHeaders.CACHE_CONTROL, "no-store")
+        .body(q);
+  }
+
+  /* ===== UPDATE (PUT) avec If-Match ETag ===== */
+  @PutMapping("/{id}")
+  public ResponseEntity<Quote> update(@PathVariable UUID id,
+                                      @RequestHeader(value = "If-Match", required = false) String ifMatch,
+                                      @RequestBody Quote q){
+    Quote cur = store.get(id);
+    if (cur==null) return ResponseEntity.notFound().build();
+    if (!StringUtils.hasText(ifMatch)) return ResponseEntity.status(428).build(); // Precondition Required
+    String expected = Etags.weakOfVersion(cur.getVersion());
+    if (!Etags.matches(ifMatch, expected)) return ResponseEntity.status(HttpStatus.PRECONDITION_FAILED).build();
+
+    // Update allowed fields
+    cur.setCustomerName(q.getCustomerName());
+    cur.setNumber(q.getNumber());
+    if (q.getStatus()!=null) cur.setStatus(q.getStatus());
+    List<DocLine> lines = (q.getLines()==null)? new ArrayList<>() : q.getLines();
+    sanitizeLines(lines);
+    cur.setLines(lines);
+    totals.recomputeTotals(cur);
+    cur.setVersion(cur.getVersion()+1);
+    cur.setUpdatedAt(Instant.now());
+    changes.emit("QUOTE_UPDATED", cur.getId().toString(), Map.of("version", cur.getVersion()));
+
+    return ResponseEntity.ok()
+        .eTag(Etags.weakOfVersion(cur.getVersion()))
+        .header(HttpHeaders.CACHE_CONTROL, "no-store")
+        .body(cur);
+  }
+
+  /* ===== DELETE (If-Match) ===== */
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> delete(@PathVariable UUID id,
+                                     @RequestHeader(value = "If-Match", required = false) String ifMatch){
+    Quote cur = store.get(id);
+    if (cur==null) return ResponseEntity.notFound().build();
+    if (!StringUtils.hasText(ifMatch)) return ResponseEntity.status(428).build();
+    String expected = Etags.weakOfVersion(cur.getVersion());
+    if (!Etags.matches(ifMatch, expected)) return ResponseEntity.status(HttpStatus.PRECONDITION_FAILED).build();
+    store.remove(id);
+    changes.emit("QUOTE_DELETED", id.toString(), Map.of());
+    return ResponseEntity.noContent().build();
+  }
+
+  /* ===== TRANSITIONS d'état ===== */
+  @PostMapping("/{id}:send")
+  public ResponseEntity<Quote> send(@PathVariable UUID id,
+                                    @RequestHeader(value = "If-Match", required = false) String ifMatch){
+    return changeStatus(id, ifMatch, DocumentStatus.SENT);
+  }
+  @PostMapping("/{id}:accept")
+  public ResponseEntity<Quote> accept(@PathVariable UUID id,
+                                      @RequestHeader(value = "If-Match", required = false) String ifMatch){
+    return changeStatus(id, ifMatch, DocumentStatus.ACCEPTED);
+  }
+  @PostMapping("/{id}:refuse")
+  public ResponseEntity<Quote> refuse(@PathVariable UUID id,
+                                      @RequestHeader(value = "If-Match", required = false) String ifMatch){
+    return changeStatus(id, ifMatch, DocumentStatus.REFUSED);
+  }
+  @PostMapping("/{id}:lock")
+  public ResponseEntity<Quote> lock(@PathVariable UUID id,
+                                    @RequestHeader(value = "If-Match", required = false) String ifMatch){
+    return changeStatus(id, ifMatch, DocumentStatus.LOCKED);
+  }
+
+  private ResponseEntity<Quote> changeStatus(UUID id, String ifMatch, DocumentStatus target){
+    Quote cur = store.get(id);
+    if (cur==null) return ResponseEntity.notFound().build();
+    if (!StringUtils.hasText(ifMatch)) return ResponseEntity.status(428).build();
+    String expected = Etags.weakOfVersion(cur.getVersion());
+    if (!Etags.matches(ifMatch, expected)) return ResponseEntity.status(HttpStatus.PRECONDITION_FAILED).build();
+    if (!cur.getStatus().canTransitionTo(target)){
+      return ResponseEntity.status(HttpStatus.CONFLICT).build();
+    }
+    cur.setStatus(target);
+    cur.setVersion(cur.getVersion()+1);
+    cur.setUpdatedAt(Instant.now());
+    changes.emit("QUOTE_STATUS", cur.getId().toString(), Map.of("status", target.name()));
+    return ResponseEntity.ok()
+        .eTag(Etags.weakOfVersion(cur.getVersion()))
+        .header(HttpHeaders.CACHE_CONTROL, "no-store")
+        .body(cur);
+  }
+
+  private void sanitizeLines(List<DocLine> lines){
+    for (DocLine l : lines){
+      if (l.getQty()==null) l.setQty(BigDecimal.ZERO);
+      if (l.getUnitPrice()==null) l.setUnitPrice(BigDecimal.ZERO);
+      if (l.getDiscountPct()==null) l.setDiscountPct(BigDecimal.ZERO);
+      if (l.getVatPct()==null) l.setVatPct(BigDecimal.ZERO);
+    }
+  }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/v1/api/SyncController.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/api/SyncController.java
@@ -1,0 +1,26 @@
+package com.materiel.suite.backend.v1.api;
+
+import com.materiel.suite.backend.v1.service.ChangeFeedService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/sync")
+public class SyncController {
+  private final ChangeFeedService changes;
+  public SyncController(ChangeFeedService changes){ this.changes = changes; }
+
+  @GetMapping("/changes")
+  public ResponseEntity<Map<String,Object>> changes(@RequestParam(name="since", required = false) Long since){
+    var feed = changes.fetchSince(since==null? 0L : since);
+    return ResponseEntity.ok()
+        .header(HttpHeaders.CACHE_CONTROL, "no-store")
+        .body(feed);
+  }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/v1/config/V1Config.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/config/V1Config.java
@@ -1,0 +1,15 @@
+package com.materiel.suite.backend.v1.config;
+
+import com.materiel.suite.backend.v1.service.ChangeFeedService;
+import com.materiel.suite.backend.v1.service.IdempotencyService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class V1Config {
+  @Bean
+  public ChangeFeedService changeFeedService(){ return new ChangeFeedService(); }
+
+  @Bean
+  public IdempotencyService idempotencyService(){ return new IdempotencyService(); }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/v1/domain/DocLine.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/domain/DocLine.java
@@ -1,0 +1,36 @@
+package com.materiel.suite.backend.v1.domain;
+
+import java.math.BigDecimal;
+
+public class DocLine {
+  private String designation;
+  private BigDecimal qty;
+  private String unit;
+  private BigDecimal unitPrice; // HT
+  private BigDecimal discountPct; // 0..100
+  private BigDecimal vatPct; // 0..100
+
+  // computed (renvoyé au client)
+  private BigDecimal lineHt;
+  private BigDecimal lineVat;
+  private BigDecimal lineTtc;
+
+  public String getDesignation() { return designation; }
+  public void setDesignation(String designation) { this.designation = designation; }
+  public BigDecimal getQty() { return qty; }
+  public void setQty(BigDecimal qty) { this.qty = qty; }
+  public String getUnit() { return unit; }
+  public void setUnit(String unit) { this.unit = unit; }
+  public BigDecimal getUnitPrice() { return unitPrice; }
+  public void setUnitPrice(BigDecimal unitPrice) { this.unitPrice = unitPrice; }
+  public BigDecimal getDiscountPct() { return discountPct; }
+  public void setDiscountPct(BigDecimal discountPct) { this.discountPct = discountPct; }
+  public BigDecimal getVatPct() { return vatPct; }
+  public void setVatPct(BigDecimal vatPct) { this.vatPct = vatPct; }
+  public BigDecimal getLineHt() { return lineHt; }
+  public void setLineHt(BigDecimal lineHt) { this.lineHt = lineHt; }
+  public BigDecimal getLineVat() { return lineVat; }
+  public void setLineVat(BigDecimal lineVat) { this.lineVat = lineVat; }
+  public BigDecimal getLineTtc() { return lineTtc; }
+  public void setLineTtc(BigDecimal lineTtc) { this.lineTtc = lineTtc; }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/v1/domain/DocumentStatus.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/domain/DocumentStatus.java
@@ -1,0 +1,21 @@
+package com.materiel.suite.backend.v1.domain;
+
+public enum DocumentStatus {
+  DRAFT,
+  SENT,
+  ACCEPTED,
+  REFUSED,
+  LOCKED,
+  ARCHIVED;
+
+  public boolean canTransitionTo(DocumentStatus target){
+    return switch (this){
+      case DRAFT -> target==SENT || target==ARCHIVED;
+      case SENT -> target==ACCEPTED || target==REFUSED || target==ARCHIVED;
+      case ACCEPTED -> target==LOCKED || target==ARCHIVED;
+      case REFUSED -> target==ARCHIVED;
+      case LOCKED -> target==ARCHIVED;
+      case ARCHIVED -> false;
+    };
+  }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/v1/domain/Quote.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/domain/Quote.java
@@ -1,0 +1,45 @@
+package com.materiel.suite.backend.v1.domain;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class Quote {
+  private UUID id;
+  private String number;
+  private String customerName;
+  private DocumentStatus status = DocumentStatus.DRAFT;
+  private List<DocLine> lines = new ArrayList<>();
+
+  // Totaux
+  private BigDecimal totalHt;
+  private BigDecimal totalVat;
+  private BigDecimal totalTtc;
+
+  // Concurrency
+  private long version = 0L;
+  private Instant updatedAt = Instant.now();
+
+  public UUID getId() { return id; }
+  public void setId(UUID id) { this.id = id; }
+  public String getNumber() { return number; }
+  public void setNumber(String number) { this.number = number; }
+  public String getCustomerName() { return customerName; }
+  public void setCustomerName(String customerName) { this.customerName = customerName; }
+  public DocumentStatus getStatus() { return status; }
+  public void setStatus(DocumentStatus status) { this.status = status; }
+  public List<DocLine> getLines() { return lines; }
+  public void setLines(List<DocLine> lines) { this.lines = lines; }
+  public BigDecimal getTotalHt() { return totalHt; }
+  public void setTotalHt(BigDecimal totalHt) { this.totalHt = totalHt; }
+  public BigDecimal getTotalVat() { return totalVat; }
+  public void setTotalVat(BigDecimal totalVat) { this.totalVat = totalVat; }
+  public BigDecimal getTotalTtc() { return totalTtc; }
+  public void setTotalTtc(BigDecimal totalTtc) { this.totalTtc = totalTtc; }
+  public long getVersion() { return version; }
+  public void setVersion(long version) { this.version = version; }
+  public Instant getUpdatedAt() { return updatedAt; }
+  public void setUpdatedAt(Instant updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/v1/service/ChangeFeedService.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/service/ChangeFeedService.java
@@ -1,0 +1,41 @@
+package com.materiel.suite.backend.v1.service;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Change Feed minimal en mémoire (foundation pour offline-sync).
+ * Stocke les derniers events (taille bornée) avec un curseur monotone.
+ */
+public class ChangeFeedService {
+  private static final int MAX_EVENTS = 10_000;
+  private final Deque<Map<String,Object>> events = new ConcurrentLinkedDeque<>();
+  private final AtomicLong cursor = new AtomicLong(System.currentTimeMillis());
+
+  public void emit(String type, String id, Map<String, Object> payload){
+    long cur = cursor.incrementAndGet();
+    Map<String,Object> ev = new LinkedHashMap<>();
+    ev.put("cursor", cur);
+    ev.put("type", type);
+    ev.put("id", id);
+    ev.put("at", Instant.now().toEpochMilli());
+    ev.put("payload", payload==null? Map.of() : payload);
+    events.addLast(ev);
+    while (events.size() > MAX_EVENTS) events.pollFirst();
+  }
+
+  public Map<String,Object> fetchSince(long since){
+    List<Map<String,Object>> out = new ArrayList<>();
+    long cur = cursor.get();
+    for (var ev : events){
+      long c = (long) ev.get("cursor");
+      if (c > since) out.add(ev);
+    }
+    Map<String,Object> res = new LinkedHashMap<>();
+    res.put("cursor", cur);
+    res.put("events", out);
+    return res;
+  }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/v1/service/IdempotencyService.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/service/IdempotencyService.java
@@ -1,0 +1,29 @@
+package com.materiel.suite.backend.v1.service;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Cache d'idempotence simple (clé = route + Idempotency-Key).
+ * En production, à stocker en base/redis avec TTL.
+ */
+public class IdempotencyService {
+  private static final long TTL_MS = 10 * 60 * 1000; // 10 min
+  private final Map<String, Entry> cache = new ConcurrentHashMap<>();
+
+  public <T> void remember(String route, String key, T obj){
+    cache.put(route+"|"+key, new Entry(obj, Instant.now().toEpochMilli()));
+  }
+  @SuppressWarnings("unchecked")
+  public <T> T findExisting(String route, String key, Class<T> cls){
+    Entry e = cache.get(route+"|"+key);
+    if (e==null) return null;
+    if (Instant.now().toEpochMilli() - e.at > TTL_MS){ cache.remove(route+"|"+key); return null; }
+    if (cls.isInstance(e.obj)) return (T) e.obj;
+    return null;
+  }
+  private record Entry(Object obj, long at){}
+}

--- a/backend/src/main/java/com/materiel/suite/backend/v1/service/TotalsCalculator.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/service/TotalsCalculator.java
@@ -1,0 +1,42 @@
+package com.materiel.suite.backend.v1.service;
+
+import com.materiel.suite.backend.v1.domain.DocLine;
+import com.materiel.suite.backend.v1.domain.Quote;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class TotalsCalculator {
+
+  public void recomputeTotals(Quote q){
+    BigDecimal totalHt = BigDecimal.ZERO;
+    BigDecimal totalVat = BigDecimal.ZERO;
+    for (DocLine l : q.getLines()){
+      computeLine(l);
+      totalHt = totalHt.add(nz(l.getLineHt()));
+      totalVat = totalVat.add(nz(l.getLineVat()));
+    }
+    q.setTotalHt(round2(totalHt));
+    q.setTotalVat(round2(totalVat));
+    q.setTotalTtc(round2(totalHt.add(totalVat)));
+  }
+
+  public void computeLine(DocLine l){
+    BigDecimal qty = nz(l.getQty());
+    BigDecimal pu = nz(l.getUnitPrice());
+    BigDecimal discPct = nz(l.getDiscountPct());
+    BigDecimal vatPct = nz(l.getVatPct());
+
+    BigDecimal gross = qty.multiply(pu);
+    BigDecimal discount = gross.multiply(discPct).divide(BigDecimal.valueOf(100), 6, RoundingMode.HALF_UP);
+    BigDecimal net = gross.subtract(discount);
+    BigDecimal vat = net.multiply(vatPct).divide(BigDecimal.valueOf(100), 6, RoundingMode.HALF_UP);
+
+    l.setLineHt(round2(net));
+    l.setLineVat(round2(vat));
+    l.setLineTtc(round2(net.add(vat)));
+  }
+
+  private static BigDecimal nz(BigDecimal b){ return b==null? BigDecimal.ZERO : b; }
+  private static BigDecimal round2(BigDecimal b){ return b.setScale(2, RoundingMode.HALF_UP); }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/v1/util/Etags.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/util/Etags.java
@@ -1,0 +1,17 @@
+package com.materiel.suite.backend.v1.util;
+
+public final class Etags {
+  private Etags(){}
+  public static String weakOfVersion(long version){
+    return "W/\"" + version + "\"";
+  }
+  public static boolean matches(String ifMatchHeader, String current){
+    if (ifMatchHeader==null) return false;
+    // gestion If-Match avec éventuelle liste
+    String[] parts = ifMatchHeader.split(",");
+    for (String p : parts){
+      if (p.trim().equals(current)) return true;
+    }
+    return false;
+  }
+}

--- a/backend/src/main/resources/openapi/openapi-v1.yaml
+++ b/backend/src/main/resources/openapi/openapi-v1.yaml
@@ -1,0 +1,200 @@
+openapi: 3.0.3
+info:
+  title: Gestion Matériel API
+  version: "1.0"
+  description: >
+    API v1 — Devis/Commandes/BL/Factures (fondations), Planning, Sync.
+    ETags (If-Match) pour updates, Idempotency-Key pour POST, Change Feed pour offline.
+servers:
+  - url: /api/v1
+paths:
+  /openapi.yaml:
+    get:
+      summary: Serve this OpenAPI document
+      responses:
+        "200":
+          description: OK
+  /quotes:
+    get:
+      summary: List quotes
+      parameters:
+        - in: query
+          name: q
+          schema: { type: string }
+        - in: query
+          name: status
+          schema: { $ref: '#/components/schemas/DocumentStatus' }
+      responses:
+        "200": { description: OK, content: { application/json: { schema: { type: array, items: { $ref: '#/components/schemas/Quote' } } } } }
+    post:
+      summary: Create quote (Idempotency-Key supported)
+      parameters:
+        - in: header
+          name: Idempotency-Key
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/Quote' }
+      responses:
+        "201": { description: Created, headers: { ETag: { schema: { type: string } } }, content: { application/json: { schema: { $ref: '#/components/schemas/Quote' } } } }
+  /quotes/{id}:
+    get:
+      summary: Get quote
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        "200": { description: OK, headers: { ETag: { schema: { type: string } } }, content: { application/json: { schema: { $ref: '#/components/schemas/Quote' } } } }
+        "404": { description: Not Found }
+    put:
+      summary: Update quote (If-Match required)
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+        - in: header
+          name: If-Match
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/Quote' }
+      responses:
+        "200": { description: OK, headers: { ETag: { schema: { type: string } } }, content: { application/json: { schema: { $ref: '#/components/schemas/Quote' } } } }
+        "404": { description: Not Found }
+        "412": { description: Precondition Failed }
+        "428": { description: Precondition Required }
+    delete:
+      summary: Delete quote (If-Match required)
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+        - in: header
+          name: If-Match
+          required: true
+          schema: { type: string }
+      responses:
+        "204": { description: No Content }
+        "404": { description: Not Found }
+        "412": { description: Precondition Failed }
+        "428": { description: Precondition Required }
+  /quotes/{id}:send:
+    post:
+      summary: Transition DRAFT->SENT
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+        - in: header
+          name: If-Match
+          required: true
+          schema: { type: string }
+      responses:
+        "200": { description: OK }
+        "409": { description: Invalid transition }
+  /quotes/{id}:accept:
+    post:
+      summary: Transition SENT->ACCEPTED
+      parameters:
+        - $ref: '#/components/parameters/IdParam'
+        - $ref: '#/components/parameters/IfMatch'
+      responses:
+        "200": { description: OK }
+        "409": { description: Invalid transition }
+  /quotes/{id}:refuse:
+    post:
+      summary: Transition SENT->REFUSED
+      parameters:
+        - $ref: '#/components/parameters/IdParam'
+        - $ref: '#/components/parameters/IfMatch'
+      responses:
+        "200": { description: OK }
+        "409": { description: Invalid transition }
+  /quotes/{id}:lock:
+    post:
+      summary: LOCKED
+      parameters:
+        - $ref: '#/components/parameters/IdParam'
+        - $ref: '#/components/parameters/IfMatch'
+      responses:
+        "200": { description: OK }
+  /sync/changes:
+    get:
+      summary: Change feed since a cursor (epoch ms)
+      parameters:
+        - in: query
+          name: since
+          schema: { type: integer, format: int64 }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  cursor: { type: integer, format: int64 }
+                  events:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        cursor: { type: integer, format: int64 }
+                        type: { type: string }
+                        id: { type: string }
+                        at: { type: integer, format: int64 }
+                        payload: { type: object }
+
+components:
+  parameters:
+    IdParam:
+      in: path
+      name: id
+      required: true
+      schema: { type: string, format: uuid }
+    IfMatch:
+      in: header
+      name: If-Match
+      required: true
+      schema: { type: string }
+  schemas:
+    DocumentStatus:
+      type: string
+      enum: [DRAFT, SENT, ACCEPTED, REFUSED, LOCKED, ARCHIVED]
+    DocLine:
+      type: object
+      properties:
+        designation: { type: string }
+        qty: { type: number }
+        unit: { type: string }
+        unitPrice: { type: number }
+        discountPct: { type: number }
+        vatPct: { type: number }
+        lineHt: { type: number }
+        lineVat: { type: number }
+        lineTtc: { type: number }
+    Quote:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        number: { type: string }
+        customerName: { type: string }
+        status: { $ref: '#/components/schemas/DocumentStatus' }
+        lines:
+          type: array
+          items: { $ref: '#/components/schemas/DocLine' }
+        totalHt: { type: number }
+        totalVat: { type: number }
+        totalTtc: { type: number }
+        version: { type: integer, format: int64 }
+        updatedAt: { type: string, format: date-time }


### PR DESCRIPTION
## Summary
- add REST controllers for quote management, OpenAPI spec serving, and change feed sync
- introduce domain models and services including totals calculator and idempotency cache
- document endpoints in new OpenAPI v1 spec

## Testing
- `mvn test` *(fails: Non-resolvable import POM: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ea89b8c48330b3bd939e6eb90c70