### PR TITLE
feat: implement REST API integration for client

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/net/RestClient.java
+++ b/client/src/main/java/com/materiel/suite/client/net/RestClient.java
@@ -6,6 +6,8 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 public class RestClient {
@@ -20,43 +22,60 @@ public class RestClient {
   }
 
   public String get(String path) throws IOException, InterruptedException {
-    HttpRequest.Builder b = HttpRequest.newBuilder().uri(URI.create(baseUrl+path)).GET();
-    bearer.ifPresent(t -> b.header("Authorization","Bearer "+t));
-    b.header("Accept","application/json");
-    var res = http.send(b.build(), HttpResponse.BodyHandlers.ofString());
-    return ensureOk(res);
+    return request("GET", path, null, null);
   }
 
   public String post(String path, String json) throws IOException, InterruptedException {
-    HttpRequest.Builder b = HttpRequest.newBuilder()
-        .uri(URI.create(baseUrl+path))
-        .header("Content-Type","application/json")
-        .POST(HttpRequest.BodyPublishers.ofString(json==null?"{}":json));
-    bearer.ifPresent(t -> b.header("Authorization","Bearer "+t));
-    var res = http.send(b.build(), HttpResponse.BodyHandlers.ofString());
-    return ensureOk(res);
+    return request("POST", path, json, null);
   }
 
   public String put(String path, String json) throws IOException, InterruptedException {
-    HttpRequest.Builder b = HttpRequest.newBuilder()
-        .uri(URI.create(baseUrl+path))
-        .header("Content-Type","application/json")
-        .PUT(HttpRequest.BodyPublishers.ofString(json==null?"{}":json));
-    bearer.ifPresent(t -> b.header("Authorization","Bearer "+t));
-    var res = http.send(b.build(), HttpResponse.BodyHandlers.ofString());
-    return ensureOk(res);
+    return request("PUT", path, json, null);
   }
 
   public String delete(String path) throws IOException, InterruptedException {
-    HttpRequest.Builder b = HttpRequest.newBuilder().uri(URI.create(baseUrl+path)).DELETE();
-    bearer.ifPresent(t -> b.header("Authorization","Bearer "+t));
-    var res = http.send(b.build(), HttpResponse.BodyHandlers.ofString());
-    return ensureOk(res);
+    return request("DELETE", path, null, null);
   }
 
-  private static String ensureOk(HttpResponse<String> res) throws IOException {
+  public String get(String path, Map<String,String> headers) throws IOException, InterruptedException {
+    return request("GET", path, null, headers);
+  }
+
+  public String post(String path, String json, Map<String,String> headers) throws IOException, InterruptedException {
+    return request("POST", path, json, headers);
+  }
+
+  public String put(String path, String json, Map<String,String> headers) throws IOException, InterruptedException {
+    return request("PUT", path, json, headers);
+  }
+
+  public String delete(String path, Map<String,String> headers) throws IOException, InterruptedException {
+    return request("DELETE", path, null, headers);
+  }
+
+  private static String ensure200(HttpResponse<String> res) throws IOException {
     int s = res.statusCode();
     if (s>=200 && s<300) return res.body();
     throw new IOException("HTTP "+s+": "+res.body());
+  }
+
+  private String request(String method, String path, String json, Map<String,String> headers) throws IOException, InterruptedException {
+    HttpRequest.Builder b = HttpRequest.newBuilder()
+        .uri(URI.create(baseUrl+path));
+    if ("GET".equals(method)) b = b.GET();
+    else if ("POST".equals(method)) b = b.header("Content-Type","application/json")
+        .POST(HttpRequest.BodyPublishers.ofString(json==null?"{}":json));
+    else if ("PUT".equals(method)) b = b.header("Content-Type","application/json")
+        .PUT(HttpRequest.BodyPublishers.ofString(json==null?"{}":json));
+    else if ("DELETE".equals(method)) b = b.DELETE();
+    bearer.ifPresent(t -> b.header("Authorization","Bearer "+t));
+    b.header("Accept","application/json");
+    if (headers!=null){
+      for (var e : headers.entrySet()){
+        if (e.getKey()!=null && e.getValue()!=null) b.header(e.getKey(), e.getValue());
+      }
+    }
+    var res = http.send(b.build(), HttpResponse.BodyHandlers.ofString());
+    return ensure200(res);
   }
 }

--- a/client/src/main/java/com/materiel/suite/client/service/SyncService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/SyncService.java
@@ -1,0 +1,37 @@
+package com.materiel.suite.client.service;
+
+import com.materiel.suite.client.net.RestClient;
+import com.materiel.suite.client.net.SimpleJson;
+
+import java.util.*;
+
+/**
+ * Change feed lecteur minimal — fondation Sprint A.
+ * Garde le dernier curseur et renvoie les events depuis la dernière synchro.
+ */
+public class SyncService {
+  private final RestClient rc;
+  private long lastCursor = 0L;
+  public SyncService(RestClient rc){ this.rc = rc; }
+
+  @SuppressWarnings("unchecked")
+  public synchronized List<Map<String,Object>> pull() {
+    try {
+      String body = rc.get("/api/v1/sync/changes?since=" + lastCursor);
+      Map<String,Object> obj = (Map<String,Object>) SimpleJson.parse(body);
+      Object cur = obj.get("cursor");
+      if (cur instanceof Number n) lastCursor = n.longValue();
+      List<Map<String,Object>> events = new ArrayList<>();
+      for (Object e : SimpleJson.asArr(obj.getOrDefault("events", List.of()))){
+        events.add((Map<String,Object>) e);
+      }
+      return events;
+    } catch(Exception e){
+      return List.of();
+    }
+  }
+
+  public synchronized long getLastCursor(){ return lastCursor; }
+  public synchronized void setLastCursor(long c){ this.lastCursor = c; }
+}
+

--- a/client/src/main/java/com/materiel/suite/client/service/api/ApiDeliveryNoteService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/api/ApiDeliveryNoteService.java
@@ -2,17 +2,59 @@ package com.materiel.suite.client.service.api;
 
 import com.materiel.suite.client.model.DeliveryNote;
 import com.materiel.suite.client.net.RestClient;
+import com.materiel.suite.client.net.SimpleJson;
 import com.materiel.suite.client.service.DeliveryNoteService;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public class ApiDeliveryNoteService implements DeliveryNoteService {
   private final RestClient rc; private final DeliveryNoteService fb;
-  public ApiDeliveryNoteService(RestClient rc, DeliveryNoteService fb){ this.rc=rc; this.fb=fb; }
-  @Override public List<DeliveryNote> list(){ try { return fb.list(); } catch(Exception e){ return fb.list(); } }
-  @Override public DeliveryNote get(UUID id){ try { return fb.get(id); } catch(Exception e){ return fb.get(id); } }
-  @Override public DeliveryNote save(DeliveryNote d){ try { return fb.save(d); } catch(Exception e){ return fb.save(d); } }
-  @Override public void delete(UUID id){ try { rc.delete("/api/delivery-notes/"+id); } catch(Exception ignore){} fb.delete(id); }
-  @Override public DeliveryNote createFromOrder(UUID orderId){ try { return fb.createFromOrder(orderId); } catch(Exception e){ return fb.createFromOrder(orderId); } }
+  public ApiDeliveryNoteService(RestClient rc, DeliveryNoteService fallback){ this.rc=rc; this.fb=fallback; }
+  @Override public List<DeliveryNote> list(){
+    try {
+      String body = rc.get("/api/v1/delivery-notes");
+      var arr = SimpleJson.asArr(SimpleJson.parse(body));
+      List<DeliveryNote> out = new ArrayList<>();
+      for (Object o : arr){ out.add(ApiSupport.toDelivery(SimpleJson.asObj(o))); }
+      return out;
+    } catch(Exception e){ return fb.list(); }
+  }
+  @Override public DeliveryNote get(UUID id){
+    try {
+      String body = rc.get("/api/v1/delivery-notes/"+id);
+      return ApiSupport.toDelivery(SimpleJson.asObj(SimpleJson.parse(body)));
+    } catch(Exception e){ return fb.get(id); }
+  }
+  @Override public DeliveryNote save(DeliveryNote d){
+    try {
+      String json = ApiSupport.toJson(d);
+      if (d.getId()==null){
+        String body = rc.post("/api/v1/delivery-notes", json);
+        return ApiSupport.toDelivery(SimpleJson.asObj(SimpleJson.parse(body)));
+      } else {
+        Map<String,String> h = new HashMap<>();
+        long v = readVersion(d); if (v>0) h.put("If-Match", "W/\""+v+"\"");
+        String body = rc.put("/api/v1/delivery-notes/"+d.getId(), json, h);
+        return ApiSupport.toDelivery(SimpleJson.asObj(SimpleJson.parse(body)));
+      }
+    } catch(Exception e){ return fb.save(d); }
+  }
+  @Override public void delete(UUID id){
+    try { rc.delete("/api/v1/delivery-notes/"+id); } catch(Exception ignore){}
+    fb.delete(id);
+  }
+  @Override public DeliveryNote createFromOrder(UUID orderId){
+    try {
+      String body = rc.post("/api/v1/delivery-notes/from-order", "{\"order\":{\"id\":\""+orderId+"\"}}" );
+      return ApiSupport.toDelivery(SimpleJson.asObj(SimpleJson.parse(body)));
+    } catch(Exception e){ return fb.createFromOrder(orderId); }
+  }
+  private long readVersion(DeliveryNote d){
+    try { return (long) DeliveryNote.class.getMethod("getVersion").invoke(d); } catch(Exception e){ return 0L; }
+  }
 }
+

--- a/client/src/main/java/com/materiel/suite/client/service/api/ApiInvoiceService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/api/ApiInvoiceService.java
@@ -2,18 +2,71 @@ package com.materiel.suite.client.service.api;
 
 import com.materiel.suite.client.model.Invoice;
 import com.materiel.suite.client.net.RestClient;
+import com.materiel.suite.client.net.SimpleJson;
 import com.materiel.suite.client.service.InvoiceService;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public class ApiInvoiceService implements InvoiceService {
   private final RestClient rc; private final InvoiceService fb;
-  public ApiInvoiceService(RestClient rc, InvoiceService fb){ this.rc=rc; this.fb=fb; }
-  @Override public List<Invoice> list(){ try { return fb.list(); } catch(Exception e){ return fb.list(); } }
-  @Override public Invoice get(UUID id){ try { return fb.get(id); } catch(Exception e){ return fb.get(id); } }
-  @Override public Invoice save(Invoice i){ try { return fb.save(i); } catch(Exception e){ return fb.save(i); } }
-  @Override public void delete(UUID id){ try { rc.delete("/api/invoices/"+id); } catch(Exception ignore){} fb.delete(id); }
-  @Override public Invoice createFromQuote(UUID quoteId){ try { return fb.createFromQuote(quoteId); } catch(Exception e){ return fb.createFromQuote(quoteId); } }
-  @Override public Invoice createFromDeliveryNotes(List<UUID> ids){ try { return fb.createFromDeliveryNotes(ids); } catch(Exception e){ return fb.createFromDeliveryNotes(ids); } }
+  public ApiInvoiceService(RestClient rc, InvoiceService fallback){ this.rc=rc; this.fb=fallback; }
+  @Override public List<Invoice> list(){
+    try {
+      String body = rc.get("/api/v1/invoices");
+      var arr = SimpleJson.asArr(SimpleJson.parse(body));
+      List<Invoice> out = new ArrayList<>();
+      for (Object o : arr){ out.add(ApiSupport.toInvoice(SimpleJson.asObj(o))); }
+      return out;
+    } catch(Exception e){ return fb.list(); }
+  }
+  @Override public Invoice get(UUID id){
+    try {
+      String body = rc.get("/api/v1/invoices/"+id);
+      return ApiSupport.toInvoice(SimpleJson.asObj(SimpleJson.parse(body)));
+    } catch(Exception e){ return fb.get(id); }
+  }
+  @Override public Invoice save(Invoice i){
+    try {
+      String json = ApiSupport.toJson(i);
+      if (i.getId()==null){
+        String body = rc.post("/api/v1/invoices", json);
+        return ApiSupport.toInvoice(SimpleJson.asObj(SimpleJson.parse(body)));
+      } else {
+        Map<String,String> h = new HashMap<>();
+        long v = readVersion(i); if (v>0) h.put("If-Match", "W/\""+v+"\"");
+        String body = rc.put("/api/v1/invoices/"+i.getId(), json, h);
+        return ApiSupport.toInvoice(SimpleJson.asObj(SimpleJson.parse(body)));
+      }
+    } catch(Exception e){ return fb.save(i); }
+  }
+  @Override public void delete(UUID id){
+    try { rc.delete("/api/v1/invoices/"+id); } catch(Exception ignore){}
+    fb.delete(id);
+  }
+  @Override public Invoice createFromQuote(UUID quoteId){
+    try {
+      String body = rc.post("/api/v1/invoices/from-quote", "{\"quote\":{\"id\":\""+quoteId+"\"}}" );
+      return ApiSupport.toInvoice(SimpleJson.asObj(SimpleJson.parse(body)));
+    } catch(Exception e){ return fb.createFromQuote(quoteId); }
+  }
+  @Override public Invoice createFromDeliveryNotes(List<UUID> deliveryNoteIds){
+    try {
+      StringBuilder arr = new StringBuilder("[");
+      for (int i=0;i<deliveryNoteIds.size();i++){
+        if (i>0) arr.append(",");
+        arr.append("{\"id\":\"").append(deliveryNoteIds.get(i)).append("\"}");
+      }
+      arr.append("]");
+      String body = rc.post("/api/v1/invoices/from-delivery-notes", "{\"deliveryNotes\":"+arr+"}");
+      return ApiSupport.toInvoice(SimpleJson.asObj(SimpleJson.parse(body)));
+    } catch(Exception e){ return fb.createFromDeliveryNotes(deliveryNoteIds); }
+  }
+  private long readVersion(Invoice i){
+    try { return (long) Invoice.class.getMethod("getVersion").invoke(i); } catch(Exception e){ return 0L; }
+  }
 }
+

--- a/client/src/main/java/com/materiel/suite/client/service/api/ApiOrderService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/api/ApiOrderService.java
@@ -2,17 +2,59 @@ package com.materiel.suite.client.service.api;
 
 import com.materiel.suite.client.model.Order;
 import com.materiel.suite.client.net.RestClient;
+import com.materiel.suite.client.net.SimpleJson;
 import com.materiel.suite.client.service.OrderService;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public class ApiOrderService implements OrderService {
   private final RestClient rc; private final OrderService fb;
-  public ApiOrderService(RestClient rc, OrderService fb){ this.rc=rc; this.fb=fb; }
-  @Override public List<Order> list(){ try { return fb.list(); } catch(Exception e){ return fb.list(); } }
-  @Override public Order get(UUID id){ try { return fb.get(id); } catch(Exception e){ return fb.get(id); } }
-  @Override public Order save(Order o){ try { return fb.save(o); } catch(Exception e){ return fb.save(o); } }
-  @Override public void delete(UUID id){ try { rc.delete("/api/orders/"+id); } catch(Exception ignore){} fb.delete(id); }
-  @Override public Order createFromQuote(UUID quoteId){ try { return fb.createFromQuote(quoteId); } catch(Exception e){ return fb.createFromQuote(quoteId); } }
+  public ApiOrderService(RestClient rc, OrderService fallback){ this.rc=rc; this.fb=fallback; }
+  @Override public List<Order> list(){
+    try {
+      String body = rc.get("/api/v1/orders");
+      var arr = SimpleJson.asArr(SimpleJson.parse(body));
+      List<Order> out = new ArrayList<>();
+      for (Object o : arr){ out.add(ApiSupport.toOrder(SimpleJson.asObj(o))); }
+      return out;
+    } catch(Exception e){ return fb.list(); }
+  }
+  @Override public Order get(UUID id){
+    try {
+      String body = rc.get("/api/v1/orders/"+id);
+      return ApiSupport.toOrder(SimpleJson.asObj(SimpleJson.parse(body)));
+    } catch(Exception e){ return fb.get(id); }
+  }
+  @Override public Order save(Order o){
+    try {
+      String json = ApiSupport.toJson(o);
+      if (o.getId()==null){
+        String body = rc.post("/api/v1/orders", json);
+        return ApiSupport.toOrder(SimpleJson.asObj(SimpleJson.parse(body)));
+      } else {
+        Map<String,String> h = new HashMap<>();
+        long v = readVersion(o); if (v>0) h.put("If-Match", "W/\""+v+"\"");
+        String body = rc.put("/api/v1/orders/"+o.getId(), json, h);
+        return ApiSupport.toOrder(SimpleJson.asObj(SimpleJson.parse(body)));
+      }
+    } catch(Exception e){ return fb.save(o); }
+  }
+  @Override public void delete(UUID id){
+    try { rc.delete("/api/v1/orders/"+id); } catch(Exception ignore){}
+    fb.delete(id);
+  }
+  @Override public Order createFromQuote(UUID quoteId){
+    try {
+      String body = rc.post("/api/v1/orders/from-quote", "{\"quote\":{\"id\":\""+quoteId+"\"}}" );
+      return ApiSupport.toOrder(SimpleJson.asObj(SimpleJson.parse(body)));
+    } catch(Exception e){ return fb.createFromQuote(quoteId); }
+  }
+  private long readVersion(Order o){
+    try { return (long) Order.class.getMethod("getVersion").invoke(o); } catch(Exception e){ return 0L; }
+  }
 }
+

--- a/client/src/main/java/com/materiel/suite/client/service/api/ApiQuoteService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/api/ApiQuoteService.java
@@ -2,17 +2,60 @@ package com.materiel.suite.client.service.api;
 
 import com.materiel.suite.client.model.Quote;
 import com.materiel.suite.client.net.RestClient;
+import com.materiel.suite.client.net.SimpleJson;
 import com.materiel.suite.client.service.QuoteService;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
+/**
+ * SDK léger — utilise RestClient. Fallback transparent sur mock en cas d'erreur.
+ */
 public class ApiQuoteService implements QuoteService {
   private final RestClient rc;
   private final QuoteService fallback;
-  public ApiQuoteService(RestClient rc, QuoteService fb){ this.rc=rc; this.fallback=fb; }
-  @Override public List<Quote> list(){ try { return fallback.list(); } catch(Exception e){ return fallback.list(); } }
-  @Override public Quote get(UUID id){ try { return fallback.get(id); } catch(Exception e){ return fallback.get(id); } }
-  @Override public Quote save(Quote q){ try { return fallback.save(q); } catch(Exception e){ return fallback.save(q); } }
-  @Override public void delete(UUID id){ try { rc.delete("/api/quotes/"+id); } catch(Exception ignore){} fallback.delete(id); }
+  public ApiQuoteService(RestClient rc, QuoteService fallback){ this.rc=rc; this.fallback=fallback; }
+  @Override public List<Quote> list(){
+    try {
+      String body = rc.get("/api/v1/quotes");
+      var arr = SimpleJson.asArr(SimpleJson.parse(body));
+      List<Quote> out = new ArrayList<>();
+      for (Object o : arr){ out.add(ApiSupport.toQuote(SimpleJson.asObj(o))); }
+      return out;
+    } catch(Exception e){ return fallback.list(); }
+  }
+  @Override public Quote get(UUID id){
+    try {
+      String body = rc.get("/api/v1/quotes/"+id);
+      return ApiSupport.toQuote(SimpleJson.asObj(SimpleJson.parse(body)));
+    } catch(Exception e){ return fallback.get(id); }
+  }
+  @Override public Quote save(Quote q){
+    try {
+      String json = ApiSupport.toJson(q);
+      if (q.getId()==null){
+        Map<String,String> h = new HashMap<>();
+        h.put("Idempotency-Key", UUID.randomUUID().toString());
+        String body = rc.post("/api/v1/quotes", json, h);
+        return ApiSupport.toQuote(SimpleJson.asObj(SimpleJson.parse(body)));
+      } else {
+        Map<String,String> h = new HashMap<>();
+        long version = readVersion(q);
+        if (version>0) h.put("If-Match", "W/\""+version+"\"");
+        String body = rc.put("/api/v1/quotes/"+q.getId(), json, h);
+        return ApiSupport.toQuote(SimpleJson.asObj(SimpleJson.parse(body)));
+      }
+    } catch(Exception e){ return fallback.save(q); }
+  }
+  @Override public void delete(UUID id){
+    try { rc.delete("/api/v1/quotes/"+id); } catch(Exception ignore){}
+    fallback.delete(id);
+  }
+
+  private long readVersion(Quote q){
+    try { return (long) Quote.class.getMethod("getVersion").invoke(q); } catch(Exception e){ return 0L; }
+  }
 }

--- a/client/src/main/java/com/materiel/suite/client/service/api/ApiSupport.java
+++ b/client/src/main/java/com/materiel/suite/client/service/api/ApiSupport.java
@@ -1,0 +1,290 @@
+package com.materiel.suite.client.service.api;
+
+import com.materiel.suite.client.model.*;
+import com.materiel.suite.client.net.SimpleJson;
+
+import java.lang.reflect.Method;
+import java.time.Instant;
+import java.util.*;
+
+/**
+ * Utilitaires de mapping JSON <-> modèles client (réflexion défensive).
+ * Tolérant aux variations (qty vs quantity, totalHt vs totalHT, etc.).
+ */
+final class ApiSupport {
+  private ApiSupport(){}
+
+  /* ================= JSON → MODEL ================= */
+  static Quote toQuote(Map<String,Object> m){
+    Quote q = new Quote();
+    q.setId(parseUUID(m.get("id")));
+    q.setNumber(SimpleJson.str(m.get("number")));
+    q.setCustomerName(SimpleJson.str(m.get("customerName")));
+    setStatusIfPresent(q, m.get("status"));
+    setIfPresent(q, "setVersion", m.get("version"));
+    setIfPresent(q, "setUpdatedAt", parseInstant(m.get("updatedAt")));
+    // totals
+    setIfPresent(q, List.of("setTotalHt","setTotalHT"), m.get("totalHt"));
+    setIfPresent(q, List.of("setTotalVat","setTotalVAT"), m.get("totalVat"));
+    setIfPresent(q, List.of("setTotalTtc","setTotalTTC"), m.get("totalTtc"));
+    // lines
+    List<Object> arr = SimpleJson.asArr(m.getOrDefault("lines", List.of()));
+    List<DocumentLine> out = new ArrayList<>();
+    for (Object o : arr){ out.add(toLine(SimpleJson.asObj(o))); }
+    try { q.setLines(out); } catch(Exception ignore){}
+    return q;
+  }
+
+  static Order toOrder(Map<String,Object> m){
+    Order o = new Order();
+    o.setId(parseUUID(m.get("id")));
+    setIfPresent(o, "setNumber", m.get("number"));
+    setIfPresent(o, "setCustomerName", m.get("customerName"));
+    setStatusIfPresent(o, m.get("status"));
+    setIfPresent(o, "setVersion", m.get("version"));
+    setIfPresent(o, "setUpdatedAt", parseInstant(m.get("updatedAt")));
+    setTotals(o, m);
+    setLines(o, m);
+    return o;
+  }
+
+  static DeliveryNote toDelivery(Map<String,Object> m){
+    DeliveryNote d = new DeliveryNote();
+    d.setId(parseUUID(m.get("id")));
+    setIfPresent(d, "setNumber", m.get("number"));
+    setIfPresent(d, "setCustomerName", m.get("customerName"));
+    setStatusIfPresent(d, m.get("status"));
+    setIfPresent(d, "setVersion", m.get("version"));
+    setIfPresent(d, "setUpdatedAt", parseInstant(m.get("updatedAt")));
+    setTotals(d, m);
+    setLines(d, m);
+    return d;
+  }
+
+  static Invoice toInvoice(Map<String,Object> m){
+    Invoice i = new Invoice();
+    i.setId(parseUUID(m.get("id")));
+    setIfPresent(i, "setNumber", m.get("number"));
+    setIfPresent(i, "setCustomerName", m.get("customerName"));
+    setStatusIfPresent(i, m.get("status"));
+    setIfPresent(i, "setVersion", m.get("version"));
+    setIfPresent(i, "setUpdatedAt", parseInstant(m.get("updatedAt")));
+    setTotals(i, m);
+    setLines(i, m);
+    return i;
+  }
+
+  static void setTotals(Object doc, Map<String,Object> m){
+    setIfPresent(doc, List.of("setTotalHt","setTotalHT"), m.get("totalHt"));
+    setIfPresent(doc, List.of("setTotalVat","setTotalVAT"), m.get("totalVat"));
+    setIfPresent(doc, List.of("setTotalTtc","setTotalTTC"), m.get("totalTtc"));
+  }
+
+  static void setLines(Object doc, Map<String,Object> m){
+    List<Object> arr = SimpleJson.asArr(m.getOrDefault("lines", List.of()));
+    List<DocumentLine> out = new ArrayList<>();
+    for (Object o : arr){ out.add(toLine(SimpleJson.asObj(o))); }
+    try {
+      Method setter = doc.getClass().getMethod("setLines", List.class);
+      setter.invoke(doc, out);
+    } catch(Exception ignore){}
+  }
+
+  static DocumentLine toLine(Map<String,Object> m){
+    DocumentLine l = new DocumentLine();
+    setIfPresent(l, "setDesignation", m.get("designation"));
+    // qty / quantity
+    Object qty = m.get("qty");
+    if (qty==null) qty = m.get("quantity");
+    setIfPresent(l, List.of("setQty","setQuantity"), qty);
+    setIfPresent(l, List.of("setUnit","setUnite"), m.get("unit"));
+    setIfPresent(l, List.of("setUnitPrice","setUnitPriceHt","setPuHt"), m.get("unitPrice"));
+    setIfPresent(l, List.of("setDiscountPct","setRemisePct"), m.get("discountPct"));
+    setIfPresent(l, List.of("setVatPct","setTvaPct"), m.get("vatPct"));
+    // computed may exist
+    setIfPresent(l, List.of("setLineHt","setLigneHt"), m.get("lineHt"));
+    setIfPresent(l, List.of("setLineVat","setLigneTva"), m.get("lineVat"));
+    setIfPresent(l, List.of("setLineTtc","setLigneTtc"), m.get("lineTtc"));
+    return l;
+  }
+
+  /* ================= MODEL → JSON ================= */
+  static String toJson(Quote q){
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    field(sb,"id", q.getId()==null? null : q.getId().toString()); comma(sb);
+    field(sb,"number", q.getNumber()); comma(sb);
+    field(sb,"customerName", q.getCustomerName()); comma(sb);
+    field(sb,"status", q.getStatus()==null? null : q.getStatus().toString()); comma(sb);
+    numeric(sb,"version", readNumber(q,"getVersion")); comma(sb);
+    // lines
+    sb.append("\"lines\":"); linesArray(sb, q.getLines()); comma(sb);
+    // optional totals
+    numeric(sb,"totalHt", readNumber(q,"getTotalHt","getTotalHT")); comma(sb);
+    numeric(sb,"totalVat", readNumber(q,"getTotalVat","getTotalVAT")); comma(sb);
+    numeric(sb,"totalTtc", readNumber(q,"getTotalTtc","getTotalTTC"));
+    sb.append("}");
+    return sb.toString();
+  }
+
+  static String toJson(Order o){
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    field(sb,"id", o.getId()==null? null : o.getId().toString()); comma(sb);
+    field(sb,"number", o.getNumber()); comma(sb);
+    field(sb,"customerName", o.getCustomerName()); comma(sb);
+    field(sb,"status", o.getStatus()==null? null : o.getStatus().toString()); comma(sb);
+    numeric(sb,"version", readNumber(o,"getVersion")); comma(sb);
+    sb.append("\"lines\":"); linesArray(sb, o.getLines()); comma(sb);
+    numeric(sb,"totalHt", readNumber(o,"getTotalHt","getTotalHT")); comma(sb);
+    numeric(sb,"totalVat", readNumber(o,"getTotalVat","getTotalVAT")); comma(sb);
+    numeric(sb,"totalTtc", readNumber(o,"getTotalTtc","getTotalTTC"));
+    sb.append("}");
+    return sb.toString();
+  }
+
+  static String toJson(DeliveryNote d){
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    field(sb,"id", d.getId()==null? null : d.getId().toString()); comma(sb);
+    field(sb,"number", d.getNumber()); comma(sb);
+    field(sb,"customerName", d.getCustomerName()); comma(sb);
+    field(sb,"status", d.getStatus()==null? null : d.getStatus().toString()); comma(sb);
+    numeric(sb,"version", readNumber(d,"getVersion")); comma(sb);
+    sb.append("\"lines\":"); linesArray(sb, d.getLines()); comma(sb);
+    numeric(sb,"totalHt", readNumber(d,"getTotalHt","getTotalHT")); comma(sb);
+    numeric(sb,"totalVat", readNumber(d,"getTotalVat","getTotalVAT")); comma(sb);
+    numeric(sb,"totalTtc", readNumber(d,"getTotalTtc","getTotalTTC"));
+    sb.append("}");
+    return sb.toString();
+  }
+
+  static String toJson(Invoice i){
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    field(sb,"id", i.getId()==null? null : i.getId().toString()); comma(sb);
+    field(sb,"number", i.getNumber()); comma(sb);
+    field(sb,"customerName", i.getCustomerName()); comma(sb);
+    field(sb,"status", i.getStatus()==null? null : i.getStatus().toString()); comma(sb);
+    numeric(sb,"version", readNumber(i,"getVersion")); comma(sb);
+    sb.append("\"lines\":"); linesArray(sb, i.getLines()); comma(sb);
+    numeric(sb,"totalHt", readNumber(i,"getTotalHt","getTotalHT")); comma(sb);
+    numeric(sb,"totalVat", readNumber(i,"getTotalVat","getTotalVAT")); comma(sb);
+    numeric(sb,"totalTtc", readNumber(i,"getTotalTtc","getTotalTTC"));
+    sb.append("}");
+    return sb.toString();
+  }
+
+  private static void linesArray(StringBuilder sb, List<DocumentLine> lines){
+    sb.append("[");
+    if (lines!=null){
+      for (int i=0;i<lines.size();i++){
+        if (i>0) sb.append(",");
+        sb.append(toJson(lines.get(i)));
+      }
+    }
+    sb.append("]");
+  }
+
+  private static String toJson(DocumentLine l){
+    StringBuilder sb = new StringBuilder("{");
+    field(sb,"designation", readString(l,"getDesignation")); comma(sb);
+    numeric(sb,"qty", readNumber(l,"getQty","getQuantity")); comma(sb);
+    field(sb,"unit", readString(l,"getUnit","getUnite")); comma(sb);
+    numeric(sb,"unitPrice", readNumber(l,"getUnitPrice","getUnitPriceHt","getPuHt")); comma(sb);
+    numeric(sb,"discountPct", readNumber(l,"getDiscountPct","getRemisePct")); comma(sb);
+    numeric(sb,"vatPct", readNumber(l,"getVatPct","getTvaPct"));
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /* ================= helpers ================= */
+  private static void field(StringBuilder sb, String k, String v){
+    sb.append("\"").append(k).append("\":");
+    if (v==null) sb.append("null");
+    else sb.append("\"").append(escape(v)).append("\"");
+  }
+
+  private static void numeric(StringBuilder sb, String k, Number v){
+    sb.append("\"").append(k).append("\":");
+    if (v==null) sb.append("null"); else sb.append(v.toString());
+  }
+
+  private static void comma(StringBuilder sb){ sb.append(","); }
+
+  private static String escape(String s){ return s.replace("\\","\\\\").replace("\"","\\\""); }
+
+  private static UUID parseUUID(Object o){
+    try { return o==null? null : UUID.fromString(o.toString()); } catch(Exception e){ return null; }
+  }
+
+  private static Date parseInstant(Object o){
+    try { if (o==null) return null; return Date.from(Instant.parse(o.toString())); } catch(Exception e){ return null; }
+  }
+
+  private static void setIfPresent(Object target, String method, Object value){
+    setIfPresent(target, List.of(method), value);
+  }
+
+  private static void setIfPresent(Object target, List<String> methods, Object value){
+    for (String m : methods){
+      try {
+        Method[] mm = target.getClass().getMethods();
+        for (Method cand : mm){
+          if (cand.getName().equals(m) && cand.getParameterCount()==1){
+            Class<?> pt = cand.getParameterTypes()[0];
+            Object coerced = coerce(value, pt);
+            if (coerced!=null || !pt.isPrimitive()){
+              cand.invoke(target, coerced);
+              return;
+            }
+          }
+        }
+      } catch(Exception ignore){}
+    }
+  }
+
+  private static void setStatusIfPresent(Object target, Object value){
+    if (value==null) return;
+    setIfPresent(target, "setStatus", value);
+  }
+
+  private static String readString(Object o, String... getters){
+    for (String g : getters){
+      try {
+        Method m = o.getClass().getMethod(g);
+        Object v = m.invoke(o);
+        if (v!=null) return v.toString();
+      } catch(Exception ignore){}
+    }
+    return null;
+  }
+
+  private static Number readNumber(Object o, String... getters){
+    for (String g : getters){
+      try {
+        Method m = o.getClass().getMethod(g);
+        Object v = m.invoke(o);
+        if (v instanceof Number n) return n;
+        if (v!=null) return Double.parseDouble(v.toString());
+      } catch(Exception ignore){}
+    }
+    return null;
+  }
+
+  private static Object coerce(Object v, Class<?> pt){
+    if (v==null) return null;
+    if (pt.isAssignableFrom(v.getClass())) return v;
+    try {
+      if (pt==String.class) return v.toString();
+      if (pt==int.class || pt==Integer.class) return (v instanceof Number n)? n.intValue() : Integer.parseInt(v.toString());
+      if (pt==long.class || pt==Long.class) return (v instanceof Number n)? n.longValue() : Long.parseLong(v.toString());
+      if (pt==double.class || pt==Double.class) return (v instanceof Number n)? n.doubleValue() : Double.parseDouble(v.toString());
+      if (pt==java.util.UUID.class) return UUID.fromString(v.toString());
+      if (pt==java.util.Date.class) return parseInstant(v);
+      if (pt.isEnum()) return Enum.valueOf((Class<Enum>)pt.asSubclass(Enum.class), v.toString());
+    } catch(Exception ignore){}
+    return null;
+  }
+}
+


### PR DESCRIPTION
## Summary
- generalize RestClient to support headers and shared request logic
- add ApiSupport for JSON <-> model mapping and extend API services to call backend
- introduce SyncService for incremental change feed

## Testing
- `mvn -pl client test` *(fails: Non-resolvable import POM: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f6338cac83309c023e039d61deef