### PR TITLE
Fix JSON property casing for totals

### DIFF
--- a/backend/src/main/java/com/materiel/suite/backend/model/Order.java
+++ b/backend/src/main/java/com/materiel/suite/backend/model/Order.java
@@ -1,5 +1,7 @@
 package com.materiel.suite.backend.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -39,7 +41,9 @@ public class Order {
     public void setTotalHT(BigDecimal totalHT) { this.totalHT = totalHT; }
     public BigDecimal getTotalTVA() { return totalTVA; }
     public void setTotalTVA(BigDecimal totalTVA) { this.totalTVA = totalTVA; }
+    @JsonProperty("totalTTC")
     public BigDecimal getTotalTtc() { return totalTtc; }
+    @JsonProperty("totalTTC")
     public void setTotalTtc(BigDecimal totalTtc) { this.totalTtc = totalTtc; }
 }
 

--- a/backend/src/main/java/com/materiel/suite/backend/model/Quote.java
+++ b/backend/src/main/java/com/materiel/suite/backend/model/Quote.java
@@ -1,5 +1,7 @@
 package com.materiel.suite.backend.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -40,6 +42,8 @@ public class Quote {
     public void setTotalHT(BigDecimal totalHT) { this.totalHT = totalHT; }
     public BigDecimal getTotalTVA() { return totalTVA; }
     public void setTotalTVA(BigDecimal totalTVA) { this.totalTVA = totalTVA; }
+    @JsonProperty("totalTTC")
     public BigDecimal getTotalTtc() { return totalTtc; }
+    @JsonProperty("totalTTC")
     public void setTotalTtc(BigDecimal totalTtc) { this.totalTtc = totalTtc; }
 }

--- a/backend/src/main/java/com/materiel/suite/backend/v1/domain/DeliveryNoteEntity.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/domain/DeliveryNoteEntity.java
@@ -1,5 +1,7 @@
 package com.materiel.suite.backend.v1.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import jakarta.persistence.*;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -40,7 +42,9 @@ public class DeliveryNoteEntity {
   public void setTotalHt(BigDecimal totalHt) { this.totalHt = totalHt; }
   public BigDecimal getTotalVat() { return totalVat; }
   public void setTotalVat(BigDecimal totalVat) { this.totalVat = totalVat; }
+  @JsonProperty("totalTTC")
   public BigDecimal getTotalTtc() { return totalTtc; }
+  @JsonProperty("totalTTC")
   public void setTotalTtc(BigDecimal totalTtc) { this.totalTtc = totalTtc; }
   public long getVersion() { return version; }
   public void setVersion(long version) { this.version = version; }

--- a/backend/src/main/java/com/materiel/suite/backend/v1/domain/InvoiceEntity.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/domain/InvoiceEntity.java
@@ -1,5 +1,7 @@
 package com.materiel.suite.backend.v1.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import jakarta.persistence.*;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -40,7 +42,9 @@ public class InvoiceEntity {
   public void setTotalHt(BigDecimal totalHt) { this.totalHt = totalHt; }
   public BigDecimal getTotalVat() { return totalVat; }
   public void setTotalVat(BigDecimal totalVat) { this.totalVat = totalVat; }
+  @JsonProperty("totalTTC")
   public BigDecimal getTotalTtc() { return totalTtc; }
+  @JsonProperty("totalTTC")
   public void setTotalTtc(BigDecimal totalTtc) { this.totalTtc = totalTtc; }
   public long getVersion() { return version; }
   public void setVersion(long version) { this.version = version; }

--- a/backend/src/main/java/com/materiel/suite/backend/v1/domain/OrderEntity.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/domain/OrderEntity.java
@@ -1,5 +1,7 @@
 package com.materiel.suite.backend.v1.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import jakarta.persistence.*;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -40,7 +42,9 @@ public class OrderEntity {
   public void setTotalHt(BigDecimal totalHt) { this.totalHt = totalHt; }
   public BigDecimal getTotalVat() { return totalVat; }
   public void setTotalVat(BigDecimal totalVat) { this.totalVat = totalVat; }
+  @JsonProperty("totalTTC")
   public BigDecimal getTotalTtc() { return totalTtc; }
+  @JsonProperty("totalTTC")
   public void setTotalTtc(BigDecimal totalTtc) { this.totalTtc = totalTtc; }
   public long getVersion() { return version; }
   public void setVersion(long version) { this.version = version; }

--- a/backend/src/main/java/com/materiel/suite/backend/v1/domain/Quote.java
+++ b/backend/src/main/java/com/materiel/suite/backend/v1/domain/Quote.java
@@ -1,5 +1,7 @@
 package com.materiel.suite.backend.v1.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -36,7 +38,9 @@ public class Quote {
   public void setTotalHt(BigDecimal totalHt) { this.totalHt = totalHt; }
   public BigDecimal getTotalVat() { return totalVat; }
   public void setTotalVat(BigDecimal totalVat) { this.totalVat = totalVat; }
+  @JsonProperty("totalTTC")
   public BigDecimal getTotalTtc() { return totalTtc; }
+  @JsonProperty("totalTTC")
   public void setTotalTtc(BigDecimal totalTtc) { this.totalTtc = totalTtc; }
   public long getVersion() { return version; }
   public void setVersion(long version) { this.version = version; }


### PR DESCRIPTION
## Summary
- ensure totals in Quote and Order models expose the JSON field `totalTTC`
- align v1 domain entities so delivery notes, orders, invoices, and quotes reuse the same casing

## Testing
- mvn -q -DskipTests install *(fails: unable to reach Maven Central from container)*

------
https://chatgpt.com/codex/tasks/task_e_68c97a0e07b08330b6c058130ed0e7a7