### PR TITLE
Add tabbed planning views

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionCalendarView.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionCalendarView.java
@@ -1,0 +1,188 @@
+package com.materiel.suite.client.ui.planning;
+
+import com.materiel.suite.client.model.Intervention;
+import com.materiel.suite.client.model.InterventionType;
+import com.materiel.suite.client.ui.icons.IconRegistry;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+
+/** Regroupement par journée pour une lecture "agenda" rapide. */
+public class InterventionCalendarView implements InterventionView {
+  private final JPanel days = new JPanel();
+  private final JScrollPane scroller = new JScrollPane(days);
+  private final DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
+  private final DateTimeFormatter dayFormatter = DateTimeFormatter.ofPattern("EEEE d MMMM", Locale.FRENCH);
+  private Consumer<Intervention> onOpen = it -> {};
+
+  public InterventionCalendarView(){
+    days.setLayout(new BoxLayout(days, BoxLayout.Y_AXIS));
+    days.setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
+    scroller.setBorder(BorderFactory.createEmptyBorder());
+    scroller.getVerticalScrollBar().setUnitIncrement(18);
+  }
+
+  @Override public JComponent getComponent(){
+    return scroller;
+  }
+
+  @Override public void setData(List<Intervention> list){
+    days.removeAll();
+    List<Intervention> data = new ArrayList<>();
+    if (list != null){
+      for (Intervention it : list){
+        if (it != null){
+          data.add(it);
+        }
+      }
+    }
+    if (data.isEmpty()){
+      days.add(emptyState());
+      refresh();
+      return;
+    }
+    Map<LocalDate, List<Intervention>> byDay = new TreeMap<>();
+    for (Intervention it : data){
+      LocalDate day = dayOf(it);
+      byDay.computeIfAbsent(day, d -> new ArrayList<>()).add(it);
+    }
+    for (Map.Entry<LocalDate, List<Intervention>> entry : byDay.entrySet()){
+      days.add(dayHeader(entry.getKey()));
+      entry.getValue().stream()
+          .sorted(Comparator.comparing(this::startDateTime))
+          .forEach(it -> days.add(row(it)));
+      days.add(Box.createVerticalStrut(6));
+    }
+    refresh();
+  }
+
+  @Override public void setOnOpen(Consumer<Intervention> onOpen){
+    this.onOpen = onOpen != null ? onOpen : it -> {};
+  }
+
+  private void refresh(){
+    days.revalidate();
+    days.repaint();
+  }
+
+  private JComponent emptyState(){
+    JLabel label = new JLabel("Aucune intervention", JLabel.CENTER);
+    label.setAlignmentX(Component.LEFT_ALIGNMENT);
+    label.setBorder(BorderFactory.createEmptyBorder(12, 8, 12, 8));
+    return label;
+  }
+
+  private JComponent dayHeader(LocalDate day){
+    String text = dayFormatter.format(day);
+    JLabel label = new JLabel(capitalize(text), IconRegistry.small("calendar"), JLabel.LEFT);
+    label.setOpaque(true);
+    label.setBackground(new Color(245, 245, 245));
+    label.setBorder(BorderFactory.createCompoundBorder(
+        BorderFactory.createMatteBorder(1, 0, 0, 0, new Color(230, 230, 230)),
+        BorderFactory.createEmptyBorder(6, 8, 4, 8)
+    ));
+    label.setAlignmentX(Component.LEFT_ALIGNMENT);
+    label.setFont(label.getFont().deriveFont(Font.BOLD));
+    return label;
+  }
+
+  private JComponent row(Intervention it){
+    JPanel panel = new JPanel(new BorderLayout(8, 0));
+    panel.setOpaque(true);
+    panel.setBackground(Color.WHITE);
+    panel.setBorder(BorderFactory.createCompoundBorder(
+        BorderFactory.createMatteBorder(0, 0, 1, 0, new Color(235, 235, 235)),
+        BorderFactory.createEmptyBorder(6, 8, 6, 8)
+    ));
+    panel.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+    JLabel iconLabel = new JLabel();
+    InterventionType type = it.getType();
+    if (type != null){
+      iconLabel.setIcon(IconRegistry.small(type.getIconKey()));
+    }
+    panel.add(iconLabel, BorderLayout.WEST);
+
+    LocalDateTime start = it.getDateHeureDebut();
+    String time = start != null ? timeFormatter.format(start) : "";
+    String title = escape(it.getLabel());
+    String client = escape(it.getClientName());
+    String address = escape(it.getAddress());
+    StringBuilder html = new StringBuilder("<html><b>").append(title).append("</b>");
+    if (!client.isBlank()){
+      html.append(" — ").append(client);
+    }
+    if (!time.isBlank()){
+      html.append(" — ").append(time);
+    }
+    if (!address.isBlank()){
+      html.append("<br/><span style='color:#555555'>").append(address).append("</span>");
+    }
+    html.append("</html>");
+    JLabel text = new JLabel(html.toString());
+    panel.add(text, BorderLayout.CENTER);
+
+    panel.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+    panel.addMouseListener(new MouseAdapter(){
+      @Override public void mouseClicked(MouseEvent e){
+        if (e.getClickCount() == 2){
+          onOpen.accept(it);
+        }
+      }
+    });
+    return panel;
+  }
+
+  private LocalDate dayOf(Intervention it){
+    LocalDateTime start = it.getDateHeureDebut();
+    if (start != null){
+      return start.toLocalDate();
+    }
+    LocalDate day = it.getDateDebut();
+    if (day != null){
+      return day;
+    }
+    return LocalDate.of(1970, 1, 1);
+  }
+
+  private LocalDateTime startDateTime(Intervention it){
+    LocalDateTime start = it.getDateHeureDebut();
+    if (start != null){
+      return start;
+    }
+    LocalDate day = it.getDateDebut();
+    if (day != null){
+      return day.atStartOfDay();
+    }
+    return LocalDateTime.MIN;
+  }
+
+  private String escape(String value){
+    if (value == null){
+      return "";
+    }
+    return value.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .trim();
+  }
+
+  private String capitalize(String value){
+    if (value == null || value.isBlank()){
+      return "";
+    }
+    return value.substring(0, 1).toUpperCase(Locale.FRENCH) + value.substring(1);
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionTableView.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionTableView.java
@@ -1,0 +1,165 @@
+package com.materiel.suite.client.ui.planning;
+
+import com.materiel.suite.client.model.Intervention;
+import com.materiel.suite.client.model.InterventionType;
+import com.materiel.suite.client.model.ResourceRef;
+import com.materiel.suite.client.ui.icons.IconRegistry;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.DefaultTableModel;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+/** Vue tabulaire compacte des interventions. */
+public class InterventionTableView implements InterventionView {
+  private final DefaultTableModel model = new DefaultTableModel(
+      new Object[]{"Début", "Fin", "Type", "Titre", "Client", "Adresse", "Ressources"}, 0){
+    @Override public boolean isCellEditable(int row, int column){ return false; }
+    @Override public Class<?> getColumnClass(int columnIndex){
+      if (columnIndex == 0 || columnIndex == 1){
+        return LocalDateTime.class;
+      }
+      if (columnIndex == 6){
+        return List.class;
+      }
+      return Object.class;
+    }
+  };
+  private final JTable table = new JTable(model);
+  private final JScrollPane scroller = new JScrollPane(table);
+  private final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("dd/MM HH:mm");
+  private List<Intervention> current = List.of();
+  private Consumer<Intervention> onOpen = it -> {};
+
+  public InterventionTableView(){
+    table.setRowHeight(24);
+    table.setFillsViewportHeight(true);
+    table.setAutoCreateRowSorter(true);
+    table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+    table.getColumnModel().getColumn(0).setCellRenderer(dateRenderer());
+    table.getColumnModel().getColumn(1).setCellRenderer(dateRenderer());
+    table.getColumnModel().getColumn(2).setCellRenderer(typeRenderer());
+    table.getColumnModel().getColumn(6).setCellRenderer(resourceRenderer());
+    table.addMouseListener(new MouseAdapter(){
+      @Override public void mouseClicked(MouseEvent e){
+        if (e.getClickCount() == 2){
+          int row = table.getSelectedRow();
+          if (row < 0){
+            return;
+          }
+          int modelRow = table.convertRowIndexToModel(row);
+          if (modelRow >= 0 && modelRow < current.size()){
+            onOpen.accept(current.get(modelRow));
+          }
+        }
+      }
+    });
+    scroller.setBorder(BorderFactory.createEmptyBorder());
+  }
+
+  @Override public JComponent getComponent(){
+    return scroller;
+  }
+
+  @Override public void setData(List<Intervention> list){
+    List<Intervention> data = new ArrayList<>();
+    if (list != null){
+      for (Intervention it : list){
+        if (it != null){
+          data.add(it);
+        }
+      }
+    }
+    current = data;
+    model.setRowCount(0);
+    for (Intervention it : current){
+      model.addRow(new Object[]{
+          it.getDateHeureDebut(),
+          it.getDateHeureFin(),
+          it.getType(),
+          safe(it.getLabel()),
+          safe(it.getClientName()),
+          safe(it.getAddress()),
+          it.getResources()
+      });
+    }
+  }
+
+  @Override public void setOnOpen(Consumer<Intervention> onOpen){
+    this.onOpen = onOpen != null ? onOpen : it -> {};
+  }
+
+  private DefaultTableCellRenderer dateRenderer(){
+    return new DefaultTableCellRenderer(){
+      @Override public void setValue(Object value){
+        if (value instanceof LocalDateTime ldt){
+          setText(dateFormatter.format(ldt));
+        } else {
+          setText("");
+        }
+      }
+    };
+  }
+
+  private DefaultTableCellRenderer typeRenderer(){
+    return new DefaultTableCellRenderer(){
+      @Override public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column){
+        JLabel label = (JLabel) super.getTableCellRendererComponent(table, "", isSelected, hasFocus, row, column);
+        label.setIcon(null);
+        if (value instanceof InterventionType type){
+          label.setText(type.toString());
+          label.setIcon(IconRegistry.small(type.getIconKey()));
+          label.setIconTextGap(6);
+        } else {
+          label.setText("");
+        }
+        return label;
+      }
+    };
+  }
+
+  private DefaultTableCellRenderer resourceRenderer(){
+    return new DefaultTableCellRenderer(){
+      @Override public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column){
+        JPanel panel = new JPanel(new FlowLayout(FlowLayout.LEFT, 4, 2));
+        panel.setOpaque(true);
+        panel.setBackground(isSelected ? table.getSelectionBackground() : table.getBackground());
+        if (value instanceof List<?> list){
+          for (Object obj : list){
+            if (obj instanceof ResourceRef ref){
+              JLabel label = new JLabel();
+              label.setOpaque(false);
+              String iconKey = ref.getIcon();
+              if (IconRegistry.isKnownKey(iconKey)){
+                label.setIcon(IconRegistry.small(iconKey));
+              } else if (iconKey != null && !iconKey.isBlank()){
+                label.setText(iconKey);
+              } else {
+                label.setIcon(IconRegistry.placeholder(16));
+              }
+              label.setToolTipText(ref.getName());
+              panel.add(label);
+            }
+          }
+        }
+        if (panel.getComponentCount() == 0){
+          JLabel empty = new JLabel("—");
+          empty.setForeground(table.getForeground());
+          panel.add(empty);
+        }
+        return panel;
+      }
+    };
+  }
+
+  private String safe(String value){
+    return value == null ? "" : value;
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionView.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionView.java
@@ -1,0 +1,14 @@
+package com.materiel.suite.client.ui.planning;
+
+import com.materiel.suite.client.model.Intervention;
+
+import javax.swing.*;
+import java.util.List;
+import java.util.function.Consumer;
+
+/** Interface minimale pour alimenter les différentes vues d'interventions. */
+public interface InterventionView {
+  JComponent getComponent();
+  void setData(List<Intervention> list);
+  void setOnOpen(Consumer<Intervention> onOpen);
+}


### PR DESCRIPTION
## Summary
- add an `InterventionView` abstraction with calendar and table implementations for interventions
- embed the new views in the planning panel via tabbed navigation and shared open handlers
- refresh the planning panel to feed the additional views and surface load feedback

## Testing
- mvn -pl client -am -DskipTests package *(fails: network unreachable while downloading Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ca778525cc833098cb8c8e6ab0e126