### PR TITLE
Add resource icons and multi-resource support to planning

### DIFF
--- a/backend/src/main/java/com/materiel/suite/backend/model/Intervention.java
+++ b/backend/src/main/java/com/materiel/suite/backend/model/Intervention.java
@@ -1,11 +1,14 @@
 package com.materiel.suite.backend.model;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 public class Intervention {
   private UUID id;
   private UUID resourceId;
+  private final List<ResourceRef> resources = new ArrayList<>();
   private String label;
   private LocalDateTime dateHeureDebut;
   private LocalDateTime dateHeureFin;
@@ -14,7 +17,56 @@ public class Intervention {
   public UUID getId(){ return id; }
   public void setId(UUID id){ this.id=id; }
   public UUID getResourceId(){ return resourceId; }
-  public void setResourceId(UUID resourceId){ this.resourceId=resourceId; }
+  public void setResourceId(UUID resourceId){
+    this.resourceId = resourceId;
+    if (resourceId==null){
+      if (!resources.isEmpty()){
+        ResourceRef ref = resources.get(0);
+        if (ref!=null){
+          ref.setId(null);
+          if (ref.getName()==null && ref.getIcon()==null){
+            resources.remove(0);
+          }
+        }
+      }
+    } else {
+      if (resources.isEmpty()){
+        resources.add(new ResourceRef(resourceId, null, null));
+      } else {
+        ResourceRef ref = resources.get(0);
+        if (ref==null){
+          resources.set(0, new ResourceRef(resourceId, null, null));
+        } else {
+          ref.setId(resourceId);
+        }
+      }
+    }
+  }
+  public List<ResourceRef> getResources(){ return new ArrayList<>(resources); }
+  public void setResources(List<ResourceRef> refs){
+    resources.clear();
+    if (refs!=null){
+      for (ResourceRef ref : refs){
+        if (ref==null) continue;
+        resources.add(new ResourceRef(ref.getId(), ref.getName(), ref.getIcon()));
+      }
+    }
+    if (resources.isEmpty()){
+      resourceId = null;
+    } else {
+      ResourceRef first = resources.get(0);
+      resourceId = first!=null? first.getId() : null;
+    }
+  }
+  public Intervention addResource(ResourceRef ref){
+    if (ref!=null) resources.add(new ResourceRef(ref.getId(), ref.getName(), ref.getIcon()));
+    if (!resources.isEmpty()){
+      ResourceRef first = resources.get(0);
+      resourceId = first!=null? first.getId() : null;
+    }
+    return this;
+  }
+  public ResourceRef primaryResource(){ return resources.isEmpty()? null : resources.get(0); }
   public String getLabel(){ return label; }
   public void setLabel(String label){ this.label=label; }
   public LocalDateTime getDateHeureDebut(){ return dateHeureDebut; }

--- a/backend/src/main/java/com/materiel/suite/backend/model/ResourceRef.java
+++ b/backend/src/main/java/com/materiel/suite/backend/model/ResourceRef.java
@@ -2,12 +2,14 @@ package com.materiel.suite.backend.model;
 
 import java.util.UUID;
 
-public class Resource {
+public class ResourceRef {
   private UUID id;
   private String name;
   private String icon;
-  public Resource(){}
-  public Resource(UUID id, String name){ this.id=id; this.name=name; }
+
+  public ResourceRef(){}
+  public ResourceRef(UUID id, String name, String icon){ this.id=id; this.name=name; this.icon=icon; }
+
   public UUID getId(){ return id; }
   public void setId(UUID id){ this.id=id; }
   public String getName(){ return name; }

--- a/backend/src/main/java/com/materiel/suite/backend/planning/InMemoryPlanningService.java
+++ b/backend/src/main/java/com/materiel/suite/backend/planning/InMemoryPlanningService.java
@@ -14,27 +14,31 @@ public class InMemoryPlanningService implements PlanningService {
   @jakarta.annotation.PostConstruct
   public void seed(){
     if (!resources.isEmpty()) return;
-    ResourceDto r1 = new ResourceDto(UUID.randomUUID(), "Grue A");
-    ResourceDto r2 = new ResourceDto(UUID.randomUUID(), "Grue B");
-    ResourceDto r3 = new ResourceDto(UUID.randomUUID(), "Nacelle 18m");
+    ResourceDto r1 = new ResourceDto(UUID.randomUUID(), "Grue A", "🏗️");
+    ResourceDto r2 = new ResourceDto(UUID.randomUUID(), "Grue B", "🏗️");
+    ResourceDto r3 = new ResourceDto(UUID.randomUUID(), "Nacelle 18m", "🛠️");
     resources.put(r1.id(), r1); resources.put(r2.id(), r2); resources.put(r3.id(), r3);
 
     LocalDate base = LocalDate.now().with(java.time.DayOfWeek.MONDAY);
-    add(new InterventionDto(UUID.randomUUID(), r1.id(), "BTP Construction",
+    add(new InterventionDto(UUID.randomUUID(), r1.id(), refsFor(r1), "BTP Construction",
         "Pont Anne-de-Bretagne", "GMK4100L-1", "Actros 26t", "Bruno", "Agence 1", "CONFIRMED",
         false, "Q-2025-018", "C-2025-003", "BL-1023", null, "#7CB9E8", false,
         base.atTime(9,0), base.atTime(17,0)));
-    add(new InterventionDto(UUID.randomUUID(), r1.id(), "Durand BTP",
+    add(new InterventionDto(UUID.randomUUID(), r1.id(), refsFor(r1), "Durand BTP",
         "Passerelle Ouest", "AC 100", null, null, "Agence 2", "PLANNED",
         false, null, null, null, null, "#A3BE8C", false,
         base.plusDays(1).atTime(8,0), base.plusDays(1).atTime(12,30)));
+  }
+  private List<ResourceRefDto> refsFor(ResourceDto dto){
+    if (dto==null) return List.of();
+    return List.of(new ResourceRefDto(dto.id(), dto.name(), dto.icon()));
   }
   private void add(InterventionDto d){ interventions.put(d.id(), d); }
 
   @Override public List<ResourceDto> listResources(){ return new ArrayList<>(resources.values()); }
   @Override public ResourceDto saveResource(ResourceDto r){
     UUID id = r.id()==null? UUID.randomUUID() : r.id();
-    ResourceDto s = new ResourceDto(id, r.name());
+    ResourceDto s = new ResourceDto(id, r.name(), r.icon());
     resources.put(id, s);
     return s;
   }
@@ -52,7 +56,7 @@ public class InMemoryPlanningService implements PlanningService {
   }
   @Override public InterventionDto saveIntervention(InterventionDto i){
     UUID id = i.id()==null? UUID.randomUUID() : i.id();
-    InterventionDto s = new InterventionDto(id, i.resourceId(), i.clientName(), i.siteLabel(), i.craneName(),
+    InterventionDto s = new InterventionDto(id, i.resourceId(), i.resources(), i.clientName(), i.siteLabel(), i.craneName(),
         i.truckName(), i.driverName(), i.agency(), i.status(), i.favorite(), i.quoteNumber(), i.orderNumber(),
         i.deliveryNumber(), i.invoiceNumber(), i.color(), i.locked(), i.dateHeureDebut(), i.dateHeureFin());
     interventions.put(id, s);

--- a/backend/src/main/java/com/materiel/suite/backend/planning/InterventionDto.java
+++ b/backend/src/main/java/com/materiel/suite/backend/planning/InterventionDto.java
@@ -1,11 +1,13 @@
 package com.materiel.suite.backend.planning;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public record InterventionDto(
     UUID id,
     UUID resourceId,
+    List<ResourceRefDto> resources,
     String clientName,
     String siteLabel,
     String craneName,

--- a/backend/src/main/java/com/materiel/suite/backend/planning/ResourceRefDto.java
+++ b/backend/src/main/java/com/materiel/suite/backend/planning/ResourceRefDto.java
@@ -2,9 +2,8 @@ package com.materiel.suite.backend.planning;
 
 import java.util.UUID;
 
-public record ResourceDto(
+public record ResourceRefDto(
     UUID id,
     String name,
     String icon
 ) {}
-

--- a/backend/src/main/java/com/materiel/suite/backend/store/InMemoryStore.java
+++ b/backend/src/main/java/com/materiel/suite/backend/store/InMemoryStore.java
@@ -2,6 +2,7 @@ package com.materiel.suite.backend.store;
 
 import com.materiel.suite.backend.model.Intervention;
 import com.materiel.suite.backend.model.Resource;
+import com.materiel.suite.backend.model.ResourceRef;
 import jakarta.annotation.PostConstruct;
 import org.springframework.stereotype.Component;
 
@@ -19,9 +20,9 @@ public class InMemoryStore {
   @PostConstruct
   public void seed(){
     if (!resources.isEmpty()) return;
-    Resource r1 = new Resource(UUID.randomUUID(), "Grue A");
-    Resource r2 = new Resource(UUID.randomUUID(), "Grue B");
-    Resource r3 = new Resource(UUID.randomUUID(), "Nacelle 18m");
+    Resource r1 = new Resource(UUID.randomUUID(), "Grue A"); r1.setIcon("🏗️");
+    Resource r2 = new Resource(UUID.randomUUID(), "Grue B"); r2.setIcon("🏗️");
+    Resource r3 = new Resource(UUID.randomUUID(), "Nacelle 18m"); r3.setIcon("🛠️");
     resources.put(r1.getId(), r1);
     resources.put(r2.getId(), r2);
     resources.put(r3.getId(), r3);
@@ -36,6 +37,7 @@ public class InMemoryStore {
     Intervention it = new Intervention();
     it.setId(UUID.randomUUID());
     it.setResourceId(r.getId());
+    it.setResources(List.of(new ResourceRef(r.getId(), r.getName(), r.getIcon())));
     it.setLabel(label);
     it.setDateHeureDebut(s);
     it.setDateHeureFin(e);
@@ -58,6 +60,12 @@ public class InMemoryStore {
   }
   public Intervention save(Intervention i){
     if (i.getId()==null) i.setId(UUID.randomUUID());
+    if (i.getResourceId()!=null && i.getResources().isEmpty()){
+      Resource r = resources.get(i.getResourceId());
+      if (r!=null){
+        i.setResources(List.of(new ResourceRef(r.getId(), r.getName(), r.getIcon())));
+      }
+    }
     interventions.put(i.getId(), i);
     return i;
   }

--- a/backend/src/main/java/com/materiel/suite/backend/web/PlanningController.java
+++ b/backend/src/main/java/com/materiel/suite/backend/web/PlanningController.java
@@ -2,6 +2,8 @@ package com.materiel.suite.backend.web;
 
 import com.materiel.suite.backend.model.Conflict;
 import com.materiel.suite.backend.model.Intervention;
+import com.materiel.suite.backend.model.Resource;
+import com.materiel.suite.backend.model.ResourceRef;
 import com.materiel.suite.backend.store.InMemoryStore;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
@@ -71,6 +73,13 @@ public class PlanningController {
           }
         }
         it.setResourceId(req.resourceId());
+        Resource target = store.resources().stream()
+            .filter(r -> r.getId().equals(req.resourceId()))
+            .findFirst()
+            .orElse(null);
+        if (target!=null){
+          it.setResources(List.of(new ResourceRef(target.getId(), target.getName(), target.getIcon())));
+        }
         return store.save(it);
       }
       case "split" -> {
@@ -82,6 +91,7 @@ public class PlanningController {
         Intervention tail = new Intervention();
         tail.setId(UUID.randomUUID());
         tail.setResourceId(it.getResourceId());
+        tail.setResources(it.getResources());
         tail.setLabel(it.getLabel()+" (suite)");
         tail.setColor(it.getColor());
         tail.setDateHeureDebut(t);

--- a/backend/src/main/resources/openapi/gestion-materiel-v1.yaml
+++ b/backend/src/main/resources/openapi/gestion-materiel-v1.yaml
@@ -236,6 +236,17 @@ components:
         totalHT:
           type: number
           format: double
+    InterventionResourceRef:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        icon:
+          type: string
+          description: "Icône simple (emoji, caractère)"
     Resource:
       type: object
       properties:
@@ -244,6 +255,9 @@ components:
           format: uuid
         name:
           type: string
+        icon:
+          type: string
+          description: "Icône simple (emoji, caractère) pour affichage"
         type:
           $ref: '#/components/schemas/ResourceType'
         color:
@@ -260,6 +274,54 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Unavailability'
+    Intervention:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        resourceId:
+          type: string
+          format: uuid
+          description: "Ressource principale (compatibilité)"
+        resources:
+          type: array
+          items:
+            $ref: '#/components/schemas/InterventionResourceRef'
+        clientName:
+          type: string
+        siteLabel:
+          type: string
+        craneName:
+          type: string
+        truckName:
+          type: string
+        driverName:
+          type: string
+        agency:
+          type: string
+        status:
+          type: string
+        favorite:
+          type: boolean
+        quoteNumber:
+          type: string
+        orderNumber:
+          type: string
+        deliveryNumber:
+          type: string
+        invoiceNumber:
+          type: string
+        color:
+          type: string
+        locked:
+          type: boolean
+        dateHeureDebut:
+          type: string
+          format: date-time
+        dateHeureFin:
+          type: string
+          format: date-time
     ResourceType:
       type: object
       required: [code]

--- a/client/src/main/java/com/materiel/suite/client/model/Intervention.java
+++ b/client/src/main/java/com/materiel/suite/client/model/Intervention.java
@@ -3,11 +3,13 @@ package com.materiel.suite.client.model;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 public class Intervention {
   private UUID id;
-  private UUID resourceId;
+  private final List<ResourceRef> resources = new ArrayList<>();
   // === CRM-INJECT BEGIN: intervention-client-id-field ===
   private UUID clientId;
   // === CRM-INJECT END ===
@@ -36,13 +38,58 @@ public class Intervention {
     this(id, resourceId, label, start.atStartOfDay(), end.atTime(LocalTime.of(18,0)), color);
   }
   public Intervention(UUID id, UUID resourceId, String label, LocalDateTime start, LocalDateTime end, String color){
-    this.id=id; this.resourceId=resourceId; this.label=label; this.dateHeureDebut=start; this.dateHeureFin=end; this.color=color;
+    this.id = id;
+    setResourceId(resourceId);
+    this.label = label;
+    this.dateHeureDebut = start;
+    this.dateHeureFin = end;
+    this.color = color;
   }
 
   public UUID getId(){ return id; }
   public void setId(UUID id){ this.id = id; }
-  public UUID getResourceId(){ return resourceId; }
-  public void setResourceId(UUID resourceId){ this.resourceId = resourceId; }
+  public UUID getResourceId(){
+    ResourceRef ref = resources.isEmpty()? null : resources.get(0);
+    return ref==null? null : ref.getId();
+  }
+  public void setResourceId(UUID resourceId){
+    if (resourceId==null){
+      if (!resources.isEmpty()){
+        ResourceRef ref = resources.get(0);
+        ref.setId(null);
+        if (ref.getName()==null && ref.getIcon()==null){
+          resources.remove(0);
+        }
+      }
+      return;
+    }
+    ResourceRef ref;
+    if (resources.isEmpty()){
+      ref = new ResourceRef();
+      resources.add(ref);
+    } else {
+      ref = resources.get(0);
+      if (ref==null){
+        ref = new ResourceRef();
+        resources.set(0, ref);
+      }
+    }
+    ref.setId(resourceId);
+  }
+  public List<ResourceRef> getResources(){ return new ArrayList<>(resources); }
+  public void setResources(List<ResourceRef> refs){
+    resources.clear();
+    if (refs==null) return;
+    for (ResourceRef ref : refs){
+      if (ref==null) continue;
+      resources.add(new ResourceRef(ref.getId(), ref.getName(), ref.getIcon()));
+    }
+  }
+  public Intervention addResource(ResourceRef ref){
+    if (ref!=null) resources.add(new ResourceRef(ref.getId(), ref.getName(), ref.getIcon()));
+    return this;
+  }
+  public ResourceRef primaryResource(){ return resources.isEmpty()? null : resources.get(0); }
   // === CRM-INJECT BEGIN: intervention-client-id-accessors ===
   public UUID getClientId(){ return clientId; }
   public void setClientId(UUID clientId){ this.clientId = clientId; }

--- a/client/src/main/java/com/materiel/suite/client/model/Resource.java
+++ b/client/src/main/java/com/materiel/suite/client/model/Resource.java
@@ -9,6 +9,7 @@ public class Resource {
   private String name;
   private ResourceType type;
   private String color;
+  private String icon;
   private String notes;
   private final List<Unavailability> unavailabilities = new ArrayList<>();
   // === CRM-INJECT BEGIN: resource-advanced-fields ===
@@ -27,6 +28,8 @@ public class Resource {
   public void setType(ResourceType type){ this.type=type; }
   public String getColor(){ return color; }
   public void setColor(String color){ this.color=color; }
+  public String getIcon(){ return icon; }
+  public void setIcon(String icon){ this.icon=icon; }
   public String getNotes(){ return notes; }
   public void setNotes(String notes){ this.notes=notes; }
   public List<Unavailability> getUnavailabilities(){ return unavailabilities; }

--- a/client/src/main/java/com/materiel/suite/client/model/ResourceRef.java
+++ b/client/src/main/java/com/materiel/suite/client/model/ResourceRef.java
@@ -1,0 +1,29 @@
+package com.materiel.suite.client.model;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/** Référence légère à une {@link Resource} pour embarquer nom et icône sans cycle complet. */
+public class ResourceRef {
+  private UUID id;
+  private String name;
+  private String icon;
+
+  public ResourceRef(){}
+  public ResourceRef(UUID id, String name, String icon){ this.id = id; this.name = name; this.icon = icon; }
+
+  public UUID getId(){ return id; }
+  public void setId(UUID id){ this.id = id; }
+  public String getName(){ return name; }
+  public void setName(String name){ this.name = name; }
+  public String getIcon(){ return icon; }
+  public void setIcon(String icon){ this.icon = icon; }
+
+  @Override public boolean equals(Object o){
+    if (this == o) return true;
+    if (!(o instanceof ResourceRef other)) return false;
+    return Objects.equals(id, other.id);
+  }
+
+  @Override public int hashCode(){ return Objects.hash(id); }
+}

--- a/client/src/main/java/com/materiel/suite/client/service/mock/MockPlanningService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/mock/MockPlanningService.java
@@ -3,6 +3,7 @@ package com.materiel.suite.client.service.mock;
 import com.materiel.suite.client.model.Conflict;
 import com.materiel.suite.client.model.Intervention;
 import com.materiel.suite.client.model.Resource;
+import com.materiel.suite.client.model.ResourceRef;
 import com.materiel.suite.client.model.ResourceType;
 import com.materiel.suite.client.model.Unavailability;
 import com.materiel.suite.client.service.PlanningService;
@@ -25,9 +26,9 @@ public class MockPlanningService implements PlanningService {
 
   public MockPlanningService(){
     if (resources.isEmpty()){
-      Resource r1 = new Resource(UUID.randomUUID(), "Grue A"); r1.setType(resourceTypes.get(0));
-      Resource r2 = new Resource(UUID.randomUUID(), "Grue B"); r2.setType(resourceTypes.get(0));
-      Resource r3 = new Resource(UUID.randomUUID(), "Nacelle 18m"); r3.setType(resourceTypes.get(2));
+      Resource r1 = new Resource(UUID.randomUUID(), "Grue A"); r1.setType(resourceTypes.get(0)); r1.setIcon("🏗️");
+      Resource r2 = new Resource(UUID.randomUUID(), "Grue B"); r2.setType(resourceTypes.get(0)); r2.setIcon("🏗️");
+      Resource r3 = new Resource(UUID.randomUUID(), "Nacelle 18m"); r3.setType(resourceTypes.get(2)); r3.setIcon("🛠️");
       // === CRM-INJECT BEGIN: resource-mock-defaults ===
       r1.setCapacity(2); r1.setTags("grue,90t"); r1.setWeeklyUnavailability("MON 08:00-12:00; THU 13:00-17:00");
       r2.setCapacity(1); r2.setTags("grue,60t"); r2.setWeeklyUnavailability("TUE 08:00-12:00");
@@ -39,23 +40,27 @@ public class MockPlanningService implements PlanningService {
           "Maintenance"));
       resources.put(r1.getId(), r1); resources.put(r2.getId(), r2); resources.put(r3.getId(), r3);
       LocalDate base = LocalDate.now().with(java.time.DayOfWeek.MONDAY);
-      add(fillCard(new Intervention(UUID.randomUUID(), r1.getId(), "Chantier Alpha", base.plusDays(0), base.plusDays(2), "#5E81AC"),
+      add(attachPrimary(fillCard(new Intervention(UUID.randomUUID(), r1.getId(), "Chantier Alpha", base.plusDays(0), base.plusDays(2), "#5E81AC"),
           "Durand BTP","Pont Anne-de-Bretagne","GMK4100L-1","Actros 26t","Bernard","Agence 1","PLANNED",true,
           "Q-2025-014","C-2025-003",null,null,
           LocalDateTime.of(base.plusDays(0), java.time.LocalTime.of(8,0)),
-          LocalDateTime.of(base.plusDays(0), java.time.LocalTime.of(12,30))));
-      add(fillCard(new Intervention(UUID.randomUUID(), r1.getId(), "Charpente Beta", base.plusDays(1), base.plusDays(3), "#A3BE8C"),
+          LocalDateTime.of(base.plusDays(0), java.time.LocalTime.of(12,30))), r1));
+      add(attachPrimary(fillCard(new Intervention(UUID.randomUUID(), r1.getId(), "Charpente Beta", base.plusDays(1), base.plusDays(3), "#A3BE8C"),
           "BTP Construction","Hall logistique","LTM 1050","Actros 26t","Bruno","Agence 1","CONFIRMED",false,
           "Q-2025-018",null,null,null,
           LocalDateTime.of(base.plusDays(1), java.time.LocalTime.of(9,0)),
-          LocalDateTime.of(base.plusDays(1), java.time.LocalTime.of(17,0))));
-      add(fillCard(new Intervention(UUID.randomUUID(), r1.getId(), "Levage Gamma", base.plusDays(2), base.plusDays(2), "#EBCB8B"),
+          LocalDateTime.of(base.plusDays(1), java.time.LocalTime.of(17,0))), r1));
+      add(attachPrimary(fillCard(new Intervention(UUID.randomUUID(), r1.getId(), "Levage Gamma", base.plusDays(2), base.plusDays(2), "#EBCB8B"),
           "Trx Publics","Passerelle Ouest","AC 100","—","Camille","Agence 2","PLANNED",false,
           null,null,"BL-1023",null,
           LocalDateTime.of(base.plusDays(2), java.time.LocalTime.of(7,30)),
-          LocalDateTime.of(base.plusDays(2), java.time.LocalTime.of(15,45))));
-      add(new Intervention(UUID.randomUUID(), r2.getId(), "Usine Delta", base.plusDays(0), base.plusDays(0), "#88C0D0"));
-      add(new Intervention(UUID.randomUUID(), r2.getId(), "Entretien", base.plusDays(4), base.plusDays(5), "#BF616A"));
+          LocalDateTime.of(base.plusDays(2), java.time.LocalTime.of(15,45))), r1));
+      Intervention i4 = new Intervention(UUID.randomUUID(), r2.getId(), "Usine Delta", base.plusDays(0), base.plusDays(0), "#88C0D0");
+      attachPrimary(i4, r2);
+      add(i4);
+      Intervention i5 = new Intervention(UUID.randomUUID(), r2.getId(), "Entretien", base.plusDays(4), base.plusDays(5), "#BF616A");
+      attachPrimary(i5, r2);
+      add(i5);
     }
   }
   private void add(Intervention i){ interventions.put(i.getId(), i); }
@@ -69,8 +74,19 @@ public class MockPlanningService implements PlanningService {
     return i;
   }
 
+  private Intervention attachPrimary(Intervention i, Resource r){
+    if (i!=null && r!=null){
+      i.setResources(List.of(new ResourceRef(r.getId(), r.getName(), r.getIcon())));
+    }
+    return i;
+  }
+
   @Override public List<Resource> listResources(){ return new ArrayList<>(resources.values()); }
-  @Override public Resource saveResource(Resource r){ if(r.getId()==null) r.setId(UUID.randomUUID()); resources.put(r.getId(), r); return r; }
+  @Override public Resource saveResource(Resource r){
+    if(r.getId()==null) r.setId(UUID.randomUUID());
+    resources.put(r.getId(), r);
+    return r;
+  }
   @Override public void deleteResource(UUID id){ resources.remove(id); }
   @Override public List<ResourceType> listResourceTypes(){ return new ArrayList<>(resourceTypes); }
   @Override public List<Unavailability> listResourceUnavailabilities(UUID resourceId){
@@ -104,7 +120,17 @@ public class MockPlanningService implements PlanningService {
     list.sort(Comparator.comparing(Intervention::getResourceId).thenComparing(Intervention::getDateDebut));
     return list;
   }
-  @Override public Intervention saveIntervention(Intervention i){ if(i.getId()==null) i.setId(UUID.randomUUID()); interventions.put(i.getId(), i); return i; }
+  @Override public Intervention saveIntervention(Intervention i){
+    if(i.getId()==null) i.setId(UUID.randomUUID());
+    if (i.getResourceId()!=null && i.getResources().isEmpty()){
+      Resource r = resources.get(i.getResourceId());
+      if (r!=null){
+        i.setResources(List.of(new ResourceRef(r.getId(), r.getName(), r.getIcon())));
+      }
+    }
+    interventions.put(i.getId(), i);
+    return i;
+  }
   @Override public void deleteIntervention(UUID id){ interventions.remove(id); }
 
   @Override public List<Conflict> listConflicts(LocalDate from, LocalDate to){
@@ -143,6 +169,12 @@ public class MockPlanningService implements PlanningService {
       if (overlap) return false;
     }
     i.setResourceId(resourceId);
+    Resource target = resources.get(resourceId);
+    if (target!=null){
+      i.setResources(List.of(new ResourceRef(target.getId(), target.getName(), target.getIcon())));
+    } else {
+      i.setResources(List.of());
+    }
     return true;
   }
   @Override public boolean resolveSplit(UUID id, LocalDateTime splitAt){
@@ -151,6 +183,7 @@ public class MockPlanningService implements PlanningService {
     if (!splitAt.isAfter(i.getDateHeureDebut()) || !i.getDateHeureFin().isAfter(splitAt)) return false;
     Intervention tail = new Intervention(UUID.randomUUID(), i.getResourceId(), i.getLabel()+" (suite)",
         splitAt.toLocalDate(), i.getDateHeureFin().toLocalDate(), i.getColor());
+    tail.setResources(i.getResources());
     tail.setDateHeureDebut(splitAt);
     tail.setDateHeureFin(i.getDateHeureFin());
     interventions.put(tail.getId(), tail);

--- a/client/src/main/java/com/materiel/suite/client/ui/commands/MoveResizeInterventionCommand.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/commands/MoveResizeInterventionCommand.java
@@ -1,15 +1,20 @@
 package com.materiel.suite.client.ui.commands;
 
 import com.materiel.suite.client.model.Intervention;
+import com.materiel.suite.client.model.ResourceRef;
 import com.materiel.suite.client.net.ServiceFactory;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.UUID;
 
 public class MoveResizeInterventionCommand implements Command {
   private final UUID id;
   private final UUID oldRes, newRes;
   private final LocalDateTime oldStart, oldEnd, newStart, newEnd;
+  private final List<ResourceRef> beforeResources;
+  private final List<ResourceRef> afterResources;
 
   public MoveResizeInterventionCommand(Intervention target,
                                        UUID newRes,
@@ -22,31 +27,47 @@ public class MoveResizeInterventionCommand implements Command {
     this.newRes = newRes;
     this.newStart = newStart;
     this.newEnd = newEnd;
+    this.beforeResources = cloneResources(target.getResources());
+    this.afterResources = adjustResources(beforeResources, newRes);
   }
 
   @Override public void execute(){
-    var it = find();
-    it.setResourceId(newRes);
-    it.setDateHeureDebut(newStart);
-    it.setDateHeureFin(newEnd);
+    var it = skeleton(newRes, newStart, newEnd, afterResources);
     ServiceFactory.planning().saveIntervention(it);
   }
 
   @Override public void undo(){
-    var it = find();
-    it.setResourceId(oldRes);
-    it.setDateHeureDebut(oldStart);
-    it.setDateHeureFin(oldEnd);
+    var it = skeleton(oldRes, oldStart, oldEnd, beforeResources);
     ServiceFactory.planning().saveIntervention(it);
   }
 
-  private Intervention find(){
-    // sans repo local, on reconstitue un squelette mutable
+  private Intervention skeleton(UUID resId, LocalDateTime start, LocalDateTime end, List<ResourceRef> resources){
     var it = new Intervention();
     it.setId(id);
-    it.setResourceId(newRes);
-    it.setDateHeureDebut(newStart);
-    it.setDateHeureFin(newEnd);
+    it.setResources(resources);
+    it.setResourceId(resId);
+    it.setDateHeureDebut(start);
+    it.setDateHeureFin(end);
     return it;
+  }
+
+  private List<ResourceRef> cloneResources(List<ResourceRef> list){
+    if (list==null || list.isEmpty()) return List.of();
+    return list.stream()
+        .map(r -> new ResourceRef(r.getId(), r.getName(), r.getIcon()))
+        .collect(Collectors.toList());
+  }
+
+  private List<ResourceRef> adjustResources(List<ResourceRef> base, UUID resourceId){
+    List<ResourceRef> copy = cloneResources(base);
+    if (resourceId==null){
+      return copy;
+    }
+    if (copy.isEmpty()){
+      return List.of(new ResourceRef(resourceId, null, null));
+    }
+    ResourceRef first = copy.get(0);
+    copy.set(0, new ResourceRef(resourceId, first.getName(), first.getIcon()));
+    return copy;
   }
 }

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionIconPainter.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionIconPainter.java
@@ -1,0 +1,30 @@
+package com.materiel.suite.client.ui.planning;
+
+import com.materiel.suite.client.model.ResourceRef;
+
+import java.awt.*;
+import java.util.List;
+
+/** Utilitaire de rendu pour afficher une série d'icônes de ressources sur une intervention. */
+public final class InterventionIconPainter {
+  private InterventionIconPainter(){}
+
+  public static void paintIcons(Graphics2D g2, Rectangle bounds, List<ResourceRef> resources){
+    if (resources==null || resources.isEmpty()) return;
+    Font old = g2.getFont();
+    float size = Math.max(10f, Math.min(bounds.height * 0.6f, 14f));
+    g2.setFont(old.deriveFont(size));
+    int pad = 6;
+    int x = bounds.x + pad;
+    int baseline = bounds.y + bounds.height - pad;
+    for (ResourceRef ref : resources){
+      if (ref==null) continue;
+      String icon = ref.getIcon();
+      if (icon==null || icon.isBlank()) icon = "🏷️";
+      g2.drawString(icon, x, baseline);
+      x += g2.getFontMetrics().stringWidth(icon) + 6;
+      if (x > bounds.x + bounds.width - 10) break;
+    }
+    g2.setFont(old);
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionTileRenderer.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionTileRenderer.java
@@ -264,6 +264,8 @@ final class InterventionTileRenderer {
       case LG -> Integer.MAX_VALUE;
     };
     paintChipsWrapped(g2, it, x, y, r.width - 2*PAD, allow);
+    Rectangle iconZone = new Rectangle(r.x + PAD, r.y + r.height - 20, r.width - 2*PAD, 16);
+    InterventionIconPainter.paintIcons(g2, iconZone, it.getResources());
   }
 
   /* Helpers de rendu */

--- a/client/src/main/java/com/materiel/suite/client/ui/resources/ResourceEditDialog.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/resources/ResourceEditDialog.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 public class ResourceEditDialog extends JDialog {
   private final JTextField nameField = new JTextField(24);
   private final JTextField colorField = new JTextField(8);
+  private final ResourceIconPicker iconPicker = new ResourceIconPicker();
   private final JTextArea notesArea = new JTextArea(5, 30);
   private final JComboBox<ResourceType> typeCombo = new JComboBox<>();
   private final JSpinner capacitySpinner = new JSpinner(new SpinnerNumberModel(1, 1, 999, 1));
@@ -59,6 +60,8 @@ public class ResourceEditDialog extends JDialog {
     gc.gridx = 1; form.add(nameField, gc);
     gc.gridx = 0; gc.gridy++; form.add(new JLabel("Type"), gc);
     gc.gridx = 1; form.add(typeCombo, gc);
+    gc.gridx = 0; gc.gridy++; form.add(new JLabel("Icône"), gc);
+    gc.gridx = 1; form.add(iconPicker, gc);
     gc.gridx = 0; gc.gridy++; form.add(new JLabel("Couleur (hex)"), gc);
     gc.gridx = 1; form.add(colorField, gc);
     gc.gridx = 0; gc.gridy++; gc.anchor = GridBagConstraints.NORTHWEST; form.add(new JLabel("Notes"), gc);
@@ -124,6 +127,7 @@ public class ResourceEditDialog extends JDialog {
     } else {
       typeCombo.setSelectedItem(null);
     }
+    iconPicker.setValue(resource.getIcon());
     // === CRM-INJECT BEGIN: resource-editor-advanced-save ===
     Integer cap = resource.getCapacity();
     if (cap==null || cap<1) cap = 1;
@@ -208,6 +212,7 @@ public class ResourceEditDialog extends JDialog {
     resource.setNotes(notesArea.getText());
     ResourceType selectedType = resolveType();
     resource.setType(selectedType);
+    resource.setIcon(iconPicker.getValue());
     // === CRM-INJECT BEGIN: resource-editor-advanced-save ===
     Object capVal = capacitySpinner.getValue();
     int cap = 1;

--- a/client/src/main/java/com/materiel/suite/client/ui/resources/ResourceIconPicker.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/resources/ResourceIconPicker.java
@@ -1,0 +1,61 @@
+package com.materiel.suite.client.ui.resources;
+
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import java.awt.*;
+import java.util.Arrays;
+import java.util.List;
+
+/** Sélecteur simple pour associer une icône (emoji ou caractère) à une ressource. */
+public class ResourceIconPicker extends JPanel {
+  private static final List<String> PALETTE = Arrays.asList(
+      "🏗️", "🚚", "🚛", "👷", "🧰", "🛠️", "🔧", "🔩", "⚙️", "🏷️"
+  );
+
+  private final JTextField custom = new JTextField(4);
+  private String value;
+
+  public ResourceIconPicker(){
+    super(new FlowLayout(FlowLayout.LEFT, 4, 0));
+    setOpaque(false);
+    ButtonGroup group = new ButtonGroup();
+    for (String icon : PALETTE){
+      JToggleButton toggle = new JToggleButton(icon);
+      toggle.setMargin(new Insets(2,6,2,6));
+      toggle.addActionListener(e -> {
+        value = icon;
+        custom.setText("");
+      });
+      group.add(toggle);
+      add(toggle);
+    }
+    custom.setColumns(4);
+    custom.setToolTipText("Saisir un caractère ou emoji personnalisé");
+    custom.getDocument().addDocumentListener(new DocumentListener() {
+      private void sync(){ value = custom.getText(); }
+      @Override public void insertUpdate(DocumentEvent e){ sync(); }
+      @Override public void removeUpdate(DocumentEvent e){ sync(); }
+      @Override public void changedUpdate(DocumentEvent e){ sync(); }
+    });
+    add(new JLabel("Perso :"));
+    add(custom);
+  }
+
+  public void setValue(String v){
+    value = v;
+    boolean match = v!=null && PALETTE.contains(v);
+    for (Component c : getComponents()){
+      if (c instanceof JToggleButton btn){
+        btn.setSelected(match && btn.getText().equals(v));
+      }
+    }
+    custom.setText(!match && v!=null? v : "");
+  }
+
+  public String getValue(){
+    if (value!=null && !value.isBlank()) return value;
+    String txt = custom.getText();
+    return txt==null? "" : txt.trim();
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/resources/ResourcesPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/resources/ResourcesPanel.java
@@ -64,7 +64,7 @@ public class ResourcesPanel extends JPanel {
   }
   private static class ResourceModel extends AbstractTableModel {
     List<Resource> items = new ArrayList<>();
-    String[] cols = {"Nom", "Type", "Couleur", "Notes"
+    String[] cols = {"Nom", "Icône", "Type", "Couleur", "Notes"
         // === CRM-INJECT BEGIN: resource-table-advanced-cols ===
         , "Capacité", "Tags", "Indispos hebdo"
         // === CRM-INJECT END ===
@@ -76,13 +76,14 @@ public class ResourcesPanel extends JPanel {
       Resource x = items.get(r);
       return switch(c){
         case 0 -> x.getName();
-        case 1 -> typeLabel(x);
-        case 2 -> x.getColor();
-        case 3 -> x.getNotes();
+        case 1 -> x.getIcon();
+        case 2 -> typeLabel(x);
+        case 3 -> x.getColor();
+        case 4 -> x.getNotes();
         // === CRM-INJECT BEGIN: resource-table-advanced-values ===
-        case 4 -> x.getCapacity();
-        case 5 -> x.getTags();
-        case 6 -> x.getWeeklyUnavailability();
+        case 5 -> x.getCapacity();
+        case 6 -> x.getTags();
+        case 7 -> x.getWeeklyUnavailability();
         // === CRM-INJECT END ===
         default -> "";
       };


### PR DESCRIPTION
## Summary
- add an icon attribute to resources with picker UI and list display updates
- introduce lightweight ResourceRef models to support multi-resource assignments and icon rendering in planning views
- propagate icons and resource references through API services, backend DTOs, and OpenAPI documentation

## Testing
- mvn -pl client -am -DskipTests package *(fails: network unreachable downloading spring-boot-dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c9406434148330acd6ab68ac28b4c9