### PR TITLE
Improve mock document services to share seeded data

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/service/mock/MockData.java
+++ b/client/src/main/java/com/materiel/suite/client/service/mock/MockData.java
@@ -29,11 +29,31 @@ public final class MockData {
     q2.getLines().add(new DocumentLine("Levage charpente", 1, "forfait", 1800, 5, 20));
     q2.recomputeTotals();
     QUOTES.add(q2);
+
+    ORDERS.add(fromQuote(q1));
+    DELIVERY_NOTES.add(fromOrder(ORDERS.get(0)));
+    INVOICES.add(fromQuoteToInvoice(q2));
   }
 
   static String nextNumber(String prefix, AtomicInteger seq){
     int n = seq.getAndIncrement();
     return "%s-%d-%05d".formatted(prefix, LocalDate.now().getYear(), n);
+  }
+
+  static String nextQuoteNumber(){
+    return nextNumber("DEV", seqQuote);
+  }
+
+  static String nextOrderNumber(){
+    return nextNumber("CMD", seqOrder);
+  }
+
+  static String nextDeliveryNumber(){
+    return nextNumber("BL", seqDN);
+  }
+
+  static String nextInvoiceNumber(){
+    return nextNumber("FAC", seqInv);
   }
 
   public static <T> T findById(List<T> list, UUID id){

--- a/client/src/main/java/com/materiel/suite/client/service/mock/MockInvoiceService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/mock/MockInvoiceService.java
@@ -1,39 +1,52 @@
 package com.materiel.suite.client.service.mock;
 
+import com.materiel.suite.client.model.DeliveryNote;
 import com.materiel.suite.client.model.Invoice;
+import com.materiel.suite.client.model.Quote;
 import com.materiel.suite.client.service.InvoiceService;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 public class MockInvoiceService implements InvoiceService {
-  private final Map<UUID, Invoice> store = new LinkedHashMap<>();
-
-  @Override public List<Invoice> list(){ return new ArrayList<>(store.values()); }
-  @Override public Invoice get(UUID id){ return store.get(id); }
+  @Override public List<Invoice> list(){ return new ArrayList<>(MockData.INVOICES); }
+  @Override public Invoice get(UUID id){ return MockData.findById(MockData.INVOICES, id); }
   @Override public Invoice save(Invoice i){
     if (i.getId()==null) i.setId(UUID.randomUUID());
-    store.put(i.getId(), i); return i;
+    if (i.getNumber()==null || i.getNumber().isBlank()){
+      i.setNumber(MockData.nextInvoiceNumber());
+    }
+    i.recomputeTotals();
+    replaceOrAdd(i);
+    return i;
   }
-  @Override public void delete(UUID id){ store.remove(id); }
+  @Override public void delete(UUID id){ MockData.INVOICES.removeIf(inv -> inv.getId().equals(id)); }
 
   @Override public Invoice createFromQuote(UUID quoteId){
-    Invoice i = new Invoice();
-    i.setId(UUID.randomUUID());
-    i.setNumber("FA-" + String.format("%06d", store.size()+1));
-    i.setCustomerName("Client depuis devis " + quoteId.toString().substring(0,8));
-    i.setLines(new ArrayList<>());
-    save(i);
-    return i;
+    Quote q = MockData.findById(MockData.QUOTES, quoteId);
+    if (q==null) return null;
+    return save(MockData.fromQuoteToInvoice(q));
   }
 
   @Override public Invoice createFromDeliveryNotes(List<UUID> deliveryNoteIds){
-    Invoice i = new Invoice();
-    i.setId(UUID.randomUUID());
-    i.setNumber("FA-" + String.format("%06d", store.size()+1));
-    i.setCustomerName("Client depuis " + deliveryNoteIds.size() + " BL");
-    i.setLines(new ArrayList<>());
-    save(i);
-    return i;
+    List<DeliveryNote> dns = new ArrayList<>();
+    for (UUID id : deliveryNoteIds){
+      DeliveryNote dn = MockData.findById(MockData.DELIVERY_NOTES, id);
+      if (dn!=null) dns.add(dn);
+    }
+    if (dns.isEmpty()) return null;
+    return save(MockData.fromDeliveryNotes(dns));
+  }
+
+  private void replaceOrAdd(Invoice inv){
+    for (int i=0; i<MockData.INVOICES.size(); i++){
+      if (MockData.INVOICES.get(i).getId().equals(inv.getId())){
+        MockData.INVOICES.set(i, inv);
+        return;
+      }
+    }
+    MockData.INVOICES.add(inv);
   }
 }
 

--- a/client/src/main/java/com/materiel/suite/client/service/mock/MockOrderService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/mock/MockOrderService.java
@@ -1,30 +1,41 @@
 package com.materiel.suite.client.service.mock;
 
 import com.materiel.suite.client.model.Order;
+import com.materiel.suite.client.model.Quote;
 import com.materiel.suite.client.service.OrderService;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 public class MockOrderService implements OrderService {
-  private final Map<UUID, Order> store = new LinkedHashMap<>();
-
-  @Override public List<Order> list(){ return new ArrayList<>(store.values()); }
-  @Override public Order get(UUID id){ return store.get(id); }
+  @Override public List<Order> list(){ return new ArrayList<>(MockData.ORDERS); }
+  @Override public Order get(UUID id){ return MockData.findById(MockData.ORDERS, id); }
   @Override public Order save(Order o){
     if (o.getId()==null) o.setId(UUID.randomUUID());
-    store.put(o.getId(), o); return o;
+    if (o.getNumber()==null || o.getNumber().isBlank()){
+      o.setNumber(MockData.nextOrderNumber());
+    }
+    o.recomputeTotals();
+    replaceOrAdd(o);
+    return o;
   }
-  @Override public void delete(UUID id){ store.remove(id); }
+  @Override public void delete(UUID id){ MockData.ORDERS.removeIf(o -> o.getId().equals(id)); }
 
   @Override public Order createFromQuote(UUID quoteId){
-    // Mock: duplique une commande depuis un "quote" présent déjà en Order pour demo
-    Order o = new Order();
-    o.setId(UUID.randomUUID());
-    o.setNumber("BC-" + String.format("%06d", store.size()+1));
-    o.setCustomerName("Client depuis devis " + quoteId.toString().substring(0,8));
-    o.setLines(new ArrayList<>());
-    save(o);
-    return o;
+    Quote q = MockData.findById(MockData.QUOTES, quoteId);
+    if (q==null) return null;
+    return save(MockData.fromQuote(q));
+  }
+
+  private void replaceOrAdd(Order o){
+    for (int i=0; i<MockData.ORDERS.size(); i++){
+      if (MockData.ORDERS.get(i).getId().equals(o.getId())){
+        MockData.ORDERS.set(i, o);
+        return;
+      }
+    }
+    MockData.ORDERS.add(o);
   }
 }
 

--- a/client/src/main/java/com/materiel/suite/client/service/mock/MockQuoteService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/mock/MockQuoteService.java
@@ -12,7 +12,7 @@ public class MockQuoteService implements QuoteService {
   @Override public Quote save(Quote q){
     if (q.getId()==null){ q.setId(UUID.randomUUID()); }
     if (q.getNumber()==null || q.getNumber().isBlank()){
-      q.setNumber(MockData.nextNumber("DEV", new java.util.concurrent.atomic.AtomicInteger(MockData.QUOTES.size()+1)));
+      q.setNumber(MockData.nextQuoteNumber());
     }
     q.recomputeTotals();
     var existing = get(q.getId());


### PR DESCRIPTION
## Summary
- seed the mock store with initial orders, delivery notes and invoices derived from seeded quotes
- expose dedicated document number generators so every mock service uses the same sequences
- rework mock order, delivery note and invoice services to read/write from MockData and clone data from existing documents

## Testing
- mvn -q -pl client test *(fails: cannot download spring-boot dependencies because the Maven central repository is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c95fb60f2c8330a91e1d1ab2134934