### PR TITLE
feat(client): refresh planning after intervention save

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/service/ClientService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/ClientService.java
@@ -8,6 +8,14 @@ import java.util.UUID;
 
 public interface ClientService {
   List<Client> list();
+  /**
+   * Retourne la liste des clients pour une sélection rapide dans l'IHM.
+   * Par défaut, se contente de déléguer à {@link #list()} pour conserver la compatibilité
+   * avec les implémentations existantes.
+   */
+  default List<Client> listClients(){
+    return list();
+  }
   Client get(UUID id);
   Client save(Client c);
   void delete(UUID id);

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/AgendaBoard.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/AgendaBoard.java
@@ -506,13 +506,12 @@ public class AgendaBoard extends JComponent {
         planning,
         ServiceFactory.clients(),
         ServiceFactory.interventionTypes());
-    dialog.edit(it);
-    dialog.setVisible(true);
-    if (dialog.isSaved()){
-      Intervention updated = dialog.getIntervention();
+    dialog.setOnSave(updated -> {
       planning.saveIntervention(updated);
       reload();
-    }
+    });
+    dialog.edit(it);
+    dialog.setVisible(true);
   }
   // === CRM-INJECT END ===
 

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningBoard.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningBoard.java
@@ -166,14 +166,13 @@ public class PlanningBoard extends JComponent {
         planning,
         ServiceFactory.clients(),
         ServiceFactory.interventionTypes());
-    dialog.edit(it);
-    dialog.setVisible(true);
-    if (dialog.isSaved()){
-      Intervention updated = dialog.getIntervention();
+    dialog.setOnSave(updated -> {
       planning.saveIntervention(updated);
       selected = updated;
       reload();
-    }
+    });
+    dialog.edit(it);
+    dialog.setVisible(true);
   }
   // === CRM-INJECT END ===
 

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
@@ -100,8 +100,7 @@ public class PlanningPanel extends JPanel {
     });
 
     add(center, BorderLayout.CENTER);
-    board.reload();
-    agenda.reload();
+    reload();
 
     putUndoRedoKeymap();
   }
@@ -232,6 +231,10 @@ public class PlanningPanel extends JPanel {
     dlg.setVisible(true);
   }
 
+  public void reload(){
+    refreshPlanning();
+  }
+
   private void refreshPlanning(){ board.reload(); agenda.reload(); }
 
   private void addInterventionDialog(){
@@ -245,13 +248,12 @@ public class PlanningPanel extends JPanel {
         planning,
         ServiceFactory.clients(),
         ServiceFactory.interventionTypes());
-    dialog.edit(new Intervention());
-    dialog.setVisible(true);
-    if (dialog.isSaved()){
-      Intervention intervention = dialog.getIntervention();
+    dialog.setOnSave(intervention -> {
       planning.saveIntervention(intervention);
       refreshPlanning();
-    }
+    });
+    dialog.edit(new Intervention());
+    dialog.setVisible(true);
   }
 
   private void putUndoRedoKeymap(){


### PR DESCRIPTION
## Summary
- expose a lightweight `listClients` helper on client services for selection components
- allow `InterventionDialog` to notify listeners once data is collected and saved
- refresh planning views automatically after creating or editing an intervention via the dialog

## Testing
- `mvn -pl client test` *(fails: unable to download Spring Boot BOM from Maven Central in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7594dac88330a8bd8180129a7af3