### PR TITLE
Add client management entities and optional link to interventions

### DIFF
--- a/backend/src/main/java/com/materiel/suite/backend/v1/api/ClientsController.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/api/ClientsController.java
@@ -1,0 +1,55 @@
+package com.materiel.suite.backend.v1.api;
+
+import com.materiel.suite.backend.v1.domain.ClientEntity;
+import com.materiel.suite.backend.v1.domain.ContactEntity;
+import com.materiel.suite.backend.v1.repo.ClientRepository;
+import com.materiel.suite.backend.v1.repo.ContactRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+
+@RestController
+@RequestMapping("/api/v1")
+public class ClientsController {
+  private final ClientRepository clients;
+  private final ContactRepository contacts;
+  public ClientsController(ClientRepository c, ContactRepository ct){ this.clients=c; this.contacts=ct; }
+
+  /* Clients */
+  @GetMapping("/clients")
+  public List<ClientEntity> listClients(){ return clients.findAll(); }
+  @GetMapping("/clients/{id}")
+  public ClientEntity getClient(@PathVariable UUID id){ return clients.findById(id).orElseThrow(); }
+  @PostMapping("/clients")
+  public ClientEntity createClient(@RequestBody ClientEntity c){ if (c.getId()==null) c.setId(UUID.randomUUID()); return clients.save(c); }
+  @PutMapping("/clients/{id}")
+  public ClientEntity updateClient(@PathVariable UUID id, @RequestBody ClientEntity c){ c.setId(id); return clients.save(c); }
+  @DeleteMapping("/clients/{id}")
+  public ResponseEntity<Void> deleteClient(@PathVariable UUID id){ clients.deleteById(id); return ResponseEntity.noContent().build(); }
+
+  /* Contacts (sous-ressource) */
+  @GetMapping("/clients/{id}/contacts")
+  public List<ContactEntity> listContacts(@PathVariable UUID id){
+    ClientEntity c = clients.findById(id).orElseThrow();
+    return contacts.findByClient(c);
+  }
+  @PostMapping("/clients/{id}/contacts")
+  public ContactEntity createContact(@PathVariable UUID id, @RequestBody ContactEntity ct){
+    ClientEntity c = clients.findById(id).orElseThrow();
+    if (ct.getId()==null) ct.setId(UUID.randomUUID());
+    ct.setClient(c);
+    return contacts.save(ct);
+  }
+  @PutMapping("/clients/{id}/contacts/{contactId}")
+  public ContactEntity updateContact(@PathVariable UUID id, @PathVariable UUID contactId, @RequestBody ContactEntity ct){
+    ClientEntity c = clients.findById(id).orElseThrow();
+    ct.setId(contactId); ct.setClient(c);
+    return contacts.save(ct);
+  }
+  @DeleteMapping("/clients/{id}/contacts/{contactId}")
+  public ResponseEntity<Void> deleteContact(@PathVariable UUID id, @PathVariable UUID contactId){
+    contacts.deleteById(contactId); return ResponseEntity.noContent().build();
+  }
+}
+

--- a/backend/src/main/java/com/materiel/suite/backend/v1/api/PlanningController.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/api/PlanningController.java
@@ -1,11 +1,13 @@
 package com.materiel.suite.backend.v1.api;
 
 import com.materiel.suite.backend.v1.domain.InterventionEntity;
+import com.materiel.suite.backend.v1.domain.ClientEntity;
 import com.materiel.suite.backend.v1.domain.ResourceEntity;
 import com.materiel.suite.backend.v1.domain.InterventionStatus;
 import com.materiel.suite.backend.v1.repo.InterventionRepository;
 import com.materiel.suite.backend.v1.repo.ResourceRepository;
 import com.materiel.suite.backend.v1.service.ChangeFeedService;
+import com.materiel.suite.backend.v1.repo.ClientRepository;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
@@ -22,8 +24,9 @@ public class PlanningController {
   private final ResourceRepository resources;
   private final InterventionRepository interventions;
   private final ChangeFeedService changes;
-  public PlanningController(ResourceRepository r, InterventionRepository i, ChangeFeedService ch){
-    this.resources=r; this.interventions=i; this.changes=ch;
+  private final ClientRepository clients;
+  public PlanningController(ResourceRepository r, InterventionRepository i, ChangeFeedService ch, ClientRepository c){
+    this.resources=r; this.interventions=i; this.changes=ch; this.clients=c;
   }
 
   /* ===== Resources ===== */
@@ -130,6 +133,7 @@ public class PlanningController {
     m.put("resource", Map.of("id", i.getResource().getId().toString(), "name", i.getResource().getName()));
     m.put("label", i.getLabel());
     m.put("color", i.getColor());
+    if (i.getClient()!=null) m.put("clientId", i.getClient().getId().toString());
     if (i.getStartDateTime()!=null) m.put("startDateTime", i.getStartDateTime().toString());
     if (i.getEndDateTime()!=null) m.put("endDateTime", i.getEndDateTime().toString());
     m.put("dateDebut", i.getDateDebut()!=null? i.getDateDebut().toString() : null);
@@ -148,6 +152,12 @@ public class PlanningController {
     }
     ResourceEntity r = resources.findById(UUID.fromString(rid)).orElseThrow();
     i.setResource(r);
+    // client optionnel
+    String cid = String.valueOf(m.get("clientId"));
+    if (StringUtils.hasText(cid)){
+      ClientEntity ce = clients.findById(UUID.fromString(cid)).orElse(null);
+      i.setClient(ce);
+    }
     i.setLabel(String.valueOf(m.getOrDefault("label","")));
     Object color = m.get("color"); if (color!=null) i.setColor(String.valueOf(color));
     Object sdt = m.get("startDateTime"); if (sdt!=null) i.setStartDateTime(LocalDateTime.parse(String.valueOf(sdt)));

--- a/backend/src/main/java/com/materiel/suite/backend/v1/domain/ClientEntity.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/domain/ClientEntity.java
@@ -1,0 +1,49 @@
+package com.materiel.suite.backend.v1.domain;
+
+import jakarta.persistence.*;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name="client")
+public class ClientEntity {
+  @Id
+  private UUID id;
+  @Column(nullable=false)
+  private String name;
+  private String code;
+  private String email;
+  private String phone;
+  private String vatNumber;
+  @Column(length=2000)
+  private String billingAddress;
+  @Column(length=2000)
+  private String shippingAddress;
+  @Column(length=4000)
+  private String notes;
+
+  @OneToMany(mappedBy="client", cascade=CascadeType.ALL, orphanRemoval = true)
+  private List<ContactEntity> contacts;
+
+  public UUID getId(){ return id; }
+  public void setId(UUID id){ this.id=id; }
+  public String getName(){ return name; }
+  public void setName(String name){ this.name=name; }
+  public String getCode(){ return code; }
+  public void setCode(String code){ this.code=code; }
+  public String getEmail(){ return email; }
+  public void setEmail(String email){ this.email=email; }
+  public String getPhone(){ return phone; }
+  public void setPhone(String phone){ this.phone=phone; }
+  public String getVatNumber(){ return vatNumber; }
+  public void setVatNumber(String vatNumber){ this.vatNumber=vatNumber; }
+  public String getBillingAddress(){ return billingAddress; }
+  public void setBillingAddress(String a){ this.billingAddress=a; }
+  public String getShippingAddress(){ return shippingAddress; }
+  public void setShippingAddress(String a){ this.shippingAddress=a; }
+  public String getNotes(){ return notes; }
+  public void setNotes(String notes){ this.notes=notes; }
+  public List<ContactEntity> getContacts(){ return contacts; }
+  public void setContacts(List<ContactEntity> contacts){ this.contacts=contacts; }
+}
+

--- a/backend/src/main/java/com/materiel/suite/backend/v1/domain/ContactEntity.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/domain/ContactEntity.java
@@ -1,0 +1,38 @@
+package com.materiel.suite.backend.v1.domain;
+
+import jakarta.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Table(name="contact")
+public class ContactEntity {
+  @Id
+  private UUID id;
+  @ManyToOne(optional=false)
+  @JoinColumn(name="client_id")
+  private ClientEntity client;
+  private String firstName;
+  private String lastName;
+  private String email;
+  private String phone;
+  private String role;
+  private boolean archived;
+
+  public UUID getId(){ return id; }
+  public void setId(UUID id){ this.id=id; }
+  public ClientEntity getClient(){ return client; }
+  public void setClient(ClientEntity c){ this.client=c; }
+  public String getFirstName(){ return firstName; }
+  public void setFirstName(String v){ this.firstName=v; }
+  public String getLastName(){ return lastName; }
+  public void setLastName(String v){ this.lastName=v; }
+  public String getEmail(){ return email; }
+  public void setEmail(String v){ this.email=v; }
+  public String getPhone(){ return phone; }
+  public void setPhone(String v){ this.phone=v; }
+  public String getRole(){ return role; }
+  public void setRole(String v){ this.role=v; }
+  public boolean isArchived(){ return archived; }
+  public void setArchived(boolean b){ this.archived=b; }
+}
+

--- a/backend/src/main/java/com/materiel/suite/backend/v1/domain/InterventionEntity.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/domain/InterventionEntity.java
@@ -14,6 +14,8 @@ public class InterventionEntity {
   @ManyToOne(optional=false)
   @JoinColumn(name="resource_id")
   private ResourceEntity resource;
+  @ManyToOne(optional = true) @JoinColumn(name="client_id")
+  private ClientEntity client;
   @Column(nullable=false)
   private String label;
   private String color;
@@ -35,6 +37,8 @@ public class InterventionEntity {
   public void setId(UUID id){ this.id=id; }
   public ResourceEntity getResource(){ return resource; }
   public void setResource(ResourceEntity resource){ this.resource=resource; }
+  public ClientEntity getClient(){ return client; }
+  public void setClient(ClientEntity c){ this.client=c; }
   public String getLabel(){ return label; }
   public void setLabel(String label){ this.label=label; }
   public String getColor(){ return color; }

--- a/backend/src/main/java/com/materiel/suite/backend/v1/domain/ResourceEntity.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/domain/ResourceEntity.java
@@ -13,6 +13,10 @@ public class ResourceEntity {
   private UUID id;
   @Column(nullable=false)
   private String name;
+  private String type;  // libre : "Grue", "Nacelle", etc.
+  private String color; // hex optionnel
+  @Column(length=2000)
+  private String notes;
   @JsonIgnore
   @OneToMany(mappedBy = "resource", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<InterventionEntity> interventions;
@@ -21,4 +25,10 @@ public class ResourceEntity {
   public void setId(UUID id){ this.id=id; }
   public String getName(){ return name; }
   public void setName(String name){ this.name=name; }
+  public String getType(){ return type; }
+  public void setType(String type){ this.type=type; }
+  public String getColor(){ return color; }
+  public void setColor(String color){ this.color=color; }
+  public String getNotes(){ return notes; }
+  public void setNotes(String notes){ this.notes=notes; }
 }

--- a/backend/src/main/java/com/materiel/suite/backend/v1/repo/ClientRepository.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/repo/ClientRepository.java
@@ -1,0 +1,9 @@
+package com.materiel.suite.backend.v1.repo;
+
+import com.materiel.suite.backend.v1.domain.ClientEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ClientRepository extends JpaRepository<ClientEntity, UUID> { }
+

--- a/backend/src/main/java/com/materiel/suite/backend/v1/repo/ContactRepository.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/repo/ContactRepository.java
@@ -1,0 +1,13 @@
+package com.materiel.suite.backend.v1.repo;
+
+import com.materiel.suite.backend.v1.domain.ContactEntity;
+import com.materiel.suite.backend.v1.domain.ClientEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ContactRepository extends JpaRepository<ContactEntity, UUID> {
+  List<ContactEntity> findByClient(ClientEntity client);
+}
+

--- a/backend/src/main/resources/openapi/openapi-v1.yaml
+++ b/backend/src/main/resources/openapi/openapi-v1.yaml
@@ -5,6 +5,19 @@ info:
 servers:
   - url: /api/v1
 paths:
+  /clients:
+    get: { summary: List clients, responses: { "200": { description: OK, content: { application/json: { schema: { type: array, items: { $ref: "#/components/schemas/Client" } } } } } } }
+    post: { summary: Create client, requestBody: { required: true, content: { application/json: { schema: { $ref: "#/components/schemas/Client" } } } }, responses: { "200": { description: OK, content: { application/json: { schema: { $ref: "#/components/schemas/Client" } } } } } }
+  /clients/{id}:
+    get: { summary: Get client, parameters: [ { in: path, name: id, required: true, schema: { type: string, format: uuid } } ], responses: { "200": { description: OK, content: { application/json: { schema: { $ref: "#/components/schemas/Client" } } } } } }
+    put: { summary: Update client, parameters: [ { in: path, name: id, required: true, schema: { type: string, format: uuid } } ], requestBody: { required: true, content: { application/json: { schema: { $ref: "#/components/schemas/Client" } } } }, responses: { "200": { description: OK, content: { application/json: { schema: { $ref: "#/components/schemas/Client" } } } } } }
+    delete: { summary: Delete client, parameters: [ { in: path, name: id, required: true, schema: { type: string, format: uuid } } ], responses: { "204": { description: No Content } } }
+  /clients/{id}/contacts:
+    get: { summary: List contacts for client, parameters: [ { in: path, name: id, required: true, schema: { type: string, format: uuid } } ], responses: { "200": { description: OK, content: { application/json: { schema: { type: array, items: { $ref: "#/components/schemas/Contact" } } } } } } }
+    post: { summary: Create contact, parameters: [ { in: path, name: id, required: true, schema: { type: string, format: uuid } } ], requestBody: { required: true, content: { application/json: { schema: { $ref: "#/components/schemas/Contact" } } } }, responses: { "200": { description: OK, content: { application/json: { schema: { $ref: "#/components/schemas/Contact" } } } } } }
+  /clients/{id}/contacts/{contactId}:
+    put: { summary: Update contact, parameters: [ { in: path, name: id, required: true, schema: { type: string, format: uuid } }, { in: path, name: contactId, required: true, schema: { type: string, format: uuid } } ], requestBody: { required: true, content: { application/json: { schema: { $ref: "#/components/schemas/Contact" } } } }, responses: { "200": { description: OK, content: { application/json: { schema: { $ref: "#/components/schemas/Contact" } } } } } }
+    delete: { summary: Delete contact, parameters: [ { in: path, name: id, required: true, schema: { type: string, format: uuid } }, { in: path, name: contactId, required: true, schema: { type: string, format: uuid } } ], responses: { "204": { description: No Content } } }
   /resources:
     get: { summary: List resources, responses: { "200": { description: OK, content: { application/json: { schema: { type: array, items: { $ref: "#/components/schemas/Resource" } } } } } } }
     post:
@@ -344,6 +357,32 @@ components:
       properties:
         id: { type: string, format: uuid }
         name: { type: string }
+        type: { type: string }
+        color: { type: string }
+        notes: { type: string }
+    Client:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        name: { type: string }
+        code: { type: string }
+        email: { type: string }
+        phone: { type: string }
+        vatNumber: { type: string }
+        billingAddress: { type: string }
+        shippingAddress: { type: string }
+        notes: { type: string }
+    Contact:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        clientId: { type: string, format: uuid }
+        firstName: { type: string }
+        lastName: { type: string }
+        email: { type: string }
+        phone: { type: string }
+        role: { type: string }
+        archived: { type: boolean }
     Intervention:
       type: object
       properties:
@@ -361,6 +400,7 @@ components:
         dateDebut: { type: string, format: date }
         dateFin: { type: string, format: date }
         status: { type: string, enum: [PLANNED, LOCKED, DONE, CANCELED] }
+        clientId: { type: string, format: uuid }
     DocumentLine:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- extend ResourceEntity with type/color/notes fields
- add Client and Contact entities, repositories, and CRUD endpoints
- link interventions to optional client and document new API in OpenAPI spec

## Testing
- `mvn -q -f backend/pom.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c820f58e9083308091e362245c6fdb