### PR TITLE
Align totals casing with client expectations

### DIFF
--- a/backend/src/main/java/com/materiel/suite/backend/model/Order.java
+++ b/backend/src/main/java/com/materiel/suite/backend/model/Order.java
@@ -17,7 +17,7 @@ public class Order {
     private List<DocumentLine> lines = new ArrayList<>();
     private BigDecimal totalHT = BigDecimal.ZERO;
     private BigDecimal totalTVA = BigDecimal.ZERO;
-    private BigDecimal totalTTC = BigDecimal.ZERO;
+    private BigDecimal totalTtc = BigDecimal.ZERO;
 
     public UUID getId() { return id; }
     public void setId(UUID id) { this.id = id; }
@@ -39,7 +39,7 @@ public class Order {
     public void setTotalHT(BigDecimal totalHT) { this.totalHT = totalHT; }
     public BigDecimal getTotalTVA() { return totalTVA; }
     public void setTotalTVA(BigDecimal totalTVA) { this.totalTVA = totalTVA; }
-    public BigDecimal getTotalTTC() { return totalTTC; }
-    public void setTotalTTC(BigDecimal totalTTC) { this.totalTTC = totalTTC; }
+    public BigDecimal getTotalTtc() { return totalTtc; }
+    public void setTotalTtc(BigDecimal totalTtc) { this.totalTtc = totalTtc; }
 }
 

--- a/backend/src/main/java/com/materiel/suite/backend/model/Quote.java
+++ b/backend/src/main/java/com/materiel/suite/backend/model/Quote.java
@@ -17,7 +17,7 @@ public class Quote {
     private List<DocumentLine> lines = new ArrayList<>();
     private BigDecimal totalHT = BigDecimal.ZERO;
     private BigDecimal totalTVA = BigDecimal.ZERO;
-    private BigDecimal totalTTC = BigDecimal.ZERO;
+    private BigDecimal totalTtc = BigDecimal.ZERO;
 
     // getters and setters
     public UUID getId() { return id; }
@@ -40,6 +40,6 @@ public class Quote {
     public void setTotalHT(BigDecimal totalHT) { this.totalHT = totalHT; }
     public BigDecimal getTotalTVA() { return totalTVA; }
     public void setTotalTVA(BigDecimal totalTVA) { this.totalTVA = totalTVA; }
-    public BigDecimal getTotalTTC() { return totalTTC; }
-    public void setTotalTTC(BigDecimal totalTTC) { this.totalTTC = totalTTC; }
+    public BigDecimal getTotalTtc() { return totalTtc; }
+    public void setTotalTtc(BigDecimal totalTtc) { this.totalTtc = totalTtc; }
 }

--- a/backend/src/main/java/com/materiel/suite/backend/service/TotalsService.java
+++ b/backend/src/main/java/com/materiel/suite/backend/service/TotalsService.java
@@ -19,10 +19,10 @@ public class TotalsService {
         }
         quote.setTotalHT(totalHT);
         quote.setTotalTVA(totalTVA);
-        quote.setTotalTTC(totalHT.add(totalTVA));
+        quote.setTotalTtc(totalHT.add(totalTVA));
     }
 
-	public void computeTotals(Order order) {
+    public void computeTotals(Order order) {
         BigDecimal totalHT = BigDecimal.ZERO;
         BigDecimal totalTVA = BigDecimal.ZERO;
         for (DocumentLine l : order.getLines()) {
@@ -31,7 +31,7 @@ public class TotalsService {
         }
         order.setTotalHT(totalHT);
         order.setTotalTVA(totalTVA);
-        order.setTotalTTC(totalHT.add(totalTVA));
+        order.setTotalTtc(totalHT.add(totalTVA));
     }
-		
+
 }


### PR DESCRIPTION
## Summary
- rename the quote/order total fields to expose `totalTtc` through Jackson instead of `totalTTC`
- adjust the totals service to use the new accessors and keep formatting consistent

## Testing
- mvn -pl backend test *(fails: network is unreachable while downloading org.springframework.boot:spring-boot-dependencies:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68c964c1cb40833098f5f1a6852a3949