### PR TITLE
feat(client): add collapsible sidebar navigation

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/ui/MainFrame.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/MainFrame.java
@@ -13,16 +13,21 @@ import com.materiel.suite.client.ui.resources.ResourcesPanel;
 import com.materiel.suite.client.ui.crm.ClientsPanel;
 import com.materiel.suite.client.ui.theme.ThemeManager;
 import com.materiel.suite.client.ui.commands.CommandBus;
+import com.materiel.suite.client.ui.shell.CollapsibleSidebar;
+import com.materiel.suite.client.ui.shell.SidebarButton;
 
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 public class MainFrame extends JFrame {
   private final CardLayout cards = new CardLayout();
   private final JPanel center = new JPanel(cards);
   private final JLabel status = new JLabel("Prêt.");
   private javax.swing.Timer syncTimer;
+  private final Map<String, SidebarButton> navButtons = new LinkedHashMap<>();
 
   public MainFrame(AppConfig cfg) {
     super("Gestion Matériel — Suite");
@@ -46,7 +51,7 @@ public class MainFrame extends JFrame {
     center.add(new ResourcesPanel(), "resources");
     center.add(new ClientsPanel(), "clients");
 
-    cards.show(center, "quotes");
+    openCard("quotes");
 
     if (ServiceFactory.http()!=null){
       SyncService sync = new SyncService(ServiceFactory.http());
@@ -89,39 +94,27 @@ public class MainFrame extends JFrame {
   }
 
   private JComponent buildSidebar() {
-    JPanel side = new JPanel();
-    side.setLayout(new BoxLayout(side, BoxLayout.Y_AXIS));
-    side.setBorder(new EmptyBorder(8,8,8,8));
-    side.setPreferredSize(new Dimension(220, 0));
-    side.add(navButton("Planning", "planning"));
-    side.add(Box.createVerticalStrut(6));
-    side.add(navButton("Agenda", "agenda"));
-    side.add(Box.createVerticalStrut(6));
-    side.add(navButton("Devis", "quotes"));
-    side.add(Box.createVerticalStrut(6));
-    side.add(navButton("Commandes", "orders"));
-    side.add(Box.createVerticalStrut(6));
-    side.add(navButton("Bons de livraison", "delivery"));
-    side.add(Box.createVerticalStrut(6));
-    side.add(navButton("Factures", "invoices"));
-    side.add(Box.createVerticalStrut(6));
-    side.add(navButton("Clients", "clients"));
-    side.add(Box.createVerticalStrut(6));
-    side.add(navButton("Ressources", "resources"));
-    side.add(Box.createVerticalGlue());
+    CollapsibleSidebar side = new CollapsibleSidebar();
+    addSidebarItem(side, "planning", "🗓", "Planning");
+    addSidebarItem(side, "agenda", "📒", "Agenda");
+    addSidebarItem(side, "quotes", "🧾", "Devis");
+    addSidebarItem(side, "orders", "📦", "Commandes");
+    addSidebarItem(side, "delivery", "🚚", "Bons de livraison");
+    addSidebarItem(side, "invoices", "💶", "Factures");
+    addSidebarItem(side, "clients", "👥", "Clients");
+    addSidebarItem(side, "resources", "🏷️", "Ressources");
     return side;
   }
 
-  private JButton navButton(String label, String card) {
-    JButton b = new JButton(label);
-    b.putClientProperty("JButton.buttonType", "roundRect");
-    b.addActionListener(e -> cards.show(center, card));
-    return b;
+  private void addSidebarItem(CollapsibleSidebar side, String card, String icon, String label) {
+    SidebarButton button = side.addItem(icon, label, () -> openCard(card));
+    navButtons.put(card, button);
   }
 
   /** Navigation inter-panneaux depuis menus contextuels */
   public void openCard(String key){
     cards.show(center, key);
+    navButtons.forEach((card, button) -> button.setActive(card.equals(key)));
   }
 }
 

--- a/client/src/main/java/com/materiel/suite/client/ui/shell/CollapsibleSidebar.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/shell/CollapsibleSidebar.java
@@ -1,0 +1,108 @@
+package com.materiel.suite.client.ui.shell;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Barre latérale rétractable : au repos = icônes seules ; en survol = icône + libellé.
+ */
+public class CollapsibleSidebar extends JPanel {
+  public static final int COLLAPSED_WIDTH = 56;
+  public static final int EXPANDED_WIDTH = 220;
+
+  private boolean expanded = false;
+  private final JPanel itemsPanel = new JPanel();
+  private final List<SidebarButton> buttons = new ArrayList<>();
+  private final Timer collapseTimer;
+
+  public CollapsibleSidebar() {
+    super(new BorderLayout());
+    setBackground(new Color(245, 245, 245));
+    setBorder(BorderFactory.createMatteBorder(0, 0, 0, 1, new Color(220, 220, 220)));
+
+    itemsPanel.setOpaque(false);
+    itemsPanel.setLayout(new BoxLayout(itemsPanel, BoxLayout.Y_AXIS));
+    itemsPanel.setBorder(BorderFactory.createEmptyBorder(8, 6, 8, 6));
+
+    JScrollPane scroll = new JScrollPane(itemsPanel);
+    scroll.setBorder(BorderFactory.createEmptyBorder());
+    scroll.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+    scroll.setOpaque(false);
+    scroll.getViewport().setOpaque(false);
+    scroll.getVerticalScrollBar().setUnitIncrement(12);
+    add(scroll, BorderLayout.CENTER);
+
+    setPreferredSize(new Dimension(COLLAPSED_WIDTH, 0));
+
+    MouseAdapter hover = new MouseAdapter() {
+      @Override
+      public void mouseEntered(MouseEvent e) {
+        setExpanded(true);
+      }
+
+      @Override
+      public void mouseExited(MouseEvent e) {
+        scheduleCollapse();
+      }
+    };
+    addMouseListener(hover);
+    addMouseMotionListener(hover);
+    itemsPanel.addMouseListener(hover);
+    itemsPanel.addMouseMotionListener(hover);
+
+    collapseTimer = new Timer(220, ev -> {
+      if (!isMouseInside()) {
+        setExpanded(false);
+      }
+    });
+    collapseTimer.setRepeats(false);
+  }
+
+  private boolean isMouseInside() {
+    Point p = getMousePosition();
+    return p != null && p.x >= 0 && p.x < getWidth() && p.y >= 0 && p.y < getHeight();
+  }
+
+  private void scheduleCollapse() {
+    collapseTimer.restart();
+  }
+
+  public void setExpanded(boolean expanded) {
+    if (this.expanded == expanded) {
+      return;
+    }
+    this.expanded = expanded;
+    for (SidebarButton b : buttons) {
+      b.setExpanded(expanded);
+    }
+    setPreferredSize(new Dimension(expanded ? EXPANDED_WIDTH : COLLAPSED_WIDTH, getHeight()));
+    revalidate();
+    repaint();
+  }
+
+  /** Ajoute un bouton avec une icône (emoji/char) et un libellé. */
+  public SidebarButton addItem(String iconText, String label, Runnable action) {
+    SidebarButton button = new SidebarButton(iconText, label, action);
+    buttons.add(button);
+    itemsPanel.add(button);
+    itemsPanel.add(Box.createVerticalStrut(4));
+    MouseAdapter hover = new MouseAdapter() {
+      @Override
+      public void mouseEntered(MouseEvent e) {
+        setExpanded(true);
+      }
+
+      @Override
+      public void mouseExited(MouseEvent e) {
+        scheduleCollapse();
+      }
+    };
+    button.addMouseListener(hover);
+    button.addMouseMotionListener(hover);
+    return button;
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/shell/SidebarButton.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/shell/SidebarButton.java
@@ -1,0 +1,108 @@
+package com.materiel.suite.client.ui.shell;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+/** Élément cliquable de la barre latérale, rend icône + texte quand expanded=true. */
+public class SidebarButton extends JPanel {
+  private static final Color BASE_COLOR = new Color(245, 245, 245);
+  private static final Color HOVER_COLOR = new Color(230, 240, 255);
+  private static final Color PRESSED_COLOR = new Color(210, 230, 255);
+  private static final Color ACTIVE_COLOR = new Color(212, 232, 255);
+  private final JLabel icon = new JLabel();
+  private final JLabel text = new JLabel();
+  private final Runnable action;
+  private boolean hovered = false;
+  private boolean pressed = false;
+  private boolean active = false;
+
+  public SidebarButton(String iconText, String label, Runnable action) {
+    super(new BorderLayout());
+    this.action = action;
+    setOpaque(true);
+    setBackground(BASE_COLOR);
+    setBorder(BorderFactory.createEmptyBorder(8, 12, 8, 12));
+    setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+
+    icon.setText(iconText);
+    icon.setHorizontalAlignment(SwingConstants.CENTER);
+    icon.setFont(icon.getFont().deriveFont(16f));
+    icon.setPreferredSize(new Dimension(28, 24));
+
+    text.setText(label);
+    text.setFont(text.getFont().deriveFont(Font.PLAIN, 13f));
+
+    JPanel line = new JPanel();
+    line.setOpaque(false);
+    line.setLayout(new BoxLayout(line, BoxLayout.X_AXIS));
+    line.add(icon);
+    line.add(Box.createHorizontalStrut(10));
+    line.add(text);
+    line.add(Box.createHorizontalGlue());
+    add(line, BorderLayout.CENTER);
+
+    setExpanded(false);
+
+    MouseAdapter ma = new MouseAdapter() {
+      @Override
+      public void mouseEntered(MouseEvent e) {
+        hovered = true;
+        refreshBackground();
+      }
+
+      @Override
+      public void mouseExited(MouseEvent e) {
+        hovered = false;
+        refreshBackground();
+      }
+
+      @Override
+      public void mousePressed(MouseEvent e) {
+        pressed = true;
+        refreshBackground();
+      }
+
+      @Override
+      public void mouseReleased(MouseEvent e) {
+        if (pressed && contains(e.getPoint())) {
+          if (action != null) {
+            action.run();
+          }
+        }
+        pressed = false;
+        refreshBackground();
+      }
+    };
+    addMouseListener(ma);
+    addMouseMotionListener(ma);
+    icon.addMouseListener(ma);
+    icon.addMouseMotionListener(ma);
+    text.addMouseListener(ma);
+    text.addMouseMotionListener(ma);
+  }
+
+  public void setExpanded(boolean expanded) {
+    text.setVisible(expanded);
+    revalidate();
+    repaint();
+  }
+
+  public void setActive(boolean active) {
+    this.active = active;
+    refreshBackground();
+  }
+
+  private void refreshBackground() {
+    if (pressed) {
+      setBackground(PRESSED_COLOR);
+    } else if (hovered) {
+      setBackground(active ? PRESSED_COLOR : HOVER_COLOR);
+    } else if (active) {
+      setBackground(ACTIVE_COLOR);
+    } else {
+      setBackground(BASE_COLOR);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- replace the fixed list of navigation buttons with a new collapsible sidebar that expands on hover and highlights the active view
- add a dedicated SidebarButton component to render icon + label pairs with hover, press and selection states
- wire the sidebar into MainFrame so that selecting a destination updates both the card layout and the active button state

## Testing
- `mvn -pl client -am test` *(fails: network unreachable while resolving Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c94db3fb248330b6dbc1fc0a91cef9