### PR TITLE
feat: add planning resources and interventions

### DIFF
--- a/backend/src/main/java/com/materiel/suite/backend/v1/api/PlanningController.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/api/PlanningController.java
@@ -1,0 +1,109 @@
+package com.materiel.suite.backend.v1.api;
+
+import com.materiel.suite.backend.v1.domain.InterventionEntity;
+import com.materiel.suite.backend.v1.domain.ResourceEntity;
+import com.materiel.suite.backend.v1.repo.InterventionRepository;
+import com.materiel.suite.backend.v1.repo.ResourceRepository;
+import com.materiel.suite.backend.v1.service.ChangeFeedService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/v1")
+public class PlanningController {
+  private final ResourceRepository resources;
+  private final InterventionRepository interventions;
+  private final ChangeFeedService changes;
+  public PlanningController(ResourceRepository r, InterventionRepository i, ChangeFeedService ch){
+    this.resources=r; this.interventions=i; this.changes=ch;
+  }
+
+  /* ===== Resources ===== */
+  @GetMapping("/resources")
+  public List<ResourceEntity> listResources(){ return resources.findAll(); }
+
+  @PostMapping("/resources")
+  public ResourceEntity createResource(@RequestBody ResourceEntity r){
+    if (r.getId()==null) r.setId(UUID.randomUUID());
+    return resources.save(r);
+  }
+  @PutMapping("/resources/{id}")
+  public ResourceEntity updateResource(@PathVariable UUID id, @RequestBody ResourceEntity r){
+    r.setId(id); return resources.save(r);
+  }
+  @DeleteMapping("/resources/{id}")
+  public ResponseEntity<Void> deleteResource(@PathVariable UUID id){
+    resources.deleteById(id); return ResponseEntity.noContent().build();
+  }
+
+  /* ===== Interventions ===== */
+  @GetMapping("/interventions")
+  public List<Map<String,Object>> listInterventions(@RequestParam LocalDate from, @RequestParam LocalDate to){
+    LocalDateTime f = from.atStartOfDay();
+    LocalDateTime t = to.atTime(23,59,59);
+    return interventions.overlap(f,t).stream().map(this::toDto).collect(Collectors.toList());
+  }
+
+  @PostMapping("/interventions")
+  public Map<String,Object> createIntervention(@RequestBody Map<String,Object> body){
+    InterventionEntity i = fromDto(body);
+    if (i.getId()==null) i.setId(UUID.randomUUID());
+    InterventionEntity saved = interventions.save(i);
+    changes.emit("INTERVENTION_CREATED", saved.getId().toString(), Map.of("resourceId", saved.getResource().getId().toString()));
+    return toDto(saved);
+  }
+  @PutMapping("/interventions/{id}")
+  public Map<String,Object> updateIntervention(@PathVariable UUID id, @RequestBody Map<String,Object> body){
+    InterventionEntity i = fromDto(body); i.setId(id);
+    InterventionEntity saved = interventions.save(i);
+    changes.emit("INTERVENTION_UPDATED", saved.getId().toString(), Map.of("resourceId", saved.getResource().getId().toString()));
+    return toDto(saved);
+  }
+  @DeleteMapping("/interventions/{id}")
+  public ResponseEntity<Void> deleteIntervention(@PathVariable UUID id){
+    interventions.deleteById(id);
+    changes.emit("INTERVENTION_DELETED", id.toString(), Map.of());
+    return ResponseEntity.noContent().build();
+  }
+
+  /* ===== Mapping ===== */
+  private Map<String,Object> toDto(InterventionEntity i){
+    Map<String,Object> m = new LinkedHashMap<>();
+    m.put("id", i.getId().toString());
+    m.put("resourceId", i.getResource().getId().toString());
+    m.put("resource", Map.of("id", i.getResource().getId().toString(), "name", i.getResource().getName()));
+    m.put("label", i.getLabel());
+    m.put("color", i.getColor());
+    if (i.getStartDateTime()!=null) m.put("startDateTime", i.getStartDateTime().toString());
+    if (i.getEndDateTime()!=null) m.put("endDateTime", i.getEndDateTime().toString());
+    m.put("dateDebut", i.getDateDebut()!=null? i.getDateDebut().toString() : null);
+    m.put("dateFin", i.getDateFin()!=null? i.getDateFin().toString() : null);
+    return m;
+  }
+  private InterventionEntity fromDto(Map<String,Object> m){
+    InterventionEntity i = new InterventionEntity();
+    Object id = m.get("id");
+    if (id!=null) i.setId(UUID.fromString(String.valueOf(id)));
+    String rid = String.valueOf(m.get("resourceId"));
+    if (!StringUtils.hasText(rid) && m.get("resource") instanceof Map<?,?> rmap){
+      Object rr = ((Map<?,?>) rmap).get("id");
+      if (rr!=null) rid = String.valueOf(rr);
+    }
+    ResourceEntity r = resources.findById(UUID.fromString(rid)).orElseThrow();
+    i.setResource(r);
+    i.setLabel(String.valueOf(m.getOrDefault("label","")));
+    Object color = m.get("color"); if (color!=null) i.setColor(String.valueOf(color));
+    Object sdt = m.get("startDateTime"); if (sdt!=null) i.setStartDateTime(LocalDateTime.parse(String.valueOf(sdt)));
+    Object edt = m.get("endDateTime"); if (edt!=null) i.setEndDateTime(LocalDateTime.parse(String.valueOf(edt)));
+    // Fallback si pas d'heure
+    if (i.getStartDateTime()==null) i.setStartDateTime(LocalDate.now().atTime(8,0));
+    if (i.getEndDateTime()==null) i.setEndDateTime(i.getStartDateTime().plusHours(1));
+    return i;
+  }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/v1/domain/InterventionEntity.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/domain/InterventionEntity.java
@@ -1,0 +1,44 @@
+package com.materiel.suite.backend.v1.domain;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name="intervention")
+public class InterventionEntity {
+  @Id
+  private UUID id;
+  @ManyToOne(optional=false)
+  @JoinColumn(name="resource_id")
+  private ResourceEntity resource;
+  @Column(nullable=false)
+  private String label;
+  private String color;
+  private LocalDateTime startDateTime;
+  private LocalDateTime endDateTime;
+
+  @Transient
+  public LocalDate getDateDebut(){
+    return startDateTime!=null? startDateTime.toLocalDate() : null;
+  }
+  @Transient
+  public LocalDate getDateFin(){
+    return endDateTime!=null? endDateTime.toLocalDate() : getDateDebut();
+  }
+
+  public UUID getId(){ return id; }
+  public void setId(UUID id){ this.id=id; }
+  public ResourceEntity getResource(){ return resource; }
+  public void setResource(ResourceEntity resource){ this.resource=resource; }
+  public String getLabel(){ return label; }
+  public void setLabel(String label){ this.label=label; }
+  public String getColor(){ return color; }
+  public void setColor(String color){ this.color=color; }
+  public LocalDateTime getStartDateTime(){ return startDateTime; }
+  public void setStartDateTime(LocalDateTime s){ this.startDateTime=s; }
+  public LocalDateTime getEndDateTime(){ return endDateTime; }
+  public void setEndDateTime(LocalDateTime e){ this.endDateTime=e; }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/v1/domain/ResourceEntity.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/domain/ResourceEntity.java
@@ -1,0 +1,24 @@
+package com.materiel.suite.backend.v1.domain;
+
+import jakarta.persistence.*;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.util.UUID;
+import java.util.List;
+
+@Entity
+@Table(name="resource")
+public class ResourceEntity {
+  @Id
+  private UUID id;
+  @Column(nullable=false)
+  private String name;
+  @JsonIgnore
+  @OneToMany(mappedBy = "resource", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<InterventionEntity> interventions;
+
+  public UUID getId(){ return id; }
+  public void setId(UUID id){ this.id=id; }
+  public String getName(){ return name; }
+  public void setName(String name){ this.name=name; }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/v1/repo/InterventionRepository.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/repo/InterventionRepository.java
@@ -1,0 +1,18 @@
+package com.materiel.suite.backend.v1.repo;
+
+import com.materiel.suite.backend.v1.domain.InterventionEntity;
+import com.materiel.suite.backend.v1.domain.ResourceEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public interface InterventionRepository extends JpaRepository<InterventionEntity, UUID> {
+  @Query("select i from InterventionEntity i where (i.startDateTime<=:to and i.endDateTime>=:from)")
+  List<InterventionEntity> overlap(@Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
+  @Query("select i from InterventionEntity i where i.resource=:res and (i.startDateTime<=:to and i.endDateTime>=:from)")
+  List<InterventionEntity> overlapByResource(@Param("res") ResourceEntity res, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
+}

--- a/backend/src/main/java/com/materiel/suite/backend/v1/repo/ResourceRepository.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/repo/ResourceRepository.java
@@ -1,0 +1,8 @@
+package com.materiel.suite.backend.v1.repo;
+
+import com.materiel.suite.backend.v1.domain.ResourceEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ResourceRepository extends JpaRepository<ResourceEntity, UUID> { }

--- a/backend/src/main/resources/openapi/openapi-v1.yaml
+++ b/backend/src/main/resources/openapi/openapi-v1.yaml
@@ -5,6 +5,43 @@ info:
 servers:
   - url: /api/v1
 paths:
+  /resources:
+    get: { summary: List resources, responses: { "200": { description: OK, content: { application/json: { schema: { type: array, items: { $ref: "#/components/schemas/Resource" } } } } } } }
+    post:
+      summary: Create resource
+      requestBody: { required: true, content: { application/json: { schema: { $ref: "#/components/schemas/Resource" } } } }
+      responses: { "200": { description: OK, content: { application/json: { schema: { $ref: "#/components/schemas/Resource" } } } } }
+  /resources/{id}:
+    put:
+      summary: Update resource
+      parameters: [ { in: path, name: id, required: true, schema: { type: string, format: uuid } } ]
+      requestBody: { required: true, content: { application/json: { schema: { $ref: "#/components/schemas/Resource" } } } }
+      responses: { "200": { description: OK, content: { application/json: { schema: { $ref: "#/components/schemas/Resource" } } } } }
+    delete:
+      summary: Delete resource
+      parameters: [ { in: path, name: id, required: true, schema: { type: string, format: uuid } } ]
+      responses: { "204": { description: No Content } }
+  /interventions:
+    get:
+      summary: List interventions in range
+      parameters:
+        - { in: query, name: from, required: true, schema: { type: string, format: date } }
+        - { in: query, name: to, required: true, schema: { type: string, format: date } }
+      responses: { "200": { description: OK, content: { application/json: { schema: { type: array, items: { $ref: "#/components/schemas/Intervention" } } } } } }
+    post:
+      summary: Create intervention
+      requestBody: { required: true, content: { application/json: { schema: { $ref: "#/components/schemas/Intervention" } } } }
+      responses: { "200": { description: OK, content: { application/json: { schema: { $ref: "#/components/schemas/Intervention" } } } } }
+  /interventions/{id}:
+    put:
+      summary: Update intervention
+      parameters: [ { in: path, name: id, required: true, schema: { type: string, format: uuid } } ]
+      requestBody: { required: true, content: { application/json: { schema: { $ref: "#/components/schemas/Intervention" } } } }
+      responses: { "200": { description: OK, content: { application/json: { schema: { $ref: "#/components/schemas/Intervention" } } } } }
+    delete:
+      summary: Delete intervention
+      parameters: [ { in: path, name: id, required: true, schema: { type: string, format: uuid } } ]
+      responses: { "204": { description: No Content } }
   /webhooks:
     post:
       summary: Register webhook
@@ -269,6 +306,27 @@ paths:
 
 components:
   schemas:
+    Resource:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        name: { type: string }
+    Intervention:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        resourceId: { type: string, format: uuid }
+        resource:
+          type: object
+          properties:
+            id: { type: string, format: uuid }
+            name: { type: string }
+        label: { type: string }
+        color: { type: string }
+        startDateTime: { type: string, format: date-time }
+        endDateTime: { type: string, format: date-time }
+        dateDebut: { type: string, format: date }
+        dateFin: { type: string, format: date }
     DocumentLine:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- add entities and repositories for resources and interventions
- introduce PlanningController for CRUD and overlap queries
- extend OpenAPI spec with planning endpoints and schemas

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c8132e5e20833099c82ba5df6d7886