### PR TITLE
Add planning validation and drag-drop enhancements

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/service/PlanningService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/PlanningService.java
@@ -3,6 +3,7 @@ package com.materiel.suite.client.service;
 import com.materiel.suite.client.model.Intervention;
 import com.materiel.suite.client.model.Resource;
 import com.materiel.suite.client.model.Conflict;
+import com.materiel.suite.client.service.PlanningValidation;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -24,4 +25,12 @@ public interface PlanningService {
   boolean resolveShift(UUID id, int minutes);
   boolean resolveReassign(UUID id, UUID resourceId);
   boolean resolveSplit(UUID id, LocalDateTime splitAt);
+
+  /**
+   * Optional server-side validation before saving an intervention.
+   * Default implementation always returns {@link PlanningValidation#ok()}.
+   */
+  default PlanningValidation validate(Intervention it){
+    return PlanningValidation.ok();
+  }
 }

--- a/client/src/main/java/com/materiel/suite/client/service/PlanningValidation.java
+++ b/client/src/main/java/com/materiel/suite/client/service/PlanningValidation.java
@@ -1,0 +1,28 @@
+package com.materiel.suite.client.service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Result of a planning validation.
+ * It may contain suggestions in case of conflicts.
+ */
+public class PlanningValidation {
+  public boolean ok;
+  public List<Suggestion> suggestions = new ArrayList<>();
+
+  public static PlanningValidation ok(){
+    PlanningValidation v = new PlanningValidation();
+    v.ok = true;
+    return v;
+  }
+
+  public static class Suggestion {
+    public UUID resourceId;
+    public LocalDateTime startDateTime;
+    public LocalDateTime endDateTime;
+    public String label;
+  }
+}


### PR DESCRIPTION
## Summary
- add PlanningValidation model and validation hook
- implement server validation and status mapping for interventions
- support duplication and locking in planning boards

## Testing
- `mvn -pl client -am test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c81b616be88330bc81cccafd8bdcaa