### PR TITLE
feat: enable calendar drag and date filtering

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionView.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionView.java
@@ -3,7 +3,9 @@ package com.materiel.suite.client.ui.planning;
 import com.materiel.suite.client.model.Intervention;
 
 import javax.swing.*;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /** Interface minimale pour alimenter les différentes vues d'interventions. */
@@ -11,4 +13,5 @@ public interface InterventionView {
   JComponent getComponent();
   void setData(List<Intervention> list);
   void setOnOpen(Consumer<Intervention> onOpen);
+  default void setOnMove(BiConsumer<Intervention, LocalDate> onMove){}
 }


### PR DESCRIPTION
## Summary
- add a move callback to intervention views and implement drag-and-drop support with drop targets in the calendar agenda
- extend the planning toolbar with week/month range controls and reload helpers to filter simple views
- persist calendar drag updates by saving interventions on drop and refreshing the planning data

## Testing
- mvn -pl client test *(fails: network is unreachable when resolving Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7def19bc83309cc11ac7d77b00c5