### PR TITLE
feat: interventions client selector & resource enhancements

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/model/Intervention.java
+++ b/client/src/main/java/com/materiel/suite/client/model/Intervention.java
@@ -8,6 +8,9 @@ import java.util.UUID;
 public class Intervention {
   private UUID id;
   private UUID resourceId;
+  // === CRM-INJECT BEGIN: intervention-client-id-field ===
+  private UUID clientId;
+  // === CRM-INJECT END ===
   private String label;
   private LocalDateTime dateHeureDebut;
   private LocalDateTime dateHeureFin;
@@ -40,6 +43,10 @@ public class Intervention {
   public void setId(UUID id){ this.id = id; }
   public UUID getResourceId(){ return resourceId; }
   public void setResourceId(UUID resourceId){ this.resourceId = resourceId; }
+  // === CRM-INJECT BEGIN: intervention-client-id-accessors ===
+  public UUID getClientId(){ return clientId; }
+  public void setClientId(UUID clientId){ this.clientId = clientId; }
+  // === CRM-INJECT END ===
   public String getLabel(){ return label; }
   public void setLabel(String label){ this.label = label; }
 

--- a/client/src/main/java/com/materiel/suite/client/model/Resource.java
+++ b/client/src/main/java/com/materiel/suite/client/model/Resource.java
@@ -8,6 +8,11 @@ public class Resource {
   private String type;
   private String color;
   private String notes;
+  // === CRM-INJECT BEGIN: resource-advanced-fields ===
+  private Integer capacity = 1;
+  private String tags;
+  private String weeklyUnavailability;
+  // === CRM-INJECT END ===
   
   public Resource(){}
   public Resource(UUID id, String name){ this.id=id; this.name=name; }
@@ -21,5 +26,13 @@ public class Resource {
   public void setColor(String color){ this.color=color; }
   public String getNotes(){ return notes; }
   public void setNotes(String notes){ this.notes=notes; }
+  // === CRM-INJECT BEGIN: resource-advanced-accessors ===
+  public Integer getCapacity(){ return capacity; }
+  public void setCapacity(Integer capacity){ this.capacity = (capacity==null || capacity<1)? 1 : capacity; }
+  public String getTags(){ return tags; }
+  public void setTags(String tags){ this.tags=tags; }
+  public String getWeeklyUnavailability(){ return weeklyUnavailability; }
+  public void setWeeklyUnavailability(String weeklyUnavailability){ this.weeklyUnavailability=weeklyUnavailability; }
+  // === CRM-INJECT END ===
   @Override public String toString(){ return name; }
 }

--- a/client/src/main/java/com/materiel/suite/client/service/api/ApiPlanningService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/api/ApiPlanningService.java
@@ -42,6 +42,20 @@ public class ApiPlanningService implements PlanningService {
         r.setType(SimpleJson.str(m.get("type")));
         r.setColor(SimpleJson.str(m.get("color")));
         r.setNotes(SimpleJson.str(m.get("notes")));
+        // === CRM-INJECT BEGIN: resource-api-read ===
+        Object cap = m.get("capacity");
+        if (cap instanceof Number n) r.setCapacity((int) Math.max(1, n.intValue()));
+        else {
+          String sc = SimpleJson.str(cap);
+          if (sc!=null && !sc.isBlank()){
+            try { r.setCapacity(Math.max(1, (int) Double.parseDouble(sc))); } catch(NumberFormatException ignore){}
+          }
+        }
+        String tags = SimpleJson.str(m.get("tags"));
+        if (tags!=null) r.setTags(tags);
+        String weekly = SimpleJson.str(m.get("weeklyUnavailability"));
+        if (weekly!=null) r.setWeeklyUnavailability(weekly);
+        // === CRM-INJECT END ===
         out.add(r);
       }
       return out;
@@ -56,6 +70,11 @@ public class ApiPlanningService implements PlanningService {
       m.put("type", r.getType());
       m.put("color", r.getColor());
       m.put("notes", r.getNotes());
+      // === CRM-INJECT BEGIN: resource-api-write ===
+      m.put("capacity", r.getCapacity());
+      m.put("tags", r.getTags());
+      m.put("weeklyUnavailability", r.getWeeklyUnavailability());
+      // === CRM-INJECT END ===
       String json = toJson(m);
       String body = (r.getId()==null? rc.post("/api/v1/resources", json) : rc.put("/api/v1/resources/"+r.getId(), json));
       var map = SimpleJson.asObj(SimpleJson.parse(body));
@@ -64,6 +83,20 @@ public class ApiPlanningService implements PlanningService {
       r.setType(SimpleJson.str(map.get("type")));
       r.setColor(SimpleJson.str(map.get("color")));
       r.setNotes(SimpleJson.str(map.get("notes")));
+      // === CRM-INJECT BEGIN: resource-api-after-save ===
+      Object cap = map.get("capacity");
+      if (cap instanceof Number n) r.setCapacity((int)Math.max(1, n.intValue()));
+      else {
+        String sc = SimpleJson.str(cap);
+        if (sc!=null && !sc.isBlank()){
+          try { r.setCapacity(Math.max(1, (int) Double.parseDouble(sc))); } catch(NumberFormatException ignore){}
+        }
+      }
+      String tags = SimpleJson.str(map.get("tags"));
+      if (tags!=null) r.setTags(tags);
+      String weekly = SimpleJson.str(map.get("weeklyUnavailability"));
+      if (weekly!=null) r.setWeeklyUnavailability(weekly);
+      // === CRM-INJECT END ===
       return r;
     } catch(Exception e){ return fb.saveResource(r); }
   }
@@ -180,6 +213,9 @@ public class ApiPlanningService implements PlanningService {
     Map<String,Object> m = new LinkedHashMap<>();
     if (it.getId()!=null) m.put("id", it.getId().toString());
     m.put("resourceId", it.getResourceId()!=null? it.getResourceId().toString() : null);
+    // === CRM-INJECT BEGIN: planning-api-client-id ===
+    m.put("clientId", it.getClientId()!=null? it.getClientId().toString() : null);
+    // === CRM-INJECT END ===
     m.put("label", it.getLabel());
     m.put("color", it.getColor());
     if (it.getDateDebut()!=null) m.put("dateDebut", it.getDateDebut().toString());
@@ -200,6 +236,12 @@ public class ApiPlanningService implements PlanningService {
       rid = SimpleJson.str(res.get("id"));
     }
     if (rid!=null && !rid.isBlank()) it.setResourceId(UUID.fromString(rid));
+    // === CRM-INJECT BEGIN: planning-api-client-mapping ===
+    String cid = SimpleJson.str(m.get("clientId"));
+    if (cid!=null && !cid.isBlank()) it.setClientId(UUID.fromString(cid));
+    String cname = SimpleJson.str(m.get("clientName"));
+    if (cname!=null) it.setClientName(cname);
+    // === CRM-INJECT END ===
     it.setLabel(SimpleJson.str(m.get("label")));
     it.setColor(SimpleJson.str(m.get("color")));
     String d1 = SimpleJson.str(m.get("dateDebut"));

--- a/client/src/main/java/com/materiel/suite/client/service/mock/MockPlanningService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/mock/MockPlanningService.java
@@ -21,6 +21,11 @@ public class MockPlanningService implements PlanningService {
       Resource r1 = new Resource(UUID.randomUUID(), "Grue A");
       Resource r2 = new Resource(UUID.randomUUID(), "Grue B");
       Resource r3 = new Resource(UUID.randomUUID(), "Nacelle 18m");
+      // === CRM-INJECT BEGIN: resource-mock-defaults ===
+      r1.setCapacity(2); r1.setTags("grue,90t"); r1.setWeeklyUnavailability("MON 08:00-12:00; THU 13:00-17:00");
+      r2.setCapacity(1); r2.setTags("grue,60t"); r2.setWeeklyUnavailability("TUE 08:00-12:00");
+      r3.setCapacity(1); r3.setTags("nacelle"); r3.setWeeklyUnavailability("FRI 14:00-18:00");
+      // === CRM-INJECT END ===
       resources.put(r1.getId(), r1); resources.put(r2.getId(), r2); resources.put(r3.getId(), r3);
       LocalDate base = LocalDate.now().with(java.time.DayOfWeek.MONDAY);
       add(fillCard(new Intervention(UUID.randomUUID(), r1.getId(), "Chantier Alpha", base.plusDays(0), base.plusDays(2), "#5E81AC"),

--- a/client/src/main/java/com/materiel/suite/client/ui/resources/ResourcesPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/resources/ResourcesPanel.java
@@ -50,7 +50,19 @@ public class ResourcesPanel extends JPanel {
     JTextField color= new JTextField(r!=null? r.getColor():"", 8);
     JTextArea notes = new JTextArea(r!=null? r.getNotes():"", 5, 30);
     notes.setLineWrap(true); notes.setWrapStyleWord(true);
-    Object[] msg = {"Nom:", name, "Type:", type, "Couleur (hex):", color, "Notes:", new JScrollPane(notes)};
+    // === CRM-INJECT BEGIN: resource-editor-advanced-fields ===
+    int baseCapacity = (r!=null && r.getCapacity()!=null)? r.getCapacity():1;
+    if (baseCapacity<1) baseCapacity = 1;
+    JSpinner capacity = new JSpinner(new SpinnerNumberModel(baseCapacity, 1, 999, 1));
+    JTextField tags = new JTextField(r!=null && r.getTags()!=null? r.getTags():"", 20);
+    JTextArea weekly = new JTextArea(r!=null && r.getWeeklyUnavailability()!=null? r.getWeeklyUnavailability():"", 4, 30);
+    weekly.setLineWrap(true); weekly.setWrapStyleWord(true);
+    // === CRM-INJECT END ===
+    Object[] msg = {"Nom:", name, "Type:", type, "Couleur (hex):", color, "Notes:", new JScrollPane(notes)
+        // === CRM-INJECT BEGIN: resource-editor-advanced-layout ===
+        , "Capacité:", capacity, "Tags:", tags, "Indisponibilités récurrentes:", new JScrollPane(weekly)
+        // === CRM-INJECT END ===
+    };
     int ok = JOptionPane.showConfirmDialog(this, msg, (r==null? "Nouvelle ressource":"Modifier ressource"), JOptionPane.OK_CANCEL_OPTION);
     if (ok==JOptionPane.OK_OPTION){
       Resource x = (r==null? new Resource() : r);
@@ -59,6 +71,17 @@ public class ResourcesPanel extends JPanel {
       x.setType(type.getText().trim());
       x.setColor(color.getText().trim());
       x.setNotes(notes.getText());
+      // === CRM-INJECT BEGIN: resource-editor-advanced-save ===
+      Object capVal = capacity.getValue();
+      int cap = 1;
+      if (capVal instanceof Number n) cap = Math.max(1, n.intValue());
+      else {
+        try { cap = Math.max(1, Integer.parseInt(String.valueOf(capVal))); } catch(Exception ignore){}
+      }
+      x.setCapacity(cap);
+      x.setTags(tags.getText().trim());
+      x.setWeeklyUnavailability(weekly.getText());
+      // === CRM-INJECT END ===
       ServiceFactory.planning().saveResource(x);
       reload();
     }
@@ -69,7 +92,11 @@ public class ResourcesPanel extends JPanel {
   }
   private static class ResourceModel extends AbstractTableModel {
     List<Resource> items = new ArrayList<>();
-    String[] cols = {"Nom", "Type", "Couleur", "Notes"};
+    String[] cols = {"Nom", "Type", "Couleur", "Notes"
+        // === CRM-INJECT BEGIN: resource-table-advanced-cols ===
+        , "Capacité", "Tags", "Indispos hebdo"
+        // === CRM-INJECT END ===
+    };
     @Override public int getRowCount(){ return items.size(); }
     @Override public int getColumnCount(){ return cols.length; }
     @Override public String getColumnName(int c){ return cols[c]; }
@@ -80,6 +107,11 @@ public class ResourcesPanel extends JPanel {
         case 1 -> x.getType();
         case 2 -> x.getColor();
         case 3 -> x.getNotes();
+        // === CRM-INJECT BEGIN: resource-table-advanced-values ===
+        case 4 -> x.getCapacity();
+        case 5 -> x.getTags();
+        case 6 -> x.getWeeklyUnavailability();
+        // === CRM-INJECT END ===
         default -> "";
       };
     }


### PR DESCRIPTION
## Summary
- add clientId support to interventions and REST mapping
- expose client selection when creating or editing interventions in planning view
- mirror client selector and display improvements in agenda view, including duplication support
- extend resources with capacity, tags, and weekly unavailability fields, persisting through API/mock services and editor UI

## Testing
- mvn -pl client compile *(fails: cannot reach Maven Central in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68c9116b18288330833d98a5ea99a8db