### PR TITLE
Add weekly calendar grid interactions

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionView.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionView.java
@@ -4,6 +4,7 @@ import com.materiel.suite.client.model.Intervention;
 
 import javax.swing.*;
 import java.time.LocalDate;
+import java.util.Date;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -14,4 +15,7 @@ public interface InterventionView {
   void setData(List<Intervention> list);
   void setOnOpen(Consumer<Intervention> onOpen);
   default void setOnMove(BiConsumer<Intervention, LocalDate> onMove){}
+  default void setOnMoveDateTime(BiConsumer<Intervention, Date> onMoveDateTime){}
+  default void setOnResizeDateTime(BiConsumer<Intervention, Date> onResizeDateTime){}
+  default void setMode(String mode){}
 }


### PR DESCRIPTION
## Summary
- extend the `InterventionView` contract with callbacks for precise moves, resizing, and mode switching
- replace the calendar view implementation with a dual month/week renderer that supports drag and resize interactions in the weekly grid
- wire the planning panel to the new callbacks and mode changes while preserving existing reload logic

## Testing
- `mvn -pl client -am -DskipTests compile` *(fails: repository download blocked in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68ca82b647788330966c8402f092ff6f