### PR TITLE
feat: extend resource entity

### DIFF
--- a/backend/src/main/java/com/materiel/suite/backend/v1/domain/ResourceEntity.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/domain/ResourceEntity.java
@@ -17,6 +17,11 @@ public class ResourceEntity {
   private String color; // hex optionnel
   @Column(length=2000)
   private String notes;
+  private Integer capacity; // nb unités (1 par défaut)
+  @Column(length=1000)
+  private String tags; // CSV simple "grue, lourde, 80t"
+  @Column(length=4000)
+  private String weeklyUnavailability; // ex: "MON 08:00-12:00; TUE 13:00-17:00"
   @JsonIgnore
   @OneToMany(mappedBy = "resource", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<InterventionEntity> interventions;
@@ -31,4 +36,10 @@ public class ResourceEntity {
   public void setColor(String color){ this.color=color; }
   public String getNotes(){ return notes; }
   public void setNotes(String notes){ this.notes=notes; }
+  public Integer getCapacity(){ return capacity; }
+  public void setCapacity(Integer c){ this.capacity=c; }
+  public String getTags(){ return tags; }
+  public void setTags(String t){ this.tags=t; }
+  public String getWeeklyUnavailability(){ return weeklyUnavailability; }
+  public void setWeeklyUnavailability(String w){ this.weeklyUnavailability=w; }
 }

--- a/backend/src/main/resources/openapi/openapi-v1.yaml
+++ b/backend/src/main/resources/openapi/openapi-v1.yaml
@@ -360,6 +360,9 @@ components:
         type: { type: string }
         color: { type: string }
         notes: { type: string }
+        capacity: { type: integer, minimum: 1 }
+        tags: { type: string, description: "Liste CSV simple" }
+        weeklyUnavailability: { type: string, description: "Ex: MON 08:00-12:00; TUE 13:00-17:00" }
     Client:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- add capacity, tags, and weekly unavailability fields to ResourceEntity
- document new resource fields in OpenAPI spec

## Testing
- `mvn -q -pl backend test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c827c77b388330b27722c34f582b3a