### PR TITLE
Expose intervention type catalog endpoint and use it in client

### DIFF
--- a/backend/src/main/java/com/materiel/suite/backend/interventions/InterventionTypeCatalogService.java
+++ b/backend/src/main/java/com/materiel/suite/backend/interventions/InterventionTypeCatalogService.java
@@ -1,0 +1,85 @@
+package com.materiel.suite.backend.interventions;
+
+import com.materiel.suite.backend.interventions.dto.InterventionTypeV2Dto;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Catalogue en mémoire pour les types d'intervention exposés en v2. */
+@Service
+public class InterventionTypeCatalogService {
+  private final Map<String, InterventionTypeV2Dto> store = new ConcurrentHashMap<>();
+
+  @PostConstruct
+  public void seed(){
+    if (store.isEmpty()){
+      put("levage", "Levage", "crane");
+      put("transport", "Transport", "truck");
+      put("manutention", "Manutention", "forklift");
+    }
+  }
+
+  private void put(String id, String name, String icon){
+    InterventionTypeV2Dto dto = new InterventionTypeV2Dto();
+    dto.setId(id);
+    dto.setName(name);
+    dto.setIconKey(icon);
+    store.put(id, dto);
+  }
+
+  public List<InterventionTypeV2Dto> list(){
+    return new ArrayList<>(store.values());
+  }
+
+  public Optional<InterventionTypeV2Dto> get(String id){
+    if (id == null || id.isBlank()){
+      return Optional.empty();
+    }
+    return Optional.ofNullable(store.get(id));
+  }
+
+  public InterventionTypeV2Dto create(InterventionTypeV2Dto dto){
+    if (dto == null){
+      return null;
+    }
+    if (dto.getId() == null || dto.getId().isBlank()){
+      dto.setId(UUID.randomUUID().toString());
+    }
+    store.put(dto.getId(), copy(dto));
+    return store.get(dto.getId());
+  }
+
+  public InterventionTypeV2Dto update(String id, InterventionTypeV2Dto dto){
+    if (id == null || id.isBlank()){
+      throw new IllegalArgumentException("id manquant");
+    }
+    InterventionTypeV2Dto copy = copy(dto);
+    copy.setId(id);
+    store.put(id, copy);
+    return copy;
+  }
+
+  public void delete(String id){
+    if (id == null || id.isBlank()){
+      return;
+    }
+    store.remove(id);
+  }
+
+  private InterventionTypeV2Dto copy(InterventionTypeV2Dto dto){
+    if (dto == null){
+      return new InterventionTypeV2Dto();
+    }
+    InterventionTypeV2Dto copy = new InterventionTypeV2Dto();
+    copy.setId(dto.getId());
+    copy.setName(dto.getName());
+    copy.setIconKey(dto.getIconKey());
+    return copy;
+  }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/interventions/InterventionTypeV2Controller.java
+++ b/backend/src/main/java/com/materiel/suite/backend/interventions/InterventionTypeV2Controller.java
@@ -1,0 +1,50 @@
+package com.materiel.suite.backend.interventions;
+
+import com.materiel.suite.backend.interventions.dto.InterventionTypeV2Dto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v2/intervention-types")
+public class InterventionTypeV2Controller {
+  private final InterventionTypeCatalogService service;
+
+  public InterventionTypeV2Controller(InterventionTypeCatalogService service){
+    this.service = service;
+  }
+
+  @GetMapping
+  public ResponseEntity<List<InterventionTypeV2Dto>> list(){
+    return ResponseEntity.ok(service.list());
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<InterventionTypeV2Dto> get(@PathVariable String id){
+    return service.get(id).map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());
+  }
+
+  @PostMapping
+  public ResponseEntity<InterventionTypeV2Dto> create(@RequestBody InterventionTypeV2Dto body){
+    return ResponseEntity.ok(service.create(body));
+  }
+
+  @PutMapping("/{id}")
+  public ResponseEntity<InterventionTypeV2Dto> update(@PathVariable String id, @RequestBody InterventionTypeV2Dto body){
+    return ResponseEntity.ok(service.update(id, body));
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> delete(@PathVariable String id){
+    service.delete(id);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/interventions/dto/InterventionTypeV2Dto.java
+++ b/backend/src/main/java/com/materiel/suite/backend/interventions/dto/InterventionTypeV2Dto.java
@@ -1,0 +1,32 @@
+package com.materiel.suite.backend.interventions.dto;
+
+/** DTO simple pour exposer les types d'intervention via l'API v2. */
+public class InterventionTypeV2Dto {
+  private String id;
+  private String name;
+  private String iconKey;
+
+  public String getId(){
+    return id;
+  }
+
+  public void setId(String id){
+    this.id = id;
+  }
+
+  public String getName(){
+    return name;
+  }
+
+  public void setName(String name){
+    this.name = name;
+  }
+
+  public String getIconKey(){
+    return iconKey;
+  }
+
+  public void setIconKey(String iconKey){
+    this.iconKey = iconKey;
+  }
+}

--- a/backend/src/main/resources/openapi/gestion-materiel-v1.yaml
+++ b/backend/src/main/resources/openapi/gestion-materiel-v1.yaml
@@ -239,6 +239,83 @@ paths:
       responses:
         '204':
           description: Deleted
+  /api/v2/intervention-types:
+    get:
+      summary: List intervention types (v2)
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/InterventionTypeV2'
+    post:
+      summary: Create intervention type (v2)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InterventionTypeV2'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InterventionTypeV2'
+  /api/v2/intervention-types/{id}:
+    get:
+      summary: Get intervention type (v2)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InterventionTypeV2'
+        '404':
+          description: Not found
+    put:
+      summary: Update intervention type (v2)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InterventionTypeV2'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InterventionTypeV2'
+    delete:
+      summary: Delete intervention type (v2)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Deleted
 components:
   schemas:
     DocumentLine:
@@ -319,6 +396,15 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Unavailability'
+    InterventionTypeV2:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        iconKey:
+          type: string
     Intervention:
       type: object
       properties:

--- a/client/src/main/java/com/materiel/suite/client/net/ServiceFactory.java
+++ b/client/src/main/java/com/materiel/suite/client/net/ServiceFactory.java
@@ -15,6 +15,7 @@ public class ServiceFactory {
   private static PlanningService planningService;
   private static DocumentWorkflowService workflowService;
   private static ClientService clientService;
+  private static InterventionTypeService interventionTypeService;
 
   public static void init(AppConfig c) {
     cfg = c;
@@ -34,6 +35,7 @@ public class ServiceFactory {
     planningService = new MockPlanningService();
     workflowService = new MockWorkflowService();
     clientService = new MockClientService();
+    interventionTypeService = new MockInterventionTypeService();
   }
 
   private static void initBackend() {
@@ -49,6 +51,7 @@ public class ServiceFactory {
     planningService = new ApiPlanningService(rc, new MockPlanningService());
     workflowService = new ApiWorkflowService(rc);
     clientService = new ApiClientService(rc, new MockClientService());
+    interventionTypeService = new ApiInterventionTypeService(rc, new MockInterventionTypeService());
   }
 
   public static QuoteService quotes(){ return quoteService; }
@@ -58,6 +61,7 @@ public class ServiceFactory {
   public static PlanningService planning(){ return planningService; }
   public static DocumentWorkflowService workflow(){ return workflowService; }
   public static ClientService clients(){ return clientService; }
+  public static InterventionTypeService interventionTypes(){ return interventionTypeService; }
   public static RestClient http(){ return restClient; }
 }
 

--- a/client/src/main/java/com/materiel/suite/client/service/InterventionTypeService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/InterventionTypeService.java
@@ -1,0 +1,11 @@
+package com.materiel.suite.client.service;
+
+import com.materiel.suite.client.model.InterventionType;
+
+import java.util.List;
+
+/** Service catalogue des types d'intervention. */
+public interface InterventionTypeService {
+  /** Retourne la liste des types disponibles (peut être vide). */
+  List<InterventionType> list();
+}

--- a/client/src/main/java/com/materiel/suite/client/service/api/ApiInterventionTypeService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/api/ApiInterventionTypeService.java
@@ -1,0 +1,52 @@
+package com.materiel.suite.client.service.api;
+
+import com.materiel.suite.client.model.InterventionType;
+import com.materiel.suite.client.net.RestClient;
+import com.materiel.suite.client.net.SimpleJson;
+import com.materiel.suite.client.service.InterventionTypeService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Récupère les types d'intervention via l'API (v2). */
+public class ApiInterventionTypeService implements InterventionTypeService {
+  private final RestClient rc;
+  private final InterventionTypeService fallback;
+
+  public ApiInterventionTypeService(RestClient rc, InterventionTypeService fallback){
+    this.rc = rc;
+    this.fallback = fallback;
+  }
+
+  @Override
+  public List<InterventionType> list(){
+    try {
+      String body = rc.get("/api/v2/intervention-types");
+      List<Object> arr = SimpleJson.asArr(SimpleJson.parse(body));
+      List<InterventionType> list = new ArrayList<>();
+      for (Object o : arr){
+        if (!(o instanceof java.util.Map<?,?> map)) continue;
+        String code = SimpleJson.str(map.get("id"));
+        String label = SimpleJson.str(map.get("name"));
+        String icon = SimpleJson.str(map.get("iconKey"));
+        if (code == null || code.isBlank()){
+          if (label == null || label.isBlank()){
+            continue;
+          }
+          code = label.trim();
+        }
+        InterventionType type = new InterventionType();
+        type.setCode(code);
+        type.setLabel(label != null && !label.isBlank() ? label : code);
+        type.setIconKey(icon);
+        list.add(type);
+      }
+      if (!list.isEmpty()){
+        return list;
+      }
+    } catch (Exception ignore){
+      // fallback ci-dessous
+    }
+    return fallback != null ? fallback.list() : List.of();
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/service/mock/MockInterventionTypeService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/mock/MockInterventionTypeService.java
@@ -1,0 +1,21 @@
+package com.materiel.suite.client.service.mock;
+
+import com.materiel.suite.client.model.InterventionType;
+import com.materiel.suite.client.service.InterventionTypeService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Fournit un catalogue statique pour l'utilisation hors-ligne. */
+public class MockInterventionTypeService implements InterventionTypeService {
+  private static final List<InterventionType> DEFAULTS = List.of(
+      new InterventionType("LIFT", "Levage", "crane"),
+      new InterventionType("TRANSPORT", "Transport", "truck"),
+      new InterventionType("MANUT", "Manutention", "forklift")
+  );
+
+  @Override
+  public List<InterventionType> list(){
+    return new ArrayList<>(DEFAULTS);
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/interventions/InterventionDialog.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/interventions/InterventionDialog.java
@@ -8,6 +8,7 @@ import com.materiel.suite.client.model.InterventionType;
 import com.materiel.suite.client.model.Resource;
 import com.materiel.suite.client.model.ResourceRef;
 import com.materiel.suite.client.service.ClientService;
+import com.materiel.suite.client.service.InterventionTypeService;
 import com.materiel.suite.client.service.PlanningService;
 import com.materiel.suite.client.ui.common.Toasts;
 import com.materiel.suite.client.ui.icons.IconRegistry;
@@ -33,6 +34,7 @@ import java.util.UUID;
 public class InterventionDialog extends JDialog {
   private final PlanningService planningService;
   private final ClientService clientService;
+  private final InterventionTypeService typeService;
   private final List<InterventionType> availableTypes = new ArrayList<>();
 
   private final JTextField titleField = new JTextField();
@@ -56,15 +58,12 @@ public class InterventionDialog extends JDialog {
   private boolean saved;
   private String signatureBase64;
 
-  public InterventionDialog(Window owner, PlanningService planningService, ClientService clientService, List<InterventionType> types){
+  public InterventionDialog(Window owner, PlanningService planningService, ClientService clientService, InterventionTypeService typeService){
     super(owner, "Intervention", ModalityType.APPLICATION_MODAL);
     this.planningService = planningService;
     this.clientService = clientService;
-    if (types != null){
-      availableTypes.addAll(types);
-    } else {
-      availableTypes.addAll(defaultTypes());
-    }
+    this.typeService = typeService;
+    reloadAvailableTypes();
     buildUI();
     setMinimumSize(new Dimension(980, 680));
     setLocationRelativeTo(owner);
@@ -283,6 +282,7 @@ public class InterventionDialog extends JDialog {
     this.current = intervention == null ? new Intervention() : intervention;
     this.saved = false;
 
+    reloadAvailableTypes();
     populateTypes();
     populateClients();
     loadResources();
@@ -522,6 +522,21 @@ public class InterventionDialog extends JDialog {
     types.add(new InterventionType("TRANSPORT", "Transport", "truck"));
     types.add(new InterventionType("MANUT", "Manutention", "forklift"));
     return types;
+  }
+
+  private void reloadAvailableTypes(){
+    availableTypes.clear();
+    List<InterventionType> types = null;
+    if (typeService != null){
+      try {
+        types = typeService.list();
+      } catch (Exception ignore){}
+    }
+    if (types == null || types.isEmpty()){
+      availableTypes.addAll(defaultTypes());
+    } else {
+      availableTypes.addAll(types);
+    }
   }
 
   private static class QuoteTableModel extends AbstractTableModel {

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/AgendaBoard.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/AgendaBoard.java
@@ -501,7 +501,11 @@ public class AgendaBoard extends JComponent {
     if (planning == null || it == null){
       return;
     }
-    InterventionDialog dialog = new InterventionDialog(SwingUtilities.getWindowAncestor(this), planning, ServiceFactory.clients(), null);
+    InterventionDialog dialog = new InterventionDialog(
+        SwingUtilities.getWindowAncestor(this),
+        planning,
+        ServiceFactory.clients(),
+        ServiceFactory.interventionTypes());
     dialog.edit(it);
     dialog.setVisible(true);
     if (dialog.isSaved()){

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningBoard.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningBoard.java
@@ -161,7 +161,11 @@ public class PlanningBoard extends JComponent {
     if (planning == null || it == null){
       return;
     }
-    InterventionDialog dialog = new InterventionDialog(SwingUtilities.getWindowAncestor(this), planning, ServiceFactory.clients(), null);
+    InterventionDialog dialog = new InterventionDialog(
+        SwingUtilities.getWindowAncestor(this),
+        planning,
+        ServiceFactory.clients(),
+        ServiceFactory.interventionTypes());
     dialog.edit(it);
     dialog.setVisible(true);
     if (dialog.isSaved()){

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
@@ -240,7 +240,11 @@ public class PlanningPanel extends JPanel {
       JOptionPane.showMessageDialog(this, "Service planning indisponible", "Erreur", JOptionPane.ERROR_MESSAGE);
       return;
     }
-    InterventionDialog dialog = new InterventionDialog(SwingUtilities.getWindowAncestor(this), planning, ServiceFactory.clients(), null);
+    InterventionDialog dialog = new InterventionDialog(
+        SwingUtilities.getWindowAncestor(this),
+        planning,
+        ServiceFactory.clients(),
+        ServiceFactory.interventionTypes());
     dialog.edit(new Intervention());
     dialog.setVisible(true);
     if (dialog.isSaved()){


### PR DESCRIPTION
## Summary
- add a dedicated intervention type service on the client (API + mock) and wire it through ServiceFactory
- load intervention types in the intervention dialog and planning views instead of hardcoded defaults
- expose a simple in-memory intervention type catalog on the backend and document the new v2 endpoints

## Testing
- `mvn -pl backend test` *(fails: network unreachable while resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ca71e222ec83308b8b6e2552bfb090