### PR TITLE
feat: add headers and conflict highlight

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/net/RestClient.java
+++ b/client/src/main/java/com/materiel/suite/client/net/RestClient.java
@@ -6,9 +6,9 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Objects;
 
 public class RestClient {
   private final String baseUrl;
@@ -70,10 +70,10 @@ public class RestClient {
     else if ("DELETE".equals(method)) b = b.DELETE();
     bearer.ifPresent(t -> b.header("Authorization","Bearer "+t));
     b.header("Accept","application/json");
-    if (headers!=null){
-      for (var e : headers.entrySet()){
-        if (e.getKey()!=null && e.getValue()!=null) b.header(e.getKey(), e.getValue());
-      }
+    if (headers != null) {
+      headers.forEach((k, v) -> {
+        if (Objects.nonNull(v)) b.header(k, v);
+      });
     }
     var res = http.send(b.build(), HttpResponse.BodyHandlers.ofString());
     return ensure200(res);

--- a/client/src/main/java/com/materiel/suite/client/service/api/ApiPlanningService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/api/ApiPlanningService.java
@@ -1,52 +1,98 @@
 package com.materiel.suite.client.service.api;
 
+import com.materiel.suite.client.model.Conflict;
 import com.materiel.suite.client.model.Intervention;
 import com.materiel.suite.client.model.Resource;
-import com.materiel.suite.client.model.Conflict;
 import com.materiel.suite.client.net.RestClient;
 import com.materiel.suite.client.net.SimpleJson;
 import com.materiel.suite.client.service.PlanningService;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.*;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
+/**
+ * Implementation of {@link PlanningService} backed by the REST API.
+ * In case of any network or parsing error, operations transparently
+ * fall back to the provided fallback service.
+ */
 public class ApiPlanningService implements PlanningService {
   private final RestClient rc; private final PlanningService fb;
   public ApiPlanningService(RestClient rc, PlanningService fallback){ this.rc=rc; this.fb=fallback; }
-  @Override public List<Resource> listResources(){ try { return fb.listResources(); } catch(Exception e){ return fb.listResources(); } }
-  @Override public Resource saveResource(Resource r){ try { return fb.saveResource(r); } catch(Exception e){ return fb.saveResource(r); } }
-  @Override public void deleteResource(UUID id){ try { rc.delete("/api/resources/"+id); } catch(Exception ignore){} fb.deleteResource(id); }
+
+  private static final DateTimeFormatter DF = DateTimeFormatter.ISO_LOCAL_DATE;
+  private static final DateTimeFormatter DTF = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+  @Override public List<Resource> listResources(){
+    try {
+      String body = rc.get("/api/v1/resources");
+      var arr = SimpleJson.asArr(SimpleJson.parse(body));
+      List<Resource> out = new ArrayList<>();
+      for (Object o : arr){
+        var m = SimpleJson.asObj(o);
+        Resource r = new Resource();
+        r.setId(UUID.fromString(SimpleJson.str(m.get("id"))));
+        r.setName(SimpleJson.str(m.getOrDefault("name","")));
+        out.add(r);
+      }
+      return out;
+    } catch(Exception e){ return fb.listResources(); }
+  }
+
+  @Override public Resource saveResource(Resource r){
+    try {
+      Map<String,Object> m = new LinkedHashMap<>();
+      if (r.getId()!=null) m.put("id", r.getId().toString());
+      m.put("name", r.getName());
+      String json = toJson(m);
+      String body = (r.getId()==null? rc.post("/api/v1/resources", json) : rc.put("/api/v1/resources/"+r.getId(), json));
+      var map = SimpleJson.asObj(SimpleJson.parse(body));
+      r.setId(UUID.fromString(SimpleJson.str(map.get("id"))));
+      r.setName(SimpleJson.str(map.getOrDefault("name","")));
+      return r;
+    } catch(Exception e){ return fb.saveResource(r); }
+  }
+
+  @Override public void deleteResource(UUID id){
+    try { rc.delete("/api/v1/resources/"+id); } catch(Exception ignore){}
+    fb.deleteResource(id);
+  }
+
   @Override public List<Intervention> listInterventions(LocalDate from, LocalDate to){
     try {
-      String body = rc.get("/api/interventions?from="+from+"&to="+to);
+      String body = rc.get("/api/v1/interventions?from="+DF.format(from)+"&to="+DF.format(to));
       var arr = SimpleJson.asArr(SimpleJson.parse(body));
-      List<Intervention> list = new ArrayList<>();
+      List<Intervention> out = new ArrayList<>();
       for (Object o : arr){
-        Map<String,Object> m = SimpleJson.asObj(o);
-        Intervention it = new Intervention();
-        it.setId(UUID.fromString(SimpleJson.str(m.get("id"))));
-        it.setResourceId(UUID.fromString(SimpleJson.str(m.get("resourceId"))));
-        it.setLabel(SimpleJson.str(m.get("label")));
-        it.setDateHeureDebut(LocalDateTime.parse(SimpleJson.str(m.get("dateHeureDebut"))));
-        it.setDateHeureFin(LocalDateTime.parse(SimpleJson.str(m.get("dateHeureFin"))));
-        it.setColor(SimpleJson.str(m.get("color")));
-        list.add(it);
+        var m = SimpleJson.asObj(o);
+        out.add(fromMap(m));
       }
-      return list;
+      return out;
     } catch(Exception e){ return fb.listInterventions(from,to); }
   }
+
   @Override public Intervention saveIntervention(Intervention i){
     try {
-      String json = "{\"id\":\""+(i.getId()==null?"":i.getId())+"\",\"resourceId\":\""+i.getResourceId()+"\",\"label\":\""+i.getLabel().replace("\"","\\\"")+"\",\"dateHeureDebut\":\""+i.getDateHeureDebut()+"\",\"dateHeureFin\":\""+i.getDateHeureFin()+"\",\"color\":\""+(i.getColor()==null?"":i.getColor())+"\"}";
-      if (i.getId()==null){ rc.post("/api/interventions", json); } else { rc.put("/api/interventions/"+i.getId(), json); }
-      return i;
+      String json = toJson(toMap(i));
+      String body = (i.getId()==null? rc.post("/api/v1/interventions", json) : rc.put("/api/v1/interventions/"+i.getId(), json));
+      var map = SimpleJson.asObj(SimpleJson.parse(body));
+      return fromMap(map);
     } catch(Exception e){ return fb.saveIntervention(i); }
   }
-  @Override public void deleteIntervention(UUID id){ try { rc.delete("/api/interventions/"+id);} catch(Exception ignore){} fb.deleteIntervention(id); }
+
+  @Override public void deleteIntervention(UUID id){
+    try { rc.delete("/api/v1/interventions/"+id);} catch(Exception ignore){}
+    fb.deleteIntervention(id);
+  }
+
   @Override public List<Conflict> listConflicts(LocalDate from, LocalDate to){
     try {
-      String body = rc.get("/api/planning/conflicts?from="+from+"&to="+to);
+      String body = rc.get("/api/v1/planning/conflicts?from="+DF.format(from)+"&to="+DF.format(to));
       var arr = SimpleJson.asArr(SimpleJson.parse(body));
       List<Conflict> list = new ArrayList<>();
       for (Object o : arr){
@@ -63,23 +109,92 @@ public class ApiPlanningService implements PlanningService {
 
   @Override public boolean resolveShift(UUID id, int minutes){
     try {
-      String body = "{\"action\":\"shift\",\"id\":\""+id+"\",\"minutes\":"+minutes+"}";
-      rc.post("/api/planning/resolve", body);
+      Map<String,Object> m = new LinkedHashMap<>();
+      m.put("action","shift");
+      m.put("id", id.toString());
+      m.put("minutes", minutes);
+      rc.post("/api/v1/planning/resolve", toJson(m));
       return true;
     } catch(Exception e){ return fb.resolveShift(id, minutes); }
   }
+
   @Override public boolean resolveReassign(UUID id, UUID resourceId){
     try {
-      String body = "{\"action\":\"reassign\",\"id\":\""+id+"\",\"resourceId\":\""+resourceId+"\"}";
-      rc.post("/api/planning/resolve", body);
+      Map<String,Object> m = new LinkedHashMap<>();
+      m.put("action","reassign");
+      m.put("id", id.toString());
+      m.put("resourceId", resourceId.toString());
+      rc.post("/api/v1/planning/resolve", toJson(m));
       return true;
     } catch(Exception e){ return fb.resolveReassign(id, resourceId); }
   }
+
   @Override public boolean resolveSplit(UUID id, LocalDateTime splitAt){
     try {
-      String body = "{\"action\":\"split\",\"id\":\""+id+"\",\"splitAt\":\""+splitAt+"\"}";
-      rc.post("/api/planning/resolve", body);
+      Map<String,Object> m = new LinkedHashMap<>();
+      m.put("action","split");
+      m.put("id", id.toString());
+      m.put("splitAt", splitAt.format(DTF));
+      rc.post("/api/v1/planning/resolve", toJson(m));
       return true;
     } catch(Exception e){ return fb.resolveSplit(id, splitAt); }
   }
+
+  /* ===== Mapping helpers ===== */
+  private Map<String,Object> toMap(Intervention it){
+    Map<String,Object> m = new LinkedHashMap<>();
+    if (it.getId()!=null) m.put("id", it.getId().toString());
+    m.put("resourceId", it.getResourceId()!=null? it.getResourceId().toString() : null);
+    m.put("label", it.getLabel());
+    m.put("color", it.getColor());
+    if (it.getDateDebut()!=null) m.put("dateDebut", it.getDateDebut().toString());
+    if (it.getDateFin()!=null) m.put("dateFin", it.getDateFin().toString());
+    if (it.getStartDateTime()!=null) m.put("startDateTime", it.getStartDateTime().format(DTF));
+    if (it.getEndDateTime()!=null) m.put("endDateTime", it.getEndDateTime().format(DTF));
+    return m;
+  }
+
+  private Intervention fromMap(Map<String,Object> m){
+    Intervention it = new Intervention();
+    String id = SimpleJson.str(m.get("id"));
+    if (id!=null && !id.isBlank()) it.setId(UUID.fromString(id));
+    String rid = SimpleJson.str(m.get("resourceId"));
+    if (rid==null && m.get("resource")!=null){
+      Map<String,Object> res = SimpleJson.asObj(m.get("resource"));
+      rid = SimpleJson.str(res.get("id"));
+    }
+    if (rid!=null && !rid.isBlank()) it.setResourceId(UUID.fromString(rid));
+    it.setLabel(SimpleJson.str(m.get("label")));
+    it.setColor(SimpleJson.str(m.get("color")));
+    String d1 = SimpleJson.str(m.get("dateDebut"));
+    String d2 = SimpleJson.str(m.get("dateFin"));
+    if (d1!=null && !d1.isBlank()) it.setDateDebut(LocalDate.parse(d1));
+    if (d2!=null && !d2.isBlank()) it.setDateFin(LocalDate.parse(d2));
+    String sdt = SimpleJson.str(m.get("startDateTime"));
+    String edt = SimpleJson.str(m.get("endDateTime"));
+    try {
+      if (sdt!=null && !sdt.isBlank()) it.setDateHeureDebut(LocalDateTime.parse(sdt));
+      if (edt!=null && !edt.isBlank()) it.setDateHeureFin(LocalDateTime.parse(edt));
+    } catch(Exception ignore){}
+    return it;
+  }
+
+  private String toJson(Map<String,Object> m){
+    StringBuilder sb = new StringBuilder("{");
+    boolean first = true;
+    for (var e : m.entrySet()){
+      if (!first) sb.append(',');
+      first = false;
+      sb.append('"').append(e.getKey()).append('"').append(':');
+      Object v = e.getValue();
+      if (v==null){ sb.append("null"); }
+      else if (v instanceof Number || v instanceof Boolean){ sb.append(v.toString()); }
+      else { sb.append('"').append(escape(v.toString())).append('"'); }
+    }
+    sb.append('}');
+    return sb.toString();
+  }
+
+  private String escape(String s){ return s.replace("\\","\\\\").replace("\"","\\\""); }
 }
+

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/AgendaBoard.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/AgendaBoard.java
@@ -150,8 +150,9 @@ public class AgendaBoard extends JComponent {
       int rowH = rowHeights.get(r.getId());
       g2.setColor(PlanningUx.ROW_DIV); // FIX: row divider
       g2.drawLine(0,y+rowH-1,getWidth(),y+rowH-1);
-
-      for (Intervention it : byResource.getOrDefault(r.getId(), List.of())){
+      var list = byResource.getOrDefault(r.getId(), List.of());
+      highlightConflicts(g2, list, y);
+      for (Intervention it : list){
         Rectangle rect = rectOf(it, y);
         paintTile(g2, it, rect);
       }
@@ -184,6 +185,31 @@ public class AgendaBoard extends JComponent {
       int baseline = r.y + Math.min(r.height-6, Math.max(14, g2.getFontMetrics().getAscent()+2));
       g2.drawString(label, r.x+10, baseline);
       g2.setClip(null);
+    }
+  }
+
+  /** Draw dashed red borders around overlapping interventions of a resource row. */
+  private void highlightConflicts(Graphics2D g2, List<Intervention> list, int rowTop){
+    for (int i=0;i<list.size();i++){
+      Intervention a = list.get(i);
+      LocalDateTime as = a.getDateHeureDebut();
+      LocalDateTime ae = a.getDateHeureFin();
+      for (int j=i+1;j<list.size();j++){
+        Intervention b = list.get(j);
+        LocalDateTime bs = b.getDateHeureDebut();
+        LocalDateTime be = b.getDateHeureFin();
+        boolean overlap = !ae.isBefore(bs) && !be.isBefore(as);
+        if (overlap){
+          Rectangle ra = rectOf(a, rowTop);
+          Rectangle rb = rectOf(b, rowTop);
+          Stroke old = g2.getStroke();
+          g2.setStroke(new BasicStroke(2f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 1f, new float[]{4f,4f}, 0f));
+          g2.setColor(new Color(0xCC3333));
+          g2.draw(ra);
+          g2.draw(rb);
+          g2.setStroke(old);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- allow REST calls with optional headers
- update API planning service for v1 endpoints and mapping
- visually mark overlapping interventions in agenda board

## Testing
- `mvn -q -pl client -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c810c61e8083308408d87df9bdd32b