### PR TITLE
feat(client): add svg sidebar icons and toast notifications

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/ui/MainFrame.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/MainFrame.java
@@ -95,19 +95,19 @@ public class MainFrame extends JFrame {
 
   private JComponent buildSidebar() {
     CollapsibleSidebar side = new CollapsibleSidebar();
-    addSidebarItem(side, "planning", "🗓", "Planning");
-    addSidebarItem(side, "agenda", "📒", "Agenda");
-    addSidebarItem(side, "quotes", "🧾", "Devis");
-    addSidebarItem(side, "orders", "📦", "Commandes");
-    addSidebarItem(side, "delivery", "🚚", "Bons de livraison");
-    addSidebarItem(side, "invoices", "💶", "Factures");
-    addSidebarItem(side, "clients", "👥", "Clients");
-    addSidebarItem(side, "resources", "🏷️", "Ressources");
+    addSidebarItem(side, "planning", "calendar", "Planning");
+    addSidebarItem(side, "agenda", "calendar", "Agenda");
+    addSidebarItem(side, "quotes", "file", "Devis");
+    addSidebarItem(side, "orders", "pallet", "Commandes");
+    addSidebarItem(side, "delivery", "truck", "Bons de livraison");
+    addSidebarItem(side, "invoices", "invoice", "Factures");
+    addSidebarItem(side, "clients", "user", "Clients");
+    addSidebarItem(side, "resources", "wrench", "Ressources");
     return side;
   }
 
-  private void addSidebarItem(CollapsibleSidebar side, String card, String icon, String label) {
-    SidebarButton button = side.addItem(icon, label, () -> openCard(card));
+  private void addSidebarItem(CollapsibleSidebar side, String card, String iconKey, String label) {
+    SidebarButton button = side.addItemSvg(iconKey, label, () -> openCard(card));
     navButtons.put(card, button);
   }
 

--- a/client/src/main/java/com/materiel/suite/client/ui/common/Toasts.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/common/Toasts.java
@@ -1,0 +1,100 @@
+package com.materiel.suite.client.ui.common;
+
+import com.materiel.suite.client.ui.icons.IconRegistry;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * Utilitaire minimaliste pour afficher des toasts légers dans l'interface Swing.
+ */
+public final class Toasts {
+  private Toasts(){}
+
+  public static void info(Component parent, String message){
+    show(parent, message, "info");
+  }
+
+  public static void success(Component parent, String message){
+    show(parent, message, "success");
+  }
+
+  public static void error(Component parent, String message){
+    show(parent, message, "error");
+  }
+
+  public static void show(Component parent, String message, String iconKey){
+    if (message == null || message.isBlank()){
+      return;
+    }
+    Window owner = parent instanceof Window ? (Window) parent : SwingUtilities.getWindowAncestor(parent);
+    if (owner == null){
+      return;
+    }
+
+    JWindow toast = new JWindow(owner);
+    toast.setFocusableWindowState(false);
+    toast.setType(Window.Type.POPUP);
+
+    JPanel panel = new JPanel(new BorderLayout(8, 0));
+    panel.setBorder(BorderFactory.createCompoundBorder(
+        BorderFactory.createLineBorder(new Color(220, 220, 220)),
+        BorderFactory.createEmptyBorder(8, 10, 8, 12)
+    ));
+    panel.setBackground(new Color(255, 255, 255, 240));
+
+    Icon icon = IconRegistry.medium(iconKey);
+    if (icon == null){
+      icon = IconRegistry.placeholder(20);
+    }
+    JLabel iconLabel = new JLabel(icon);
+    JLabel textLabel = new JLabel(message);
+    textLabel.setFont(textLabel.getFont().deriveFont(Font.PLAIN, 12f));
+
+    panel.add(iconLabel, BorderLayout.WEST);
+    panel.add(textLabel, BorderLayout.CENTER);
+
+    toast.setContentPane(panel);
+    toast.pack();
+
+    Rectangle screenBounds = owner.getGraphicsConfiguration() != null
+        ? owner.getGraphicsConfiguration().getBounds()
+        : owner.getBounds();
+    int x = screenBounds.x + screenBounds.width - toast.getWidth() - 16;
+    int y = screenBounds.y + screenBounds.height - toast.getHeight() - 16;
+    toast.setLocation(x, y);
+    toast.setAlwaysOnTop(true);
+
+    boolean supportsOpacity = true;
+    try {
+      toast.setOpacity(1f);
+    } catch (UnsupportedOperationException | IllegalComponentStateException ex){
+      supportsOpacity = false;
+    }
+
+    toast.setVisible(true);
+
+    if (!supportsOpacity){
+      Timer hide = new Timer(2000, e -> {
+        toast.setVisible(false);
+        toast.dispose();
+      });
+      hide.setRepeats(false);
+      hide.start();
+      return;
+    }
+
+    Timer fade = new Timer(18, e -> {
+      float alpha = toast.getOpacity();
+      if (alpha <= 0.05f){
+        ((Timer) e.getSource()).stop();
+        toast.setVisible(false);
+        toast.dispose();
+      } else {
+        toast.setOpacity(alpha - 0.06f);
+      }
+    });
+    fade.setInitialDelay(1600);
+    fade.start();
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/delivery/DeliveryNoteEditor.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/delivery/DeliveryNoteEditor.java
@@ -10,6 +10,8 @@ import com.materiel.suite.client.ui.doc.DocumentTotalsPanel;
 import com.materiel.suite.client.ui.doc.ClientContactBinding;
 // === CRM-INJECT END ===
 
+import com.materiel.suite.client.ui.common.Toasts;
+
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
@@ -99,7 +101,13 @@ public class DeliveryNoteEditor extends JDialog {
     JButton save = new JButton("Enregistrer");
     JButton toInv = new JButton("Créer facture…");
     cancel.addActionListener(e -> dispose());
-    save.addActionListener(e -> { flushToBean(); ServiceFactory.deliveryNotes().save(bean); dispose(); });
+    save.addActionListener(e -> {
+      flushToBean();
+      ServiceFactory.deliveryNotes().save(bean);
+      Window anchor = getOwner() != null ? getOwner() : this;
+      Toasts.success(anchor, "Bon de livraison enregistré");
+      dispose();
+    });
     toInv.addActionListener(e -> {
       flushToBean(); ServiceFactory.deliveryNotes().save(bean);
       var inv = ServiceFactory.invoices().createFromDeliveryNotes(java.util.List.of(bean.getId()));

--- a/client/src/main/java/com/materiel/suite/client/ui/icons/IconRegistry.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/icons/IconRegistry.java
@@ -13,7 +13,8 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class IconRegistry {
   private static final List<String> ICON_KEYS = List.of(
       "crane", "truck", "forklift", "excavator", "generator", "container",
-      "hook", "helmet", "wrench", "pallet", "calendar", "user"
+      "hook", "helmet", "wrench", "pallet", "calendar", "user",
+      "file", "invoice", "search", "success", "error", "info"
   );
   private static final Set<String> ICON_SET = Set.copyOf(ICON_KEYS);
   private static final Map<Integer, Icon> PLACEHOLDER_CACHE = new ConcurrentHashMap<>();

--- a/client/src/main/java/com/materiel/suite/client/ui/invoices/InvoiceEditor.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/invoices/InvoiceEditor.java
@@ -10,6 +10,8 @@ import com.materiel.suite.client.ui.doc.DocumentTotalsPanel;
 import com.materiel.suite.client.ui.doc.ClientContactBinding;
 // === CRM-INJECT END ===
 
+import com.materiel.suite.client.ui.common.Toasts;
+
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
@@ -98,7 +100,13 @@ public class InvoiceEditor extends JDialog {
     JButton cancel = new JButton("Annuler");
     JButton save = new JButton("Enregistrer");
     cancel.addActionListener(e -> dispose());
-    save.addActionListener(e -> { flushToBean(); ServiceFactory.invoices().save(bean); dispose(); });
+    save.addActionListener(e -> {
+      flushToBean();
+      ServiceFactory.invoices().save(bean);
+      Window anchor = getOwner() != null ? getOwner() : this;
+      Toasts.success(anchor, "Facture enregistrée");
+      dispose();
+    });
     buttons.add(cancel); buttons.add(save);
     south.add(buttons, BorderLayout.SOUTH);
     return south;

--- a/client/src/main/java/com/materiel/suite/client/ui/orders/OrderEditor.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/orders/OrderEditor.java
@@ -10,6 +10,8 @@ import com.materiel.suite.client.ui.doc.DocumentTotalsPanel;
 import com.materiel.suite.client.ui.doc.ClientContactBinding;
 // === CRM-INJECT END ===
 
+import com.materiel.suite.client.ui.common.Toasts;
+
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
@@ -99,7 +101,13 @@ public class OrderEditor extends JDialog {
     JButton save = new JButton("Enregistrer");
     JButton toDN = new JButton("Générer BL…");
     cancel.addActionListener(e -> dispose());
-    save.addActionListener(e -> { flushToBean(); ServiceFactory.orders().save(bean); dispose(); });
+    save.addActionListener(e -> {
+      flushToBean();
+      ServiceFactory.orders().save(bean);
+      Window anchor = getOwner() != null ? getOwner() : this;
+      Toasts.success(anchor, "Commande enregistrée");
+      dispose();
+    });
     toDN.addActionListener(e -> {
       flushToBean(); ServiceFactory.orders().save(bean);
       var d = ServiceFactory.deliveryNotes().createFromOrder(bean.getId());

--- a/client/src/main/java/com/materiel/suite/client/ui/quotes/QuoteEditor.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/quotes/QuoteEditor.java
@@ -10,6 +10,8 @@ import com.materiel.suite.client.ui.doc.DocumentTotalsPanel;
 import com.materiel.suite.client.ui.doc.ClientContactBinding;
 // === CRM-INJECT END ===
 
+import com.materiel.suite.client.ui.common.Toasts;
+
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
@@ -100,7 +102,13 @@ public class QuoteEditor extends JDialog {
     JButton save = new JButton("Enregistrer");
     JButton toOrder = new JButton("Créer BC…");
     cancel.addActionListener(e -> dispose());
-    save.addActionListener(e -> { flushToBean(); ServiceFactory.quotes().save(bean); dispose(); });
+    save.addActionListener(e -> {
+      flushToBean();
+      ServiceFactory.quotes().save(bean);
+      Window anchor = getOwner() != null ? getOwner() : this;
+      Toasts.success(anchor, "Devis enregistré");
+      dispose();
+    });
     toOrder.addActionListener(e -> {
       flushToBean(); ServiceFactory.quotes().save(bean);
       var o = ServiceFactory.orders().createFromQuote(bean.getId());

--- a/client/src/main/java/com/materiel/suite/client/ui/search/GlobalSearchDialog.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/search/GlobalSearchDialog.java
@@ -1,0 +1,120 @@
+package com.materiel.suite.client.ui.search;
+
+import com.materiel.suite.client.ui.common.Toasts;
+
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import java.awt.*;
+import java.awt.event.KeyEvent;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Fenêtre de recherche globale (prototype léger) qui illustre l'usage du renderer avec icônes.
+ */
+public class GlobalSearchDialog extends JDialog {
+  private final JTextField input = new JTextField();
+  private final DefaultListModel<Object> model = new DefaultListModel<>();
+  private final JList<Object> results = new JList<>(model);
+  private final List<IconSearchRenderer.SearchItem> sampleItems = List.of(
+      new IconSearchRenderer.SearchItem("quote", "Devis #DV-2024-001", "Client : Axone BTP", "file"),
+      new IconSearchRenderer.SearchItem("order", "Commande #BC-458", "Client : Atlas", "pallet"),
+      new IconSearchRenderer.SearchItem("delivery", "BL #BL-210", "Destination : Chantier Nord", "truck"),
+      new IconSearchRenderer.SearchItem("invoice", "Facture #FA-2024-018", "Montant : 12 500 €", "invoice"),
+      new IconSearchRenderer.SearchItem("client", "Client : Société Rimbaud", "Dernier contact : 12/05", "user"),
+      new IconSearchRenderer.SearchItem("resource", "Ressource : Groupe électrogène", "Disponibilité : 3 restants", "generator")
+  );
+
+  public GlobalSearchDialog(Window owner) {
+    super(owner, "Recherche globale", ModalityType.MODELESS);
+    setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+    setSize(600, 420);
+    setLocationRelativeTo(owner);
+    setLayout(new BorderLayout(0, 8));
+
+    results.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+    results.setCellRenderer(new IconSearchRenderer());
+    results.setVisibleRowCount(10);
+
+    add(buildHeader(), BorderLayout.NORTH);
+    add(new JScrollPane(results), BorderLayout.CENTER);
+
+    input.getDocument().addDocumentListener(new DocumentListener() {
+      @Override public void insertUpdate(DocumentEvent e) { updateResults(); }
+      @Override public void removeUpdate(DocumentEvent e) { updateResults(); }
+      @Override public void changedUpdate(DocumentEvent e) { updateResults(); }
+    });
+    input.addActionListener(e -> openSelection());
+
+    results.addListSelectionListener(e -> {
+      if (!e.getValueIsAdjusting() && results.getSelectedIndex() == -1 && model.getSize() > 0) {
+        results.setSelectedIndex(0);
+      }
+    });
+    results.addMouseListener(new java.awt.event.MouseAdapter() {
+      @Override public void mouseClicked(java.awt.event.MouseEvent e) {
+        if (e.getClickCount() == 2 && results.locationToIndex(e.getPoint()) >= 0) {
+          openSelection();
+        }
+      }
+    });
+
+    InputMap im = getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
+    im.put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), "close");
+    getRootPane().getActionMap().put("close", new AbstractAction() {
+      @Override public void actionPerformed(java.awt.event.ActionEvent e) {
+        dispose();
+      }
+    });
+
+    updateResults();
+    SwingUtilities.invokeLater(() -> input.requestFocusInWindow());
+  }
+
+  private JComponent buildHeader() {
+    JPanel panel = new JPanel(new BorderLayout(8, 0));
+    panel.setBorder(BorderFactory.createEmptyBorder(10, 12, 6, 12));
+    JLabel title = new JLabel("Rechercher (Ctrl+K)");
+    title.setFont(title.getFont().deriveFont(Font.BOLD, 14f));
+    panel.add(title, BorderLayout.WEST);
+    input.putClientProperty("JTextField.placeholderText", "Tapez un mot-clé (ex. client, devis…)");
+    panel.add(input, BorderLayout.CENTER);
+    return panel;
+  }
+
+  private void updateResults() {
+    String query = input.getText() == null ? "" : input.getText().trim();
+    model.clear();
+    if (query.length() < 2) {
+      model.addElement("info: Tapez au moins 2 caractères pour rechercher");
+      results.setSelectedIndex(0);
+      return;
+    }
+    String normalized = query.toLowerCase(Locale.ROOT);
+    sampleItems.stream()
+        .filter(item -> matches(item, normalized))
+        .forEach(model::addElement);
+    if (model.isEmpty()) {
+      model.addElement("error: Aucun résultat pour \"" + query + "\"");
+    }
+    results.setSelectedIndex(0);
+  }
+
+  private boolean matches(IconSearchRenderer.SearchItem item, String normalizedQuery) {
+    return item.label().toLowerCase(Locale.ROOT).contains(normalizedQuery)
+        || (item.subtitle() != null && item.subtitle().toLowerCase(Locale.ROOT).contains(normalizedQuery))
+        || (item.type() != null && item.type().toLowerCase(Locale.ROOT).contains(normalizedQuery));
+  }
+
+  private void openSelection() {
+    Object value = results.getSelectedValue();
+    if (value instanceof IconSearchRenderer.SearchItem item) {
+      String key = item.iconKey() != null && !item.iconKey().isBlank() ? item.iconKey() : "search";
+      Toasts.show(this, "Ouverture : " + item.label(), key);
+      dispose();
+    } else if (value instanceof String str && !str.startsWith("error:")) {
+      Toasts.info(this, str.replaceFirst("^[^:]+:\\s*", ""));
+    }
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/search/IconSearchRenderer.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/search/IconSearchRenderer.java
@@ -1,0 +1,74 @@
+package com.materiel.suite.client.ui.search;
+
+import com.materiel.suite.client.ui.icons.IconRegistry;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.Locale;
+
+/**
+ * Renderer utilisé par la recherche globale : chaque élément peut afficher une icône contextuelle.
+ */
+public class IconSearchRenderer extends DefaultListCellRenderer {
+  @Override
+  public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+    JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+    String iconKey = null;
+    String textValue = value != null ? value.toString() : "";
+
+    if (value instanceof SearchItem item) {
+      iconKey = item.iconKey() != null ? item.iconKey() : mapType(item.type());
+      label.setText(item.label());
+      label.setToolTipText(item.subtitle());
+    } else {
+      int sep = textValue.indexOf(':');
+      if (sep > 0) {
+        iconKey = mapType(textValue.substring(0, sep));
+        label.setText(textValue.substring(sep + 1).trim());
+      }
+    }
+
+    Icon icon = iconKey != null ? IconRegistry.small(iconKey) : null;
+    if (icon == null) {
+      icon = IconRegistry.placeholder(16);
+    }
+    label.setIcon(icon);
+    label.setIconTextGap(8);
+    return label;
+  }
+
+  private String mapType(String type) {
+    if (type == null) {
+      return "search";
+    }
+    String normalized = type.toLowerCase(Locale.ROOT);
+    if (normalized.contains("quote") || normalized.contains("devis")) {
+      return "file";
+    }
+    if (normalized.contains("order") || normalized.contains("commande") || normalized.equals("bc")) {
+      return "pallet";
+    }
+    if (normalized.contains("delivery") || normalized.contains("bl")) {
+      return "truck";
+    }
+    if (normalized.contains("invoice") || normalized.contains("facture")) {
+      return "invoice";
+    }
+    if (normalized.contains("client") || normalized.contains("customer")) {
+      return "user";
+    }
+    if (normalized.contains("resource") || normalized.contains("ressource")) {
+      return "wrench";
+    }
+    if (normalized.contains("agenda") || normalized.contains("planning") || normalized.contains("calendar")) {
+      return "calendar";
+    }
+    return "search";
+  }
+
+  /**
+   * Représentation légère d'un résultat pour la liste.
+   */
+  public static record SearchItem(String type, String label, String subtitle, String iconKey) {
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/shell/CollapsibleSidebar.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/shell/CollapsibleSidebar.java
@@ -1,7 +1,12 @@
 package com.materiel.suite.client.ui.shell;
 
+import com.materiel.suite.client.ui.common.Toasts;
+import com.materiel.suite.client.ui.icons.IconRegistry;
+import com.materiel.suite.client.ui.search.GlobalSearchDialog;
+
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.ActionEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
@@ -75,6 +80,22 @@ public class CollapsibleSidebar extends JPanel {
     });
     collapseTimer.setRepeats(false);
     setPinMode(PinMode.AUTO);
+
+    InputMap im = getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
+    ActionMap am = getActionMap();
+    im.put(KeyStroke.getKeyStroke("control K"), "open-global-search");
+    am.put("open-global-search", new AbstractAction() {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        Window owner = SwingUtilities.getWindowAncestor(CollapsibleSidebar.this);
+        try {
+          GlobalSearchDialog dialog = new GlobalSearchDialog(owner);
+          dialog.setVisible(true);
+        } catch (Exception ex) {
+          Toasts.info(CollapsibleSidebar.this, "Recherche globale indisponible");
+        }
+      }
+    });
   }
 
   private void buildHeader() {
@@ -126,9 +147,13 @@ public class CollapsibleSidebar extends JPanel {
     repaint();
   }
 
-  /** Ajoute un bouton avec une icône (emoji/char) et un libellé. */
-  public SidebarButton addItem(String iconText, String label, Runnable action) {
-    SidebarButton button = new SidebarButton(iconText, label, action);
+  /** Ajoute un bouton avec une icône et un libellé. */
+  public SidebarButton addItem(String iconKey, Icon icon, String label, Runnable action) {
+    Icon resolved = icon;
+    if (resolved == null) {
+      resolved = iconKey != null ? IconRegistry.loadOrPlaceholder(iconKey, 20) : null;
+    }
+    SidebarButton button = new SidebarButton(iconKey, resolved, label, action);
     buttons.add(button);
     itemsPanel.add(button);
     itemsPanel.add(Box.createVerticalStrut(2));
@@ -150,6 +175,11 @@ public class CollapsibleSidebar extends JPanel {
     button.addMouseListener(hover);
     button.addMouseMotionListener(hover);
     return button;
+  }
+
+  /** Ajoute un bouton en utilisant une icône du registre SVG. */
+  public SidebarButton addItemSvg(String iconKey, String label, Runnable action) {
+    return addItem(iconKey, IconRegistry.medium(iconKey), label, action);
   }
 
   private void onExpandPinToggled(){

--- a/client/src/main/java/com/materiel/suite/client/ui/shell/SidebarButton.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/shell/SidebarButton.java
@@ -1,5 +1,7 @@
 package com.materiel.suite.client.ui.shell;
 
+import com.materiel.suite.client.ui.common.Toasts;
+
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.MouseAdapter;
@@ -12,24 +14,26 @@ public class SidebarButton extends JPanel {
   private static final Color PRESSED_COLOR = new Color(210, 230, 255);
   private static final Color ACTIVE_COLOR = new Color(212, 232, 255);
   private final JLabel icon = new JLabel();
+  private final Component spacer = Box.createHorizontalStrut(10);
   private final JLabel text = new JLabel();
   private final Runnable action;
+  private final String iconKey;
   private boolean hovered = false;
   private boolean pressed = false;
   private boolean active = false;
 
-  public SidebarButton(String iconText, String label, Runnable action) {
+  public SidebarButton(String iconKey, Icon iconSvg, String label, Runnable action) {
     super(new BorderLayout());
     this.action = action;
+    this.iconKey = iconKey;
     setOpaque(true);
     setBackground(BASE_COLOR);
     setBorder(BorderFactory.createEmptyBorder(6, 10, 6, 10));
     setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 
-    icon.setText(iconText);
     icon.setHorizontalAlignment(SwingConstants.CENTER);
-    icon.setFont(icon.getFont().deriveFont(14f));
-    icon.setPreferredSize(new Dimension(24, 20));
+    icon.setPreferredSize(new Dimension(28, 24));
+    icon.setIcon(iconSvg);
 
     text.setText(label);
     text.setFont(text.getFont().deriveFont(Font.PLAIN, 12f));
@@ -38,7 +42,7 @@ public class SidebarButton extends JPanel {
     line.setOpaque(false);
     line.setLayout(new BoxLayout(line, BoxLayout.X_AXIS));
     line.add(icon);
-    line.add(Box.createHorizontalStrut(10));
+    line.add(spacer);
     line.add(text);
     line.add(Box.createHorizontalGlue());
     add(line, BorderLayout.CENTER);
@@ -66,13 +70,18 @@ public class SidebarButton extends JPanel {
 
       @Override
       public void mouseReleased(MouseEvent e) {
-        if (pressed && contains(e.getPoint())) {
-          if (action != null) {
-            action.run();
-          }
+        boolean inside = contains(e.getPoint());
+        if (inside && action != null) {
+          action.run();
         }
         pressed = false;
         refreshBackground();
+        if (inside) {
+          Window w = SwingUtilities.getWindowAncestor(SidebarButton.this);
+          Component anchor = w != null ? w : SidebarButton.this;
+          String key = iconKey != null && !iconKey.isBlank() ? iconKey : "info";
+          Toasts.show(anchor, "Ouverture : " + text.getText(), key);
+        }
       }
     };
     addMouseListener(ma);
@@ -85,6 +94,7 @@ public class SidebarButton extends JPanel {
 
   public void setExpanded(boolean expanded) {
     text.setVisible(expanded);
+    spacer.setVisible(expanded);
     revalidate();
     repaint();
   }

--- a/client/src/main/resources/icons/error.svg
+++ b/client/src/main/resources/icons/error.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <circle cx="12" cy="12" r="9.5" fill="#e53935"/>
+  <path d="M8 8l8 8M16 8l-8 8" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/client/src/main/resources/icons/file.svg
+++ b/client/src/main/resources/icons/file.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <path d="M6 3h7l5 5v13a1.5 1.5 0 0 1-1.5 1.5h-10A1.5 1.5 0 0 1 5 21V4.5A1.5 1.5 0 0 1 6.5 3Z" fill="#64b5f6"/>
+  <path d="M13 3v5h5l-5-5z" fill="#1e88e5"/>
+  <rect x="7.5" y="11" width="9" height="1.6" rx="0.8" fill="#e3f2fd"/>
+  <rect x="7.5" y="14" width="9" height="1.6" rx="0.8" fill="#e3f2fd"/>
+  <rect x="7.5" y="17" width="6" height="1.6" rx="0.8" fill="#e3f2fd"/>
+</svg>

--- a/client/src/main/resources/icons/info.svg
+++ b/client/src/main/resources/icons/info.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <circle cx="12" cy="12" r="9.5" fill="#1e88e5"/>
+  <rect x="11" y="10" width="2" height="7" fill="#fff" rx="1"/>
+  <rect x="11" y="7" width="2" height="2" fill="#fff" rx="1"/>
+</svg>

--- a/client/src/main/resources/icons/invoice.svg
+++ b/client/src/main/resources/icons/invoice.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <path d="M6 3h11a2 2 0 0 1 2 2v15l-2.5-1.5L14 20l-2.5-1.5L9 20l-2.5-1.5L4 20V5a2 2 0 0 1 2-2z" fill="#ffb74d"/>
+  <path d="M8 7h8" stroke="#fff3e0" stroke-width="1.6" stroke-linecap="round"/>
+  <path d="M8 11h8" stroke="#fff3e0" stroke-width="1.6" stroke-linecap="round"/>
+  <circle cx="12" cy="15" r="2.6" fill="#fb8c00"/>
+  <path d="M12 12.6v4.8" stroke="#fff" stroke-width="1.4" stroke-linecap="round"/>
+  <path d="M10.8 13.8h1.6a1.2 1.2 0 1 1 0 2.4h-1.6" stroke="#fff" stroke-width="1.4" stroke-linecap="round" fill="none"/>
+</svg>

--- a/client/src/main/resources/icons/search.svg
+++ b/client/src/main/resources/icons/search.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <circle cx="11" cy="11" r="6.5" fill="#90caf9"/>
+  <circle cx="11" cy="11" r="3" fill="#e3f2fd"/>
+  <rect x="15.5" y="15" width="6" height="2" rx="1" transform="rotate(45 15.5 15)" fill="#1565c0"/>
+</svg>

--- a/client/src/main/resources/icons/success.svg
+++ b/client/src/main/resources/icons/success.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <circle cx="12" cy="12" r="9.5" fill="#43a047"/>
+  <path d="M7.5 12.5l3 3 6-6" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- add a reusable toast helper and surface success messages in document editors and sidebar interactions
- switch the sidebar to use registry-provided SVG icons and expose a Ctrl+K shortcut for the new global search dialog
- introduce a search list renderer and supporting SVG assets for search/status icons

## Testing
- `mvn -pl client test` *(fails: could not reach repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68ca60b0ed088330896a7ca20665b57d