### PR TITLE
feat: add agenda navigation between planning and agenda views

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/ui/MainFrame.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/MainFrame.java
@@ -8,6 +8,7 @@ import com.materiel.suite.client.ui.invoices.InvoicesPanel;
 import com.materiel.suite.client.ui.orders.OrdersPanel;
 import com.materiel.suite.client.ui.quotes.QuotesPanel;
 import com.materiel.suite.client.ui.planning.PlanningPanel;
+import com.materiel.suite.client.ui.planning.agenda.AgendaPanel;
 import com.materiel.suite.client.ui.theme.ThemeManager;
 import com.materiel.suite.client.ui.commands.CommandBus;
 
@@ -35,6 +36,7 @@ public class MainFrame extends JFrame {
     setJMenuBar(buildMenuBar());
 
     center.add(new PlanningPanel(), "planning");
+    center.add(new AgendaPanel(), "agenda");
     center.add(new QuotesPanel(), "quotes");
     center.add(new OrdersPanel(), "orders");
     center.add(new DeliveryNotesPanel(), "delivery");
@@ -90,6 +92,8 @@ public class MainFrame extends JFrame {
     side.setBorder(new EmptyBorder(8,8,8,8));
     side.setPreferredSize(new Dimension(220, 0));
     side.add(navButton("Planning", "planning"));
+    side.add(Box.createVerticalStrut(6));
+    side.add(navButton("Agenda", "agenda"));
     side.add(Box.createVerticalStrut(6));
     side.add(navButton("Devis", "quotes"));
     side.add(Box.createVerticalStrut(6));

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
@@ -41,6 +41,7 @@ import com.materiel.suite.client.model.Resource;
 import com.materiel.suite.client.net.ServiceFactory;
 import com.materiel.suite.client.service.PlanningService;
 import com.materiel.suite.client.ui.commands.CommandBus;
+import com.materiel.suite.client.ui.MainFrame;
 
 public class PlanningPanel extends JPanel {
   private final PlanningBoard board = new PlanningBoard();
@@ -118,6 +119,7 @@ public class PlanningPanel extends JPanel {
     JComboBox<String> density = new JComboBox<>(new String[]{"COMPACT","NORMAL","SPACIOUS"});
     JToggleButton mode = new JToggleButton("Agenda");
     conflictsBtn = new JButton("Conflits (0)");
+    JButton toAgenda = new JButton("↔ Agenda");
     JButton addI = new JButton("+ Intervention");
 
     mode.addActionListener(e -> switchMode(mode.isSelected()));
@@ -145,14 +147,21 @@ public class PlanningPanel extends JPanel {
       revalidate(); repaint();
     });
     addI.addActionListener(e -> addInterventionDialog());
+    toAgenda.addActionListener(e -> navigate("agenda"));
 
     bar.add(prev); bar.add(next); bar.add(today); bar.add(mode);
     bar.add(Box.createHorizontalStrut(16)); bar.add(zoomL); bar.add(zoom);
     bar.add(Box.createHorizontalStrut(12)); bar.add(granL); bar.add(gran);
     bar.add(Box.createHorizontalStrut(12)); bar.add(densL); bar.add(density);
     bar.add(Box.createHorizontalStrut(8)); bar.add(conflictsBtn);
+    bar.add(Box.createHorizontalStrut(12)); bar.add(toAgenda);
     bar.add(Box.createHorizontalStrut(16)); bar.add(addI);
     return bar;
+  }
+
+  private void navigate(String key){
+    var w = SwingUtilities.getWindowAncestor(this);
+    if (w instanceof MainFrame mf) mf.openCard(key);
   }
 
   private void switchMode(boolean agendaMode){

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/agenda/AgendaPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/agenda/AgendaPanel.java
@@ -1,0 +1,62 @@
+package com.materiel.suite.client.ui.planning.agenda;
+
+import com.materiel.suite.client.ui.MainFrame;
+
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import java.awt.*;
+import java.time.LocalDate;
+
+/**
+ * Standalone agenda panel showing a single day.
+ * Provides navigation back to the planning view.
+ */
+public class AgendaPanel extends JPanel {
+  private final AgendaView view = new AgendaView();
+
+  public AgendaPanel(){
+    super(new BorderLayout());
+    add(buildToolbar(), BorderLayout.NORTH);
+    add(view, BorderLayout.CENTER);
+    view.setDay(LocalDate.now());
+  }
+
+  private JComponent buildToolbar(){
+    JPanel bar = new JPanel(new FlowLayout(FlowLayout.LEFT));
+    bar.setBorder(new EmptyBorder(6,6,6,6));
+    JButton prev = new JButton("◀ Jour");
+    JButton next = new JButton("Jour ▶");
+    JButton today = new JButton("Aujourd'hui");
+    JButton toPlanning = new JButton("↔ Planning");
+    JLabel l = new JLabel("Début:");
+    JComboBox<String> start = new JComboBox<>(new String[]{"06:00", "07:00", "08:00"});
+    start.setSelectedItem("07:00");
+    JLabel l2 = new JLabel("Fin:");
+    JComboBox<String> end = new JComboBox<>(new String[]{"17:00", "18:00", "19:00"});
+    end.setSelectedItem("18:00");
+
+    next.addActionListener(e -> view.setDay(view.getDay().plusDays(1)));
+    prev.addActionListener(e -> view.setDay(view.getDay().minusDays(1)));
+    today.addActionListener(e -> view.setDay(LocalDate.now()));
+    start.addActionListener(e -> view.setDayStart(parse((String)start.getSelectedItem())));
+    end.addActionListener(e -> view.setDayEnd(parse((String)end.getSelectedItem())));
+    toPlanning.addActionListener(e -> navigate("planning"));
+
+    bar.add(prev); bar.add(next); bar.add(today);
+    bar.add(Box.createHorizontalStrut(16)); bar.add(toPlanning);
+    bar.add(Box.createHorizontalStrut(16)); bar.add(l); bar.add(start);
+    bar.add(Box.createHorizontalStrut(8)); bar.add(l2); bar.add(end);
+    return bar;
+  }
+
+  private int parse(String hhmm){
+    String[] p = hhmm.split(":" );
+    return Integer.parseInt(p[0])*60 + Integer.parseInt(p[1]);
+  }
+
+  private void navigate(String key){
+    var w = SwingUtilities.getWindowAncestor(this);
+    if (w instanceof MainFrame mf) mf.openCard(key);
+  }
+}
+

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/agenda/AgendaView.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/agenda/AgendaView.java
@@ -1,0 +1,44 @@
+package com.materiel.suite.client.ui.planning.agenda;
+
+import javax.swing.*;
+import java.awt.*;
+import java.time.LocalDate;
+
+/**
+ * Simple day agenda view placeholder used for navigation tests.
+ * It currently renders an empty component but exposes basic
+ * setters to control the displayed day and hours range.
+ */
+public class AgendaView extends JComponent {
+  private LocalDate day = LocalDate.now();
+  private int dayStart = 7 * 60;  // minutes
+  private int dayEnd = 18 * 60;   // minutes
+
+  public AgendaView(){
+    setPreferredSize(new Dimension(800, 600));
+  }
+
+  public void setDay(LocalDate d){
+    day = d;
+    repaint();
+  }
+  public LocalDate getDay(){
+    return day;
+  }
+  public void setDayStart(int m){
+    dayStart = m;
+    repaint();
+  }
+  public void setDayEnd(int m){
+    dayEnd = m;
+    repaint();
+  }
+
+  @Override protected void paintComponent(Graphics g){
+    super.paintComponent(g);
+    // simple background placeholder
+    g.setColor(new Color(0xF4F4F4));
+    g.fillRect(0,0,getWidth(),getHeight());
+  }
+}
+


### PR DESCRIPTION
## Summary
- add dedicated Agenda panel and lightweight view
- add Agenda entry in sidebar and card switching
- enable cross-navigation between Planning and Agenda panels

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c80a4628b8833093eb767eea8f892a