### PR TITLE
Add resource type selection and unavailability management

### DIFF
--- a/backend/src/main/resources/openapi/gestion-materiel-v1.yaml
+++ b/backend/src/main/resources/openapi/gestion-materiel-v1.yaml
@@ -57,6 +57,140 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Order'
+  /api/v1/resources:
+    get:
+      summary: List resources
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Resource'
+    post:
+      summary: Create resource
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Resource'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Resource'
+  /api/v1/resources/{id}:
+    put:
+      summary: Update resource
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Resource'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Resource'
+    delete:
+      summary: Delete resource
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: Deleted
+  /api/v1/resource-types:
+    get:
+      summary: List resource types
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ResourceType'
+  /api/v1/resources/{id}/unavailability:
+    get:
+      summary: List resource unavailability periods
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Unavailability'
+    post:
+      summary: Add unavailability period
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Unavailability'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Unavailability'
+  /api/v1/resources/{id}/unavailability/{uid}:
+    delete:
+      summary: Remove unavailability period
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: uid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: Deleted
 components:
   schemas:
     DocumentLine:
@@ -102,3 +236,50 @@ components:
         totalHT:
           type: number
           format: double
+    Resource:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        type:
+          $ref: '#/components/schemas/ResourceType'
+        color:
+          type: string
+        notes:
+          type: string
+        capacity:
+          type: integer
+        tags:
+          type: string
+        weeklyUnavailability:
+          type: string
+        unavailabilities:
+          type: array
+          items:
+            $ref: '#/components/schemas/Unavailability'
+    ResourceType:
+      type: object
+      required: [code]
+      properties:
+        code:
+          type: string
+        label:
+          type: string
+    Unavailability:
+      type: object
+      required: [start, end]
+      properties:
+        id:
+          type: string
+          format: uuid
+        start:
+          type: string
+          format: date-time
+        end:
+          type: string
+          format: date-time
+        reason:
+          type: string

--- a/client/openapi/gestion-materiel-v1.yaml
+++ b/client/openapi/gestion-materiel-v1.yaml
@@ -57,6 +57,140 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Order'
+  /api/v1/resources:
+    get:
+      summary: List resources
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Resource'
+    post:
+      summary: Create resource
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Resource'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Resource'
+  /api/v1/resources/{id}:
+    put:
+      summary: Update resource
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Resource'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Resource'
+    delete:
+      summary: Delete resource
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: Deleted
+  /api/v1/resource-types:
+    get:
+      summary: List resource types
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ResourceType'
+  /api/v1/resources/{id}/unavailability:
+    get:
+      summary: List resource unavailability periods
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Unavailability'
+    post:
+      summary: Add unavailability period
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Unavailability'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Unavailability'
+  /api/v1/resources/{id}/unavailability/{uid}:
+    delete:
+      summary: Remove unavailability period
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: uid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: Deleted
 components:
   schemas:
     DocumentLine:
@@ -102,3 +236,50 @@ components:
         totalHT:
           type: number
           format: double
+    Resource:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        type:
+          $ref: '#/components/schemas/ResourceType'
+        color:
+          type: string
+        notes:
+          type: string
+        capacity:
+          type: integer
+        tags:
+          type: string
+        weeklyUnavailability:
+          type: string
+        unavailabilities:
+          type: array
+          items:
+            $ref: '#/components/schemas/Unavailability'
+    ResourceType:
+      type: object
+      required: [code]
+      properties:
+        code:
+          type: string
+        label:
+          type: string
+    Unavailability:
+      type: object
+      required: [start, end]
+      properties:
+        id:
+          type: string
+          format: uuid
+        start:
+          type: string
+          format: date-time
+        end:
+          type: string
+          format: date-time
+        reason:
+          type: string

--- a/client/src/main/java/com/materiel/suite/client/model/Resource.java
+++ b/client/src/main/java/com/materiel/suite/client/model/Resource.java
@@ -1,31 +1,41 @@
 package com.materiel.suite.client.model;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 public class Resource {
   private UUID id;
   private String name;
-  private String type;
+  private ResourceType type;
   private String color;
   private String notes;
+  private final List<Unavailability> unavailabilities = new ArrayList<>();
   // === CRM-INJECT BEGIN: resource-advanced-fields ===
   private Integer capacity = 1;
   private String tags;
   private String weeklyUnavailability;
   // === CRM-INJECT END ===
-  
+
   public Resource(){}
   public Resource(UUID id, String name){ this.id=id; this.name=name; }
   public UUID getId(){ return id; }
   public void setId(UUID id){ this.id=id; }
   public String getName(){ return name; }
   public void setName(String name){ this.name=name; }
-  public String getType(){ return type; }
-  public void setType(String type){ this.type=type; }
+  public ResourceType getType(){ return type; }
+  public void setType(ResourceType type){ this.type=type; }
   public String getColor(){ return color; }
   public void setColor(String color){ this.color=color; }
   public String getNotes(){ return notes; }
   public void setNotes(String notes){ this.notes=notes; }
+  public List<Unavailability> getUnavailabilities(){ return unavailabilities; }
+  public void setUnavailabilities(List<Unavailability> list){
+    unavailabilities.clear();
+    if (list!=null) unavailabilities.addAll(list);
+  }
+  public String getTypeCode(){ return type!=null? type.getCode():null; }
+  public String getTypeLabel(){ return type!=null? type.getLabel():null; }
   // === CRM-INJECT BEGIN: resource-advanced-accessors ===
   public Integer getCapacity(){ return capacity; }
   public void setCapacity(Integer capacity){ this.capacity = (capacity==null || capacity<1)? 1 : capacity; }

--- a/client/src/main/java/com/materiel/suite/client/model/ResourceType.java
+++ b/client/src/main/java/com/materiel/suite/client/model/ResourceType.java
@@ -1,0 +1,32 @@
+package com.materiel.suite.client.model;
+
+import java.util.Objects;
+
+public class ResourceType {
+  private String code;
+  private String label;
+
+  public ResourceType(){}
+  public ResourceType(String code, String label){ this.code = code; this.label = label; }
+
+  public String getCode(){ return code; }
+  public void setCode(String code){ this.code = code; }
+  public String getLabel(){ return label; }
+  public void setLabel(String label){ this.label = label; }
+
+  @Override public String toString(){
+    if (label!=null && !label.isBlank()) return label;
+    return code;
+  }
+
+  @Override public boolean equals(Object o){
+    if (this == o) return true;
+    if (!(o instanceof ResourceType)) return false;
+    ResourceType that = (ResourceType) o;
+    return Objects.equals(code, that.code);
+  }
+
+  @Override public int hashCode(){
+    return Objects.hash(code);
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/model/Unavailability.java
+++ b/client/src/main/java/com/materiel/suite/client/model/Unavailability.java
@@ -1,0 +1,44 @@
+package com.materiel.suite.client.model;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.UUID;
+
+public class Unavailability {
+  private UUID id;
+  private LocalDateTime start;
+  private LocalDateTime end;
+  private String reason;
+
+  public Unavailability(){}
+  public Unavailability(LocalDateTime start, LocalDateTime end, String reason){
+    this(null, start, end, reason);
+  }
+  public Unavailability(UUID id, LocalDateTime start, LocalDateTime end, String reason){
+    this.id = id;
+    this.start = start;
+    this.end = end;
+    this.reason = reason;
+  }
+
+  public UUID getId(){ return id; }
+  public void setId(UUID id){ this.id = id; }
+  public LocalDateTime getStart(){ return start; }
+  public void setStart(LocalDateTime start){ this.start = start; }
+  public LocalDateTime getEnd(){ return end; }
+  public void setEnd(LocalDateTime end){ this.end = end; }
+  public String getReason(){ return reason; }
+  public void setReason(String reason){ this.reason = reason; }
+
+  @Override public boolean equals(Object o){
+    if (this == o) return true;
+    if (!(o instanceof Unavailability)) return false;
+    Unavailability that = (Unavailability) o;
+    if (id!=null && that.id!=null) return Objects.equals(id, that.id);
+    return Objects.equals(start, that.start) && Objects.equals(end, that.end) && Objects.equals(reason, that.reason);
+  }
+
+  @Override public int hashCode(){
+    return id!=null? id.hashCode() : Objects.hash(start, end, reason);
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/service/PlanningService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/PlanningService.java
@@ -1,8 +1,10 @@
 package com.materiel.suite.client.service;
 
+import com.materiel.suite.client.model.Conflict;
 import com.materiel.suite.client.model.Intervention;
 import com.materiel.suite.client.model.Resource;
-import com.materiel.suite.client.model.Conflict;
+import com.materiel.suite.client.model.ResourceType;
+import com.materiel.suite.client.model.Unavailability;
 import com.materiel.suite.client.service.PlanningValidation;
 
 import java.time.LocalDate;
@@ -14,6 +16,10 @@ public interface PlanningService {
   List<Resource> listResources();
   Resource saveResource(Resource r);
   void deleteResource(UUID id);
+  default List<ResourceType> listResourceTypes(){ return List.of(); }
+  default List<Unavailability> listResourceUnavailabilities(UUID resourceId){ return List.of(); }
+  default Unavailability addUnavailability(UUID resourceId, Unavailability u){ throw new UnsupportedOperationException(); }
+  default void deleteUnavailability(UUID resourceId, UUID unavailabilityId){}
 
   List<Intervention> listInterventions(LocalDate from, LocalDate to);
   Intervention saveIntervention(Intervention i);

--- a/client/src/main/java/com/materiel/suite/client/ui/common/DateTimeField.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/common/DateTimeField.java
@@ -1,0 +1,41 @@
+package com.materiel.suite.client.ui.common;
+
+import javax.swing.*;
+import java.awt.*;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+public class DateTimeField extends JPanel {
+  private final JSpinner dateSpinner;
+  private final JSpinner timeSpinner;
+
+  public DateTimeField(){
+    super(new FlowLayout(FlowLayout.LEFT, 4, 0));
+    Date now = new Date();
+    dateSpinner = new JSpinner(new SpinnerDateModel(now, null, null, java.util.Calendar.DAY_OF_MONTH));
+    timeSpinner = new JSpinner(new SpinnerDateModel(now, null, null, java.util.Calendar.MINUTE));
+    dateSpinner.setEditor(new JSpinner.DateEditor(dateSpinner, "yyyy-MM-dd"));
+    timeSpinner.setEditor(new JSpinner.DateEditor(timeSpinner, "HH:mm"));
+    add(dateSpinner);
+    add(timeSpinner);
+  }
+
+  public LocalDateTime getDateTime(){
+    Date d = (Date) dateSpinner.getValue();
+    Date t = (Date) timeSpinner.getValue();
+    ZoneId zone = ZoneId.systemDefault();
+    LocalDateTime base = LocalDateTime.ofInstant(d.toInstant(), zone);
+    LocalDateTime time = LocalDateTime.ofInstant(t.toInstant(), zone);
+    return LocalDateTime.of(base.toLocalDate(), time.toLocalTime().withSecond(0).withNano(0));
+  }
+
+  public void setDateTime(LocalDateTime ldt){
+    if (ldt==null) return;
+    ZoneId zone = ZoneId.systemDefault();
+    Date date = Date.from(ldt.withHour(0).withMinute(0).withSecond(0).withNano(0).atZone(zone).toInstant());
+    Date time = Date.from(ldt.atZone(zone).toInstant());
+    dateSpinner.setValue(date);
+    timeSpinner.setValue(time);
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/resources/ResourceEditDialog.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/resources/ResourceEditDialog.java
@@ -1,0 +1,278 @@
+package com.materiel.suite.client.ui.resources;
+
+import com.materiel.suite.client.model.Resource;
+import com.materiel.suite.client.model.ResourceType;
+import com.materiel.suite.client.model.Unavailability;
+import com.materiel.suite.client.service.PlanningService;
+import com.materiel.suite.client.ui.common.DateTimeField;
+
+import javax.swing.*;
+import java.awt.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+public class ResourceEditDialog extends JDialog {
+  private final JTextField nameField = new JTextField(24);
+  private final JTextField colorField = new JTextField(8);
+  private final JTextArea notesArea = new JTextArea(5, 30);
+  private final JComboBox<ResourceType> typeCombo = new JComboBox<>();
+  private final JSpinner capacitySpinner = new JSpinner(new SpinnerNumberModel(1, 1, 999, 1));
+  private final JTextField tagsField = new JTextField(20);
+  private final JTextArea weeklyArea = new JTextArea(4, 30);
+  private final UnavailabilityTableModel tableModel = new UnavailabilityTableModel();
+  private final JTable table = new JTable(tableModel);
+  private final PlanningService service;
+  private final Set<UUID> initialUnavailabilityIds = new HashSet<>();
+  private Resource resource;
+  private boolean saved;
+
+  public ResourceEditDialog(Window owner, PlanningService service, Resource resource){
+    super(owner, resource==null? "Nouvelle ressource" : "Modifier la ressource", ModalityType.APPLICATION_MODAL);
+    this.service = service;
+    this.resource = resource!=null? resource : new Resource();
+    buildUI();
+    loadTypes();
+    bindValues();
+    pack();
+    setLocationRelativeTo(owner);
+  }
+
+  public boolean isSaved(){ return saved; }
+
+  private void buildUI(){
+    notesArea.setLineWrap(true);
+    notesArea.setWrapStyleWord(true);
+    weeklyArea.setLineWrap(true);
+    weeklyArea.setWrapStyleWord(true);
+    typeCombo.setEditable(true);
+
+    JPanel form = new JPanel(new GridBagLayout());
+    GridBagConstraints gc = new GridBagConstraints();
+    gc.insets = new Insets(4,4,4,4);
+    gc.anchor = GridBagConstraints.WEST;
+    gc.gridx = 0; gc.gridy = 0; form.add(new JLabel("Nom"), gc);
+    gc.gridx = 1; form.add(nameField, gc);
+    gc.gridx = 0; gc.gridy++; form.add(new JLabel("Type"), gc);
+    gc.gridx = 1; form.add(typeCombo, gc);
+    gc.gridx = 0; gc.gridy++; form.add(new JLabel("Couleur (hex)"), gc);
+    gc.gridx = 1; form.add(colorField, gc);
+    gc.gridx = 0; gc.gridy++; gc.anchor = GridBagConstraints.NORTHWEST; form.add(new JLabel("Notes"), gc);
+    gc.gridx = 1; form.add(new JScrollPane(notesArea), gc);
+    // === CRM-INJECT BEGIN: resource-editor-advanced-fields ===
+    gc.gridx = 0; gc.gridy++; gc.anchor = GridBagConstraints.WEST; form.add(new JLabel("Capacité"), gc);
+    gc.gridx = 1; form.add(capacitySpinner, gc);
+    gc.gridx = 0; gc.gridy++; form.add(new JLabel("Tags"), gc);
+    gc.gridx = 1; form.add(tagsField, gc);
+    gc.gridx = 0; gc.gridy++; gc.anchor = GridBagConstraints.NORTHWEST; form.add(new JLabel("Indisponibilités récurrentes"), gc);
+    gc.gridx = 1; form.add(new JScrollPane(weeklyArea), gc);
+    // === CRM-INJECT END ===
+
+    JPanel unavailabilityPanel = new JPanel(new BorderLayout(4,4));
+    unavailabilityPanel.setBorder(BorderFactory.createTitledBorder("Indisponibilités ponctuelles"));
+    table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+    table.setFillsViewportHeight(true);
+    unavailabilityPanel.add(new JScrollPane(table), BorderLayout.CENTER);
+
+    JPanel actions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 4));
+    JButton add = new JButton("Ajouter…");
+    JButton remove = new JButton("Supprimer");
+    actions.add(add); actions.add(remove);
+    unavailabilityPanel.add(actions, BorderLayout.NORTH);
+    add.addActionListener(e -> onAdd());
+    remove.addActionListener(e -> onRemove());
+
+    JButton save = new JButton("Enregistrer");
+    JButton cancel = new JButton("Annuler");
+    save.addActionListener(e -> onSave());
+    cancel.addActionListener(e -> dispose());
+
+    JPanel south = new JPanel(new FlowLayout(FlowLayout.RIGHT, 8, 4));
+    south.add(cancel); south.add(save);
+
+    JPanel root = new JPanel(new BorderLayout(8,8));
+    root.setBorder(BorderFactory.createEmptyBorder(8,8,8,8));
+    root.add(form, BorderLayout.NORTH);
+    root.add(unavailabilityPanel, BorderLayout.CENTER);
+    root.add(south, BorderLayout.SOUTH);
+    setContentPane(root);
+  }
+
+  private void loadTypes(){
+    DefaultComboBoxModel<ResourceType> model = new DefaultComboBoxModel<>();
+    try {
+      List<ResourceType> types = service.listResourceTypes();
+      for (ResourceType t : types){
+        if (t!=null) model.addElement(t);
+      }
+    } catch(Exception ignore){}
+    typeCombo.setModel(model);
+  }
+
+  private void bindValues(){
+    nameField.setText(resource.getName()!=null? resource.getName():"");
+    colorField.setText(resource.getColor()!=null? resource.getColor():"");
+    notesArea.setText(resource.getNotes()!=null? resource.getNotes():"");
+    ResourceType type = resource.getType();
+    if (type!=null){
+      ensureTypeInModel(type);
+      typeCombo.setSelectedItem(type);
+    } else {
+      typeCombo.setSelectedItem(null);
+    }
+    // === CRM-INJECT BEGIN: resource-editor-advanced-save ===
+    Integer cap = resource.getCapacity();
+    if (cap==null || cap<1) cap = 1;
+    capacitySpinner.setValue(cap);
+    tagsField.setText(resource.getTags()!=null? resource.getTags():"");
+    weeklyArea.setText(resource.getWeeklyUnavailability()!=null? resource.getWeeklyUnavailability():"");
+    // === CRM-INJECT END ===
+
+    List<Unavailability> list;
+    if (resource.getId()!=null){
+      try {
+        list = service.listResourceUnavailabilities(resource.getId());
+      } catch(Exception e){
+        list = new ArrayList<>(resource.getUnavailabilities());
+      }
+    } else {
+      list = new ArrayList<>(resource.getUnavailabilities());
+    }
+    tableModel.setRows(list);
+    initialUnavailabilityIds.clear();
+    for (Unavailability u : list){
+      if (u.getId()!=null) initialUnavailabilityIds.add(u.getId());
+    }
+  }
+
+  private void ensureTypeInModel(ResourceType type){
+    ComboBoxModel<ResourceType> model = typeCombo.getModel();
+    for (int i=0;i<model.getSize();i++){
+      ResourceType t = model.getElementAt(i);
+      if (t!=null && t.equals(type)) return;
+    }
+    ((DefaultComboBoxModel<ResourceType>)model).addElement(type);
+  }
+
+  private void onAdd(){
+    DateTimeField startField = new DateTimeField();
+    DateTimeField endField = new DateTimeField();
+    JTextField reason = new JTextField(20);
+
+    JPanel panel = new JPanel(new GridBagLayout());
+    GridBagConstraints gc = new GridBagConstraints();
+    gc.insets = new Insets(4,4,4,4);
+    gc.anchor = GridBagConstraints.WEST;
+    gc.gridx = 0; gc.gridy = 0; panel.add(new JLabel("Début"), gc);
+    gc.gridx = 1; panel.add(startField, gc);
+    gc.gridx = 0; gc.gridy = 1; panel.add(new JLabel("Fin"), gc);
+    gc.gridx = 1; panel.add(endField, gc);
+    gc.gridx = 0; gc.gridy = 2; panel.add(new JLabel("Motif"), gc);
+    gc.gridx = 1; panel.add(reason, gc);
+
+    int res = JOptionPane.showConfirmDialog(this, panel, "Ajouter une indisponibilité", JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
+    if (res==JOptionPane.OK_OPTION){
+      LocalDateTime start = startField.getDateTime();
+      LocalDateTime end = endField.getDateTime();
+      if (end.isBefore(start)){
+        JOptionPane.showMessageDialog(this, "La fin doit être postérieure au début.", "Validation", JOptionPane.WARNING_MESSAGE);
+        return;
+      }
+      tableModel.add(new Unavailability(null, start, end, reason.getText().trim()));
+    }
+  }
+
+  private void onRemove(){
+    int row = table.getSelectedRow();
+    if (row<0) return;
+    tableModel.remove(row);
+  }
+
+  private void onSave(){
+    try {
+      applyAndSave();
+      saved = true;
+      dispose();
+    } catch(Exception e){
+      JOptionPane.showMessageDialog(this, "Erreur lors de l'enregistrement : "+e.getMessage(), "Erreur", JOptionPane.ERROR_MESSAGE);
+    }
+  }
+
+  private void applyAndSave(){
+    resource.setName(nameField.getText().trim());
+    resource.setColor(colorField.getText().trim());
+    resource.setNotes(notesArea.getText());
+    ResourceType selectedType = resolveType();
+    resource.setType(selectedType);
+    // === CRM-INJECT BEGIN: resource-editor-advanced-save ===
+    Object capVal = capacitySpinner.getValue();
+    int cap = 1;
+    if (capVal instanceof Number n) cap = Math.max(1, n.intValue());
+    else {
+      try { cap = Math.max(1, Integer.parseInt(String.valueOf(capVal))); } catch(Exception ignore){}
+    }
+    resource.setCapacity(cap);
+    resource.setTags(tagsField.getText().trim());
+    resource.setWeeklyUnavailability(weeklyArea.getText());
+    // === CRM-INJECT END ===
+
+    List<Unavailability> desired = tableModel.getRows();
+    resource.setUnavailabilities(desired);
+    resource = service.saveResource(resource);
+
+    UUID resourceId = resource.getId();
+    if (resourceId!=null){
+      List<Unavailability> afterSave = new ArrayList<>(resource.getUnavailabilities()!=null? resource.getUnavailabilities(): Collections.emptyList());
+      if (!afterSave.isEmpty()){
+        desired = afterSave;
+        tableModel.setRows(afterSave);
+      }
+      Set<UUID> currentIds = new HashSet<>();
+      for (Unavailability u : desired){
+        if (u.getId()!=null) currentIds.add(u.getId());
+      }
+      for (UUID id : new ArrayList<>(initialUnavailabilityIds)){
+        if (!currentIds.contains(id)){
+          service.deleteUnavailability(resourceId, id);
+        }
+      }
+      List<Unavailability> persisted = new ArrayList<>();
+      for (Unavailability u : desired){
+        if (u.getId()==null){
+          Unavailability created = service.addUnavailability(resourceId, u);
+          if (created!=null){
+            persisted.add(created);
+          } else {
+            persisted.add(u);
+          }
+        } else {
+          persisted.add(u);
+        }
+      }
+      List<Unavailability> refreshed = persisted;
+      try {
+        refreshed = service.listResourceUnavailabilities(resourceId);
+      } catch(Exception ignore){}
+      resource.setUnavailabilities(refreshed);
+      tableModel.setRows(refreshed);
+      initialUnavailabilityIds.clear();
+      for (Unavailability u : refreshed){
+        if (u.getId()!=null) initialUnavailabilityIds.add(u.getId());
+      }
+    }
+  }
+
+  private ResourceType resolveType(){
+    Object selected = typeCombo.getSelectedItem();
+    if (selected instanceof ResourceType t) return t;
+    if (selected!=null){
+      String txt = selected.toString().trim();
+      if (!txt.isEmpty()) return new ResourceType(txt, txt);
+    }
+    return null;
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/resources/ResourcesPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/resources/ResourcesPanel.java
@@ -1,6 +1,7 @@
 package com.materiel.suite.client.ui.resources;
 
 import com.materiel.suite.client.model.Resource;
+import com.materiel.suite.client.model.ResourceType;
 import com.materiel.suite.client.net.ServiceFactory;
 
 import javax.swing.*;
@@ -9,7 +10,6 @@ import javax.swing.table.AbstractTableModel;
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 public class ResourcesPanel extends JPanel {
   private final JTable table = new JTable();
@@ -45,50 +45,22 @@ public class ResourcesPanel extends JPanel {
     return bar;
   }
   private void editResource(Resource r){
-    JTextField name = new JTextField(r!=null? r.getName():"", 20);
-    JTextField type = new JTextField(r!=null? r.getType():"", 12);
-    JTextField color= new JTextField(r!=null? r.getColor():"", 8);
-    JTextArea notes = new JTextArea(r!=null? r.getNotes():"", 5, 30);
-    notes.setLineWrap(true); notes.setWrapStyleWord(true);
-    // === CRM-INJECT BEGIN: resource-editor-advanced-fields ===
-    int baseCapacity = (r!=null && r.getCapacity()!=null)? r.getCapacity():1;
-    if (baseCapacity<1) baseCapacity = 1;
-    JSpinner capacity = new JSpinner(new SpinnerNumberModel(baseCapacity, 1, 999, 1));
-    JTextField tags = new JTextField(r!=null && r.getTags()!=null? r.getTags():"", 20);
-    JTextArea weekly = new JTextArea(r!=null && r.getWeeklyUnavailability()!=null? r.getWeeklyUnavailability():"", 4, 30);
-    weekly.setLineWrap(true); weekly.setWrapStyleWord(true);
-    // === CRM-INJECT END ===
-    Object[] msg = {"Nom:", name, "Type:", type, "Couleur (hex):", color, "Notes:", new JScrollPane(notes)
-        // === CRM-INJECT BEGIN: resource-editor-advanced-layout ===
-        , "Capacité:", capacity, "Tags:", tags, "Indisponibilités récurrentes:", new JScrollPane(weekly)
-        // === CRM-INJECT END ===
-    };
-    int ok = JOptionPane.showConfirmDialog(this, msg, (r==null? "Nouvelle ressource":"Modifier ressource"), JOptionPane.OK_CANCEL_OPTION);
-    if (ok==JOptionPane.OK_OPTION){
-      Resource x = (r==null? new Resource() : r);
-      if (x.getId()==null) x.setId(UUID.randomUUID());
-      x.setName(name.getText().trim());
-      x.setType(type.getText().trim());
-      x.setColor(color.getText().trim());
-      x.setNotes(notes.getText());
-      // === CRM-INJECT BEGIN: resource-editor-advanced-save ===
-      Object capVal = capacity.getValue();
-      int cap = 1;
-      if (capVal instanceof Number n) cap = Math.max(1, n.intValue());
-      else {
-        try { cap = Math.max(1, Integer.parseInt(String.valueOf(capVal))); } catch(Exception ignore){}
-      }
-      x.setCapacity(cap);
-      x.setTags(tags.getText().trim());
-      x.setWeeklyUnavailability(weekly.getText());
-      // === CRM-INJECT END ===
-      ServiceFactory.planning().saveResource(x);
-      reload();
-    }
+    Window owner = SwingUtilities.getWindowAncestor(this);
+    ResourceEditDialog dlg = new ResourceEditDialog(owner, ServiceFactory.planning(), r);
+    dlg.setVisible(true);
+    if (dlg.isSaved()) reload();
   }
   private void reload(){
     model.items = new ArrayList<>(ServiceFactory.planning().listResources());
     model.fireTableDataChanged();
+  }
+  private static String typeLabel(Resource r){
+    ResourceType t = r.getType();
+    if (t==null) return "";
+    String label = t.getLabel();
+    if (label!=null && !label.isBlank()) return label;
+    String code = t.getCode();
+    return code!=null? code : "";
   }
   private static class ResourceModel extends AbstractTableModel {
     List<Resource> items = new ArrayList<>();
@@ -104,7 +76,7 @@ public class ResourcesPanel extends JPanel {
       Resource x = items.get(r);
       return switch(c){
         case 0 -> x.getName();
-        case 1 -> x.getType();
+        case 1 -> typeLabel(x);
         case 2 -> x.getColor();
         case 3 -> x.getNotes();
         // === CRM-INJECT BEGIN: resource-table-advanced-values ===

--- a/client/src/main/java/com/materiel/suite/client/ui/resources/UnavailabilityTableModel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/resources/UnavailabilityTableModel.java
@@ -1,0 +1,54 @@
+package com.materiel.suite.client.ui.resources;
+
+import com.materiel.suite.client.model.Unavailability;
+
+import javax.swing.table.AbstractTableModel;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+public class UnavailabilityTableModel extends AbstractTableModel {
+  private final List<Unavailability> rows = new ArrayList<>();
+  private static final String[] COLS = {"Début", "Fin", "Motif"};
+  private static final DateTimeFormatter FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+  public void setRows(List<Unavailability> list){
+    rows.clear();
+    if (list!=null) rows.addAll(list);
+    fireTableDataChanged();
+  }
+
+  public List<Unavailability> getRows(){
+    return new ArrayList<>(rows);
+  }
+
+  public void add(Unavailability u){
+    rows.add(u);
+    int i = rows.size()-1;
+    fireTableRowsInserted(i, i);
+  }
+
+  public void remove(int idx){
+    if (idx<0 || idx>=rows.size()) return;
+    rows.remove(idx);
+    fireTableRowsDeleted(idx, idx);
+  }
+
+  public Unavailability getAt(int idx){
+    if (idx<0 || idx>=rows.size()) return null;
+    return rows.get(idx);
+  }
+
+  @Override public int getRowCount(){ return rows.size(); }
+  @Override public int getColumnCount(){ return COLS.length; }
+  @Override public String getColumnName(int column){ return COLS[column]; }
+  @Override public Object getValueAt(int rowIndex, int columnIndex){
+    Unavailability u = rows.get(rowIndex);
+    return switch (columnIndex){
+      case 0 -> u.getStart()!=null? FMT.format(u.getStart()) : "";
+      case 1 -> u.getEnd()!=null? FMT.format(u.getEnd()) : "";
+      case 2 -> u.getReason()!=null? u.getReason() : "";
+      default -> "";
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- introduce ResourceType and Unavailability models and enrich Resource with typed fields
- extend planning services and UI with a dialog, table model, and date-time picker to manage resource types and unavailability periods
- document new API contracts for resources, resource types, and unavailability in both OpenAPI specs

## Testing
- `mvn -pl client -am test` *(fails: unable to reach Maven Central from container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9378f3af08330a8d0586d6a7c9e72