### PR TITLE
feat: add client selector to interventions

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/model/Intervention.java
+++ b/client/src/main/java/com/materiel/suite/client/model/Intervention.java
@@ -8,6 +8,9 @@ import java.util.UUID;
 public class Intervention {
   private UUID id;
   private UUID resourceId;
+  // === CRM-INJECT BEGIN: intervention-client-id-field ===
+  private UUID clientId;
+  // === CRM-INJECT END ===
   private String label;
   private LocalDateTime dateHeureDebut;
   private LocalDateTime dateHeureFin;
@@ -40,6 +43,10 @@ public class Intervention {
   public void setId(UUID id){ this.id = id; }
   public UUID getResourceId(){ return resourceId; }
   public void setResourceId(UUID resourceId){ this.resourceId = resourceId; }
+  // === CRM-INJECT BEGIN: intervention-client-id-accessors ===
+  public UUID getClientId(){ return clientId; }
+  public void setClientId(UUID clientId){ this.clientId = clientId; }
+  // === CRM-INJECT END ===
   public String getLabel(){ return label; }
   public void setLabel(String label){ this.label = label; }
 

--- a/client/src/main/java/com/materiel/suite/client/service/api/ApiPlanningService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/api/ApiPlanningService.java
@@ -180,6 +180,9 @@ public class ApiPlanningService implements PlanningService {
     Map<String,Object> m = new LinkedHashMap<>();
     if (it.getId()!=null) m.put("id", it.getId().toString());
     m.put("resourceId", it.getResourceId()!=null? it.getResourceId().toString() : null);
+    // === CRM-INJECT BEGIN: planning-api-client-id ===
+    m.put("clientId", it.getClientId()!=null? it.getClientId().toString() : null);
+    // === CRM-INJECT END ===
     m.put("label", it.getLabel());
     m.put("color", it.getColor());
     if (it.getDateDebut()!=null) m.put("dateDebut", it.getDateDebut().toString());
@@ -200,6 +203,12 @@ public class ApiPlanningService implements PlanningService {
       rid = SimpleJson.str(res.get("id"));
     }
     if (rid!=null && !rid.isBlank()) it.setResourceId(UUID.fromString(rid));
+    // === CRM-INJECT BEGIN: planning-api-client-mapping ===
+    String cid = SimpleJson.str(m.get("clientId"));
+    if (cid!=null && !cid.isBlank()) it.setClientId(UUID.fromString(cid));
+    String cname = SimpleJson.str(m.get("clientName"));
+    if (cname!=null) it.setClientName(cname);
+    // === CRM-INJECT END ===
     it.setLabel(SimpleJson.str(m.get("label")));
     it.setColor(SimpleJson.str(m.get("color")));
     String d1 = SimpleJson.str(m.get("dateDebut"));


### PR DESCRIPTION
## Summary
- add clientId support to interventions and REST mapping
- expose client selection when creating or editing interventions in planning view
- mirror client selector and display improvements in agenda view, including duplication support

## Testing
- mvn -pl client compile *(fails: cannot reach Maven Central in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68c9116b18288330833d98a5ea99a8db