### PR TITLE
feat: expose planning UI density selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Monorepo Maven (Java 17) avec deux modules :
 - **backend/** : **API Spring Boot exécutable** (Ressources, Interventions, Conflits planning, seed mémoire + CORS)
 - **client/** : application Swing (Mode Mock par défaut), fenêtre de choix Mock/API, UI ERP + **Planning DnD**
 
+## Sprint C — UX Planning
+- **Tuiles adaptatives** (rendu responsive selon largeur/hauteur), **menu contextuel** (ouvrir/dupliquer/verrouiller placeholder).
+- **Sélecteur de densité** (Compact / Normal / Spacieux), DnD plus stable (seuil, curseurs), entête de ligne **synchronisée** avec la grille.
+
 ### ❗️Dépendance `com.materiel:gestion-materiel:1.0.0-SNAPSHOT` introuvable
 Si vous voyez :
 ```

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionTileRenderer.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionTileRenderer.java
@@ -12,7 +12,7 @@ final class InterventionTileRenderer {
   private static final int CHIP_H = 24;
   private static final int CHIP_GAP = 8;
   private boolean compact = false;
-  private PlanningBoard.Density density = PlanningBoard.Density.NORMAL;
+  private UiDensity density = UiDensity.NORMAL;
   private double scaleY = 1.0;
 
   // States
@@ -32,11 +32,11 @@ final class InterventionTileRenderer {
 
   int heightBase(){ return (int)Math.round(PlanningUx.TILE_CARD_H * scaleY); }
   void setCompact(boolean c){ compact = c; }
-  void setDensity(PlanningBoard.Density d){
+  void setDensity(UiDensity d){
     density = d;
     scaleY = switch(d){
       case COMPACT -> 0.88;
-      case ROOMY -> 1.15;
+      case SPACIOUS -> 1.15;
       default -> 1.0;
     };
   }

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningBoard.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningBoard.java
@@ -44,8 +44,7 @@ public class PlanningBoard extends JComponent {
   private int rowGap = PlanningUx.ROW_GAP;
   private boolean compact = false; // compat
 
-  public enum Density { COMPACT, NORMAL, ROOMY }
-  private Density density = Density.NORMAL;
+  private UiDensity density = UiDensity.NORMAL;
 
   // DnD state
   private Intervention dragItem;
@@ -112,10 +111,10 @@ public class PlanningBoard extends JComponent {
   public int getSlotMinutes(){ return slotMinutes; }
   public boolean isCompact(){ return compact; }
   public void setCompact(boolean c){ this.compact = c; this.tile.setCompact(c); reload(); }
-  public Density getDensity(){ return density; }
-  public void setDensity(Density d){
+  public UiDensity getDensity(){ return density; }
+  public void setDensity(UiDensity d){
     this.density = d;
-    this.compact = (d == Density.COMPACT);
+    this.compact = (d == UiDensity.COMPACT);
     this.tile.setCompact(this.compact);
     this.tile.setDensity(d);
     reload();

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
@@ -115,21 +115,16 @@ public class PlanningPanel extends JPanel {
     JComboBox<String> gran = new JComboBox<>(new String[]{"5 min","10 min","15 min","30 min","60 min"});
     gran.setSelectedItem(board.getSlotMinutes()+" min");
     JLabel densL = new JLabel("Densité:");
-    JComboBox<String> density = new JComboBox<>(new String[]{"Compact","Normal","Spacieux"});
+    JComboBox<String> density = new JComboBox<>(new String[]{"COMPACT","NORMAL","SPACIOUS"});
     JToggleButton mode = new JToggleButton("Agenda");
     conflictsBtn = new JButton("Conflits (0)");
     JButton addI = new JButton("+ Intervention");
 
     mode.addActionListener(e -> switchMode(mode.isSelected()));
     conflictsBtn.addActionListener(e -> openConflictsDialog());
-    density.setSelectedIndex(1);
+    density.setSelectedItem(board.getDensity().name());
     density.addActionListener(e -> {
-      String sel = String.valueOf(density.getSelectedItem());
-      switch (sel){
-        case "Compact" -> board.setDensity(PlanningBoard.Density.COMPACT);
-        case "Spacieux" -> board.setDensity(PlanningBoard.Density.ROOMY);
-        default -> board.setDensity(PlanningBoard.Density.NORMAL);
-      }
+      board.setDensity(UiDensity.fromString(String.valueOf(density.getSelectedItem())));
       revalidate(); repaint();
     });
 

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/UiDensity.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/UiDensity.java
@@ -1,0 +1,20 @@
+package com.materiel.suite.client.ui.planning;
+
+/** Simple UI density helper for planning views. */
+public enum UiDensity {
+  COMPACT(18), NORMAL(26), SPACIOUS(34);
+
+  /** Base tile height in pixels for this density. */
+  public final int baseTileHeight;
+
+  UiDensity(int h){ this.baseTileHeight = h; }
+
+  /** Parse from name, defaulting to NORMAL when unknown. */
+  public static UiDensity fromString(String s){
+    try {
+      return UiDensity.valueOf(String.valueOf(s).toUpperCase());
+    } catch(Exception e){
+      return NORMAL;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add standalone `UiDensity` enum with base tile heights and parsing
- update planning board, tile renderer and toolbar to use `UiDensity`
- document new planning UX in README

## Testing
- `mvn -q -DskipTests compile` *(fails: Non-resolvable import POM: spring-boot-dependencies 3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68c80576b2208330beaabb35990fef67