### PR TITLE
Affine la barre latérale du client

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/ui/shell/CollapsibleSidebar.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/shell/CollapsibleSidebar.java
@@ -11,8 +11,8 @@ import java.util.List;
  * Barre latérale rétractable : au repos = icônes seules ; en survol = icône + libellé.
  */
 public class CollapsibleSidebar extends JPanel {
-  public static final int COLLAPSED_WIDTH = 56;
-  public static final int EXPANDED_WIDTH = 220;
+  public static final int COLLAPSED_WIDTH = 48;
+  public static final int EXPANDED_WIDTH = 200;
 
   public enum PinMode { AUTO, PIN_EXPANDED, PIN_COLLAPSED }
 
@@ -23,7 +23,8 @@ public class CollapsibleSidebar extends JPanel {
   private final Timer collapseTimer;
   private final JToggleButton pinExpandToggle = new JToggleButton("📌");
   private final JToggleButton pinCompactToggle = new JToggleButton("📎");
-  private final JLabel titleLabel = new JLabel("  Menu");
+  private final JLabel titleLabel = new JLabel();
+  private String headerTitle = "Menu";
   private boolean adjustingPinToggle = false;
 
   public CollapsibleSidebar() {
@@ -81,7 +82,9 @@ public class CollapsibleSidebar extends JPanel {
     header.setOpaque(true);
     header.setBackground(getBackground());
     header.setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
-    titleLabel.setFont(titleLabel.getFont().deriveFont(Font.BOLD, 13f));
+    titleLabel.setFont(titleLabel.getFont().deriveFont(Font.BOLD, 12f));
+    titleLabel.setBorder(BorderFactory.createEmptyBorder(0, 2, 0, 0));
+    updateHeader();
     header.add(titleLabel, BorderLayout.WEST);
     JPanel pinPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 4, 0));
     pinPanel.setOpaque(false);
@@ -117,6 +120,7 @@ public class CollapsibleSidebar extends JPanel {
     for (SidebarButton b : buttons) {
       b.setExpanded(expanded);
     }
+    updateHeader();
     setPreferredSize(new Dimension(expanded ? EXPANDED_WIDTH : COLLAPSED_WIDTH, getHeight()));
     revalidate();
     repaint();
@@ -127,7 +131,7 @@ public class CollapsibleSidebar extends JPanel {
     SidebarButton button = new SidebarButton(iconText, label, action);
     buttons.add(button);
     itemsPanel.add(button);
-    itemsPanel.add(Box.createVerticalStrut(4));
+    itemsPanel.add(Box.createVerticalStrut(2));
     MouseAdapter hover = new MouseAdapter() {
       @Override
       public void mouseEntered(MouseEvent e) {
@@ -173,11 +177,12 @@ public class CollapsibleSidebar extends JPanel {
   }
 
   public void setTitle(String title) {
-    titleLabel.setText(title);
+    headerTitle = title;
+    updateHeader();
   }
 
   public String getTitle() {
-    return titleLabel.getText();
+    return headerTitle;
   }
 
   public void setPinMode(PinMode mode){
@@ -227,5 +232,17 @@ public class CollapsibleSidebar extends JPanel {
     } finally {
       adjustingPinToggle = false;
     }
+  }
+
+  private void updateHeader() {
+    String title = headerTitle;
+    boolean hasTitle = title != null && !title.isBlank();
+    String displayTitle = hasTitle ? title.strip() : "";
+    if (expanded && hasTitle) {
+      titleLabel.setText("  ☰  " + displayTitle);
+    } else {
+      titleLabel.setText("  ☰");
+    }
+    titleLabel.setToolTipText(expanded || displayTitle.isEmpty() ? null : displayTitle);
   }
 }

--- a/client/src/main/java/com/materiel/suite/client/ui/shell/SidebarButton.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/shell/SidebarButton.java
@@ -8,7 +8,7 @@ import java.awt.event.MouseEvent;
 /** Élément cliquable de la barre latérale, rend icône + texte quand expanded=true. */
 public class SidebarButton extends JPanel {
   private static final Color BASE_COLOR = new Color(245, 245, 245);
-  private static final Color HOVER_COLOR = new Color(230, 240, 255);
+  private static final Color HOVER_COLOR = new Color(234, 242, 255);
   private static final Color PRESSED_COLOR = new Color(210, 230, 255);
   private static final Color ACTIVE_COLOR = new Color(212, 232, 255);
   private final JLabel icon = new JLabel();
@@ -23,16 +23,16 @@ public class SidebarButton extends JPanel {
     this.action = action;
     setOpaque(true);
     setBackground(BASE_COLOR);
-    setBorder(BorderFactory.createEmptyBorder(8, 12, 8, 12));
+    setBorder(BorderFactory.createEmptyBorder(6, 10, 6, 10));
     setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 
     icon.setText(iconText);
     icon.setHorizontalAlignment(SwingConstants.CENTER);
-    icon.setFont(icon.getFont().deriveFont(16f));
-    icon.setPreferredSize(new Dimension(28, 24));
+    icon.setFont(icon.getFont().deriveFont(14f));
+    icon.setPreferredSize(new Dimension(24, 20));
 
     text.setText(label);
-    text.setFont(text.getFont().deriveFont(Font.PLAIN, 13f));
+    text.setFont(text.getFont().deriveFont(Font.PLAIN, 12f));
 
     JPanel line = new JPanel();
     line.setOpaque(false);


### PR DESCRIPTION
## Summary
- réduit la largeur de la barre latérale en modes compact et étendu pour un rendu plus étroit
- adapte l’en-tête afin d’afficher seulement l’icône hamburger en mode réduit et « ☰ Menu » en mode étendu
- compacte l’apparence des boutons (marges, tailles d’icône et police) pour correspondre au nouveau gabarit

## Testing
- `mvn -pl client -am test` *(échoue : impossible de télécharger org.springframework.boot:spring-boot-dependencies:pom:3.2.5 depuis Maven Central – Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ca570e93c88330950ce771c136b82d