### PR TITLE
Add intervention status with validation and duplication endpoints

### DIFF
--- a/backend/src/main/java/com/materiel/suite/backend/v1/domain/InterventionEntity.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/domain/InterventionEntity.java
@@ -19,6 +19,8 @@ public class InterventionEntity {
   private String color;
   private LocalDateTime startDateTime;
   private LocalDateTime endDateTime;
+  @Enumerated(EnumType.STRING)
+  private InterventionStatus status = InterventionStatus.PLANNED;
 
   @Transient
   public LocalDate getDateDebut(){
@@ -41,4 +43,6 @@ public class InterventionEntity {
   public void setStartDateTime(LocalDateTime s){ this.startDateTime=s; }
   public LocalDateTime getEndDateTime(){ return endDateTime; }
   public void setEndDateTime(LocalDateTime e){ this.endDateTime=e; }
+  public InterventionStatus getStatus(){ return status; }
+  public void setStatus(InterventionStatus s){ this.status=s; }
 }

--- a/backend/src/main/java/com/materiel/suite/backend/v1/domain/InterventionStatus.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/domain/InterventionStatus.java
@@ -1,0 +1,5 @@
+package com.materiel.suite.backend.v1.domain;
+
+public enum InterventionStatus {
+  PLANNED, LOCKED, DONE, CANCELED
+}

--- a/backend/src/main/resources/openapi/openapi-v1.yaml
+++ b/backend/src/main/resources/openapi/openapi-v1.yaml
@@ -32,6 +32,32 @@ paths:
       summary: Create intervention
       requestBody: { required: true, content: { application/json: { schema: { $ref: "#/components/schemas/Intervention" } } } }
       responses: { "200": { description: OK, content: { application/json: { schema: { $ref: "#/components/schemas/Intervention" } } } } }
+  /interventions/validate:
+    post:
+      summary: Validate intervention and return suggestions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/Intervention" }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  suggestions:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        resourceId: { type: string, format: uuid }
+                        startDateTime: { type: string, format: date-time }
+                        endDateTime: { type: string, format: date-time }
+                        label: { type: string }
   /interventions/{id}:
     put:
       summary: Update intervention
@@ -42,6 +68,13 @@ paths:
       summary: Delete intervention
       parameters: [ { in: path, name: id, required: true, schema: { type: string, format: uuid } } ]
       responses: { "204": { description: No Content } }
+  /interventions/{id}/duplicate:
+    post:
+      summary: Duplicate intervention by N days
+      parameters:
+        - { in: path, name: id, required: true, schema: { type: string, format: uuid } }
+        - { in: query, name: days, required: false, schema: { type: integer, default: 7 } }
+      responses: { "200": { description: OK, content: { application/json: { schema: { $ref: "#/components/schemas/Intervention" } } } } }
   /webhooks:
     post:
       summary: Register webhook
@@ -327,6 +360,7 @@ components:
         endDateTime: { type: string, format: date-time }
         dateDebut: { type: string, format: date }
         dateFin: { type: string, format: date }
+        status: { type: string, enum: [PLANNED, LOCKED, DONE, CANCELED] }
     DocumentLine:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- track intervention lifecycle with new `InterventionStatus`
- expose validation and duplication endpoints in PlanningController
- document new endpoints and status field in OpenAPI spec

## Testing
- `mvn -q -pl backend test` *(fails: Non-resolvable import POM: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68c81b6aa1788330b42256ef603f6471