### PR TITLE
Add resource type catalog management and v2 API support

### DIFF
--- a/backend/src/main/java/com/materiel/suite/backend/resources/ResourceTypeCatalogService.java
+++ b/backend/src/main/java/com/materiel/suite/backend/resources/ResourceTypeCatalogService.java
@@ -1,0 +1,93 @@
+package com.materiel.suite.backend.resources;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class ResourceTypeCatalogService {
+  private final Map<String, ResourceTypeV2Dto> store = new ConcurrentHashMap<>();
+
+  @PostConstruct
+  public void seed(){
+    if (!store.isEmpty()){
+      return;
+    }
+    put("CRANE", "Grue", "crane", new BigDecimal("120.00"));
+    put("TRUCK", "Camion", "truck", new BigDecimal("85.00"));
+    put("FORKLIFT", "Chariot", "forklift", new BigDecimal("55.00"));
+    put("CONTAINER", "Nacelle", "container", new BigDecimal("95.00"));
+  }
+
+  private void put(String id, String name, String icon, BigDecimal price){
+    ResourceTypeV2Dto dto = new ResourceTypeV2Dto();
+    dto.setId(id);
+    dto.setName(name);
+    dto.setIconKey(icon);
+    dto.setUnitPriceHt(price);
+    store.put(id, dto);
+  }
+
+  public List<ResourceTypeV2Dto> list(){
+    List<ResourceTypeV2Dto> list = new ArrayList<>();
+    for (ResourceTypeV2Dto dto : store.values()){
+      list.add(copy(dto));
+    }
+    return list;
+  }
+
+  public Optional<ResourceTypeV2Dto> get(String id){
+    if (id == null || id.isBlank()){
+      return Optional.empty();
+    }
+    return Optional.ofNullable(store.get(id)).map(this::copy);
+  }
+
+  public ResourceTypeV2Dto create(ResourceTypeV2Dto dto){
+    if (dto == null){
+      return null;
+    }
+    ResourceTypeV2Dto copy = copy(dto);
+    if (copy.getId() == null || copy.getId().isBlank()){
+      copy.setId(UUID.randomUUID().toString());
+    }
+    store.put(copy.getId(), copy);
+    return copy(copy);
+  }
+
+  public ResourceTypeV2Dto update(String id, ResourceTypeV2Dto dto){
+    if (id == null || id.isBlank()){
+      throw new IllegalArgumentException("id manquant");
+    }
+    ResourceTypeV2Dto copy = copy(dto);
+    copy.setId(id);
+    store.put(id, copy);
+    return copy(copy);
+  }
+
+  public void delete(String id){
+    if (id == null || id.isBlank()){
+      return;
+    }
+    store.remove(id);
+  }
+
+  private ResourceTypeV2Dto copy(ResourceTypeV2Dto dto){
+    if (dto == null){
+      return new ResourceTypeV2Dto();
+    }
+    ResourceTypeV2Dto copy = new ResourceTypeV2Dto();
+    copy.setId(dto.getId());
+    copy.setName(dto.getName());
+    copy.setIconKey(dto.getIconKey());
+    copy.setUnitPriceHt(dto.getUnitPriceHt());
+    return copy;
+  }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/resources/ResourceTypeV2Controller.java
+++ b/backend/src/main/java/com/materiel/suite/backend/resources/ResourceTypeV2Controller.java
@@ -1,0 +1,49 @@
+package com.materiel.suite.backend.resources;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v2/resource-types")
+public class ResourceTypeV2Controller {
+  private final ResourceTypeCatalogService service;
+
+  public ResourceTypeV2Controller(ResourceTypeCatalogService service){
+    this.service = service;
+  }
+
+  @GetMapping
+  public ResponseEntity<List<ResourceTypeV2Dto>> list(){
+    return ResponseEntity.ok(service.list());
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<ResourceTypeV2Dto> get(@PathVariable String id){
+    return service.get(id).map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());
+  }
+
+  @PostMapping
+  public ResponseEntity<ResourceTypeV2Dto> create(@RequestBody ResourceTypeV2Dto body){
+    return ResponseEntity.ok(service.create(body));
+  }
+
+  @PutMapping("/{id}")
+  public ResponseEntity<ResourceTypeV2Dto> update(@PathVariable String id, @RequestBody ResourceTypeV2Dto body){
+    return ResponseEntity.ok(service.update(id, body));
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> delete(@PathVariable String id){
+    service.delete(id);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/resources/ResourceTypeV2Dto.java
+++ b/backend/src/main/java/com/materiel/suite/backend/resources/ResourceTypeV2Dto.java
@@ -1,0 +1,55 @@
+package com.materiel.suite.backend.resources;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+public class ResourceTypeV2Dto {
+  private String id;
+  private String name;
+  private String iconKey;
+  private BigDecimal unitPriceHt;
+
+  public String getId(){
+    return id;
+  }
+
+  public void setId(String id){
+    this.id = id;
+  }
+
+  public String getName(){
+    return name;
+  }
+
+  public void setName(String name){
+    this.name = name;
+  }
+
+  public String getIconKey(){
+    return iconKey;
+  }
+
+  public void setIconKey(String iconKey){
+    this.iconKey = iconKey;
+  }
+
+  public BigDecimal getUnitPriceHt(){
+    return unitPriceHt;
+  }
+
+  public void setUnitPriceHt(BigDecimal unitPriceHt){
+    this.unitPriceHt = unitPriceHt;
+  }
+
+  @Override
+  public boolean equals(Object o){
+    if (this == o) return true;
+    if (!(o instanceof ResourceTypeV2Dto other)) return false;
+    return Objects.equals(id, other.id);
+  }
+
+  @Override
+  public int hashCode(){
+    return Objects.hash(id);
+  }
+}

--- a/backend/src/main/resources/openapi/gestion-materiel-v1.yaml
+++ b/backend/src/main/resources/openapi/gestion-materiel-v1.yaml
@@ -239,6 +239,83 @@ paths:
       responses:
         '204':
           description: Deleted
+  /api/v2/resource-types:
+    get:
+      summary: Lister les types de ressources (v2)
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ResourceTypeV2'
+    post:
+      summary: Créer un type de ressource (v2)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResourceTypeV2'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceTypeV2'
+  /api/v2/resource-types/{id}:
+    get:
+      summary: Obtenir un type de ressource (v2)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceTypeV2'
+        '404':
+          description: Not found
+    put:
+      summary: Mettre à jour un type de ressource (v2)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResourceTypeV2'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceTypeV2'
+    delete:
+      summary: Supprimer un type de ressource (v2)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Deleted
   /api/v2/intervention-types:
     get:
       summary: List intervention types (v2)
@@ -477,6 +554,17 @@ components:
           type: string
         icon:
           type: string
+    ResourceTypeV2:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        iconKey:
+          type: string
+        unitPriceHt:
+          type: number
     Unavailability:
       type: object
       required: [start, end]

--- a/client/src/main/java/com/materiel/suite/client/model/ResourceType.java
+++ b/client/src/main/java/com/materiel/suite/client/model/ResourceType.java
@@ -1,36 +1,47 @@
 package com.materiel.suite.client.model;
 
+import java.math.BigDecimal;
 import java.util.Objects;
 
 public class ResourceType {
-  private String code;
-  private String label;
-  private String icon;
+  private String id;
+  private String name;
+  private String iconKey;
+  private BigDecimal unitPriceHt;
 
   public ResourceType(){}
-  public ResourceType(String code, String label){ this.code = code; this.label = label; }
-  public ResourceType(String code, String label, String icon){ this.code = code; this.label = label; this.icon = icon; }
+  public ResourceType(String code, String label){ this.id = code; this.name = label; }
+  public ResourceType(String code, String label, String icon){ this.id = code; this.name = label; this.iconKey = icon; }
 
-  public String getCode(){ return code; }
-  public void setCode(String code){ this.code = code; }
-  public String getLabel(){ return label; }
-  public void setLabel(String label){ this.label = label; }
-  public String getIcon(){ return icon; }
-  public void setIcon(String icon){ this.icon = icon; }
+  public String getId(){ return id; }
+  public void setId(String id){ this.id = id; }
+  public String getName(){ return name; }
+  public void setName(String name){ this.name = name; }
+  public String getIconKey(){ return iconKey; }
+  public void setIconKey(String iconKey){ this.iconKey = iconKey; }
+  public BigDecimal getUnitPriceHt(){ return unitPriceHt; }
+  public void setUnitPriceHt(BigDecimal unitPriceHt){ this.unitPriceHt = unitPriceHt; }
+
+  public String getCode(){ return id; }
+  public void setCode(String code){ this.id = code; }
+  public String getLabel(){ return name; }
+  public void setLabel(String label){ this.name = label; }
+  public String getIcon(){ return iconKey; }
+  public void setIcon(String icon){ this.iconKey = icon; }
 
   @Override public String toString(){
-    if (label!=null && !label.isBlank()) return label;
-    return code;
+    if (name!=null && !name.isBlank()) return name;
+    return id;
   }
 
   @Override public boolean equals(Object o){
     if (this == o) return true;
     if (!(o instanceof ResourceType)) return false;
     ResourceType that = (ResourceType) o;
-    return Objects.equals(code, that.code);
+    return Objects.equals(getCode(), that.getCode());
   }
 
   @Override public int hashCode(){
-    return Objects.hash(code);
+    return Objects.hash(getCode());
   }
 }

--- a/client/src/main/java/com/materiel/suite/client/net/ServiceFactory.java
+++ b/client/src/main/java/com/materiel/suite/client/net/ServiceFactory.java
@@ -16,6 +16,7 @@ public class ServiceFactory {
   private static DocumentWorkflowService workflowService;
   private static ClientService clientService;
   private static InterventionTypeService interventionTypeService;
+  private static ResourceTypeService resourceTypeService;
 
   public static void init(AppConfig c) {
     cfg = c;
@@ -36,6 +37,7 @@ public class ServiceFactory {
     workflowService = new MockWorkflowService();
     clientService = new MockClientService();
     interventionTypeService = new MockInterventionTypeService();
+    resourceTypeService = new MockResourceTypeService();
   }
 
   private static void initBackend() {
@@ -52,6 +54,7 @@ public class ServiceFactory {
     workflowService = new ApiWorkflowService(rc);
     clientService = new ApiClientService(rc, new MockClientService());
     interventionTypeService = new ApiInterventionTypeService(rc, new MockInterventionTypeService());
+    resourceTypeService = new ApiResourceTypeService(rc, new MockResourceTypeService());
   }
 
   public static QuoteService quotes(){ return quoteService; }
@@ -62,6 +65,7 @@ public class ServiceFactory {
   public static DocumentWorkflowService workflow(){ return workflowService; }
   public static ClientService clients(){ return clientService; }
   public static InterventionTypeService interventionTypes(){ return interventionTypeService; }
+  public static ResourceTypeService resourceTypes(){ return resourceTypeService; }
   public static RestClient http(){ return restClient; }
 }
 

--- a/client/src/main/java/com/materiel/suite/client/service/ResourceTypeService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/ResourceTypeService.java
@@ -1,0 +1,11 @@
+package com.materiel.suite.client.service;
+
+import com.materiel.suite.client.model.ResourceType;
+
+import java.util.List;
+
+public interface ResourceTypeService {
+  List<ResourceType> listAll();
+  ResourceType save(ResourceType type);
+  void delete(String id);
+}

--- a/client/src/main/java/com/materiel/suite/client/service/api/ApiResourceTypeService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/api/ApiResourceTypeService.java
@@ -1,0 +1,145 @@
+package com.materiel.suite.client.service.api;
+
+import com.materiel.suite.client.model.ResourceType;
+import com.materiel.suite.client.net.RestClient;
+import com.materiel.suite.client.net.SimpleJson;
+import com.materiel.suite.client.service.ResourceTypeService;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class ApiResourceTypeService implements ResourceTypeService {
+  private final RestClient rc;
+  private final ResourceTypeService fallback;
+
+  public ApiResourceTypeService(RestClient rc, ResourceTypeService fallback){
+    this.rc = rc;
+    this.fallback = fallback;
+  }
+
+  @Override
+  public List<ResourceType> listAll(){
+    if (rc == null){
+      return fallback != null ? fallback.listAll() : List.of();
+    }
+    try {
+      String body = rc.get("/api/v2/resource-types");
+      var arr = SimpleJson.asArr(SimpleJson.parse(body));
+      List<ResourceType> out = new ArrayList<>();
+      for (Object o : arr){
+        out.add(fromMap(SimpleJson.asObj(o)));
+      }
+      return out;
+    } catch (Exception e){
+      return fallback != null ? fallback.listAll() : List.of();
+    }
+  }
+
+  @Override
+  public ResourceType save(ResourceType type){
+    if (rc == null){
+      return fallback != null ? fallback.save(type) : type;
+    }
+    try {
+      boolean create = type.getId() == null || type.getId().isBlank();
+      String payload = toJson(type);
+      String response;
+      if (create){
+        response = rc.post("/api/v2/resource-types", payload);
+      } else {
+        response = rc.put("/api/v2/resource-types/" + encode(type.getId()), payload);
+      }
+      return fromMap(SimpleJson.asObj(SimpleJson.parse(response)));
+    } catch (Exception e){
+      return fallback != null ? fallback.save(type) : type;
+    }
+  }
+
+  @Override
+  public void delete(String id){
+    if (id == null || id.isBlank()){
+      return;
+    }
+    if (rc != null){
+      try {
+        rc.delete("/api/v2/resource-types/" + encode(id));
+      } catch (IOException | InterruptedException ignore){}
+    }
+    if (fallback != null){
+      fallback.delete(id);
+    }
+  }
+
+  private ResourceType fromMap(Map<String, Object> map){
+    ResourceType type = new ResourceType();
+    type.setId(SimpleJson.str(map.get("id")));
+    type.setName(SimpleJson.str(map.get("name")));
+    type.setIconKey(SimpleJson.str(map.get("iconKey")));
+    type.setUnitPriceHt(parseBigDecimal(map.get("unitPriceHt")));
+    return type;
+  }
+
+  private BigDecimal parseBigDecimal(Object value){
+    if (value == null){
+      return null;
+    }
+    if (value instanceof BigDecimal bd){
+      return bd;
+    }
+    if (value instanceof Number n){
+      return BigDecimal.valueOf(n.doubleValue());
+    }
+    try {
+      return new BigDecimal(value.toString());
+    } catch (NumberFormatException ex){
+      return null;
+    }
+  }
+
+  private String toJson(ResourceType type){
+    StringBuilder sb = new StringBuilder("{");
+    appendField(sb, "id", type.getId());
+    appendField(sb, "name", type.getName());
+    appendField(sb, "iconKey", type.getIconKey());
+    appendNumber(sb, "unitPriceHt", type.getUnitPriceHt());
+    sb.append('}');
+    return sb.toString();
+  }
+
+  private void appendField(StringBuilder sb, String key, String value){
+    if (sb.length() > 1){
+      sb.append(',');
+    }
+    sb.append('"').append(key).append('"').append(':');
+    if (value == null){
+      sb.append("null");
+    } else {
+      sb.append('"').append(escape(value)).append('"');
+    }
+  }
+
+  private void appendNumber(StringBuilder sb, String key, BigDecimal value){
+    if (sb.length() > 1){
+      sb.append(',');
+    }
+    sb.append('"').append(key).append('"').append(':');
+    if (value == null){
+      sb.append("null");
+    } else {
+      sb.append(value.stripTrailingZeros().toPlainString());
+    }
+  }
+
+  private String escape(String s){
+    return s.replace("\\", "\\\\").replace("\"", "\\\"");
+  }
+
+  private String encode(String value){
+    return URLEncoder.encode(value, StandardCharsets.UTF_8);
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/service/mock/MockResourceTypeService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/mock/MockResourceTypeService.java
@@ -1,0 +1,83 @@
+package com.materiel.suite.client.service.mock;
+
+import com.materiel.suite.client.model.ResourceType;
+import com.materiel.suite.client.service.ResourceTypeService;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class MockResourceTypeService implements ResourceTypeService {
+  private final Map<String, ResourceType> store = new ConcurrentHashMap<>();
+
+  public MockResourceTypeService(){
+    seed();
+  }
+
+  @Override
+  public List<ResourceType> listAll(){
+    List<ResourceType> list = new ArrayList<>();
+    for (ResourceType type : store.values()){
+      list.add(copyOf(type));
+    }
+    return list;
+  }
+
+  @Override
+  public ResourceType save(ResourceType type){
+    if (type == null){
+      return null;
+    }
+    ResourceType copy = copyOf(type);
+    if (copy.getId() == null || copy.getId().isBlank()){
+      copy.setId(UUID.randomUUID().toString());
+    }
+    store.put(copy.getId(), copy);
+    return copyOf(copy);
+  }
+
+  @Override
+  public void delete(String id){
+    if (id != null){
+      store.remove(id);
+    }
+  }
+
+  private void seed(){
+    if (!store.isEmpty()){
+      return;
+    }
+    put(create("CRANE", "Grue", "crane", new BigDecimal("120.00")));
+    put(create("TRUCK", "Camion", "truck", new BigDecimal("85.00")));
+    put(create("FORKLIFT", "Chariot", "forklift", new BigDecimal("55.00")));
+    put(create("CONTAINER", "Nacelle", "container", new BigDecimal("95.00")));
+  }
+
+  private void put(ResourceType type){
+    store.put(type.getId(), copyOf(type));
+  }
+
+  private ResourceType create(String id, String name, String icon, BigDecimal price){
+    ResourceType type = new ResourceType();
+    type.setId(id);
+    type.setName(name);
+    type.setIconKey(icon);
+    type.setUnitPriceHt(price);
+    return type;
+  }
+
+  private ResourceType copyOf(ResourceType src){
+    if (src == null){
+      return null;
+    }
+    ResourceType copy = new ResourceType();
+    copy.setId(src.getId());
+    copy.setName(src.getName());
+    copy.setIconKey(src.getIconKey());
+    copy.setUnitPriceHt(src.getUnitPriceHt());
+    return copy;
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/icons/IconRegistry.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/icons/IconRegistry.java
@@ -15,7 +15,8 @@ public final class IconRegistry {
       "crane", "truck", "forklift", "excavator", "generator", "container",
       "hook", "helmet", "wrench", "pallet", "calendar", "user",
       "file", "invoice", "search", "success", "error", "info",
-      "settings", "signature", "task"
+      "settings", "signature", "task", "plus", "edit", "trash",
+      "refresh", "image", "cube"
   );
   private static final Set<String> ICON_SET = Set.copyOf(ICON_KEYS);
   private static final Map<Integer, Icon> PLACEHOLDER_CACHE = new ConcurrentHashMap<>();

--- a/client/src/main/java/com/materiel/suite/client/ui/resources/ResourceTypeEditor.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/resources/ResourceTypeEditor.java
@@ -1,0 +1,289 @@
+package com.materiel.suite.client.ui.resources;
+
+import com.materiel.suite.client.model.ResourceType;
+import com.materiel.suite.client.net.ServiceFactory;
+import com.materiel.suite.client.service.ResourceTypeService;
+import com.materiel.suite.client.ui.common.Toasts;
+import com.materiel.suite.client.ui.icons.IconPickerDialog;
+import com.materiel.suite.client.ui.icons.IconRegistry;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.DefaultTableModel;
+import java.awt.*;
+import java.math.BigDecimal;
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+
+/** Éditeur simple pour gérer les types de ressources (nom, icône, prix unitaire). */
+public class ResourceTypeEditor extends JPanel {
+  private final ResourceTypeService service = ServiceFactory.resourceTypes();
+  private final DefaultTableModel model = new DefaultTableModel(new Object[]{"Icône", "Nom", "PU HT"}, 0){
+    @Override public boolean isCellEditable(int row, int column){ return false; }
+  };
+  private final JTable table = new JTable(model);
+  private final JButton addButton = new JButton("Ajouter", IconRegistry.small("plus"));
+  private final JButton editButton = new JButton("Modifier", IconRegistry.small("edit"));
+  private final JButton deleteButton = new JButton("Supprimer", IconRegistry.small("trash"));
+  private final JButton refreshButton = new JButton("Recharger", IconRegistry.small("refresh"));
+  private List<ResourceType> current = new ArrayList<>();
+
+  public ResourceTypeEditor(){
+    super(new BorderLayout(6, 6));
+    buildUI();
+    reload();
+  }
+
+  private void buildUI(){
+    table.setRowHeight(26);
+    table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+    table.getTableHeader().setReorderingAllowed(false);
+    if (table.getColumnModel().getColumnCount() > 0){
+      table.getColumnModel().getColumn(0).setMinWidth(48);
+      table.getColumnModel().getColumn(0).setMaxWidth(64);
+      table.getColumnModel().getColumn(0).setCellRenderer(new IconCellRenderer());
+    }
+
+    JToolBar toolbar = new JToolBar();
+    toolbar.setFloatable(false);
+    toolbar.add(addButton);
+    toolbar.add(editButton);
+    toolbar.add(deleteButton);
+    toolbar.addSeparator();
+    toolbar.add(refreshButton);
+
+    add(toolbar, BorderLayout.NORTH);
+    add(new JScrollPane(table), BorderLayout.CENTER);
+
+    addButton.addActionListener(e -> openDialog(null));
+    editButton.addActionListener(e -> {
+      ResourceType type = currentSelection();
+      if (type != null){
+        openDialog(type);
+      }
+    });
+    deleteButton.addActionListener(e -> onDelete());
+    refreshButton.addActionListener(e -> reload());
+
+    boolean available = service != null;
+    addButton.setEnabled(available);
+    editButton.setEnabled(available);
+    deleteButton.setEnabled(available);
+    refreshButton.setEnabled(available);
+    table.setEnabled(available);
+  }
+
+  private void reload(){
+    model.setRowCount(0);
+    current = new ArrayList<>();
+    if (service == null){
+      return;
+    }
+    try {
+      List<ResourceType> list = new ArrayList<>(service.listAll());
+      list.sort(Comparator.comparing(rt -> normalize(rt.getName()), String.CASE_INSENSITIVE_ORDER));
+      current.addAll(list);
+      for (ResourceType type : list){
+        BigDecimal price = type.getUnitPriceHt();
+        model.addRow(new Object[]{ type.getIconKey(), type.getName(), price });
+      }
+    } catch (Exception ex){
+      Toasts.error(this, "Chargement impossible : " + ex.getMessage());
+    }
+  }
+
+  private String normalize(String value){
+    return value == null ? "" : value.toLowerCase(Locale.ROOT);
+  }
+
+  private ResourceType currentSelection(){
+    int row = table.getSelectedRow();
+    if (row < 0){
+      return null;
+    }
+    int modelRow = table.convertRowIndexToModel(row);
+    if (modelRow < 0 || modelRow >= current.size()){
+      return null;
+    }
+    return current.get(modelRow);
+  }
+
+  private void onDelete(){
+    ResourceType type = currentSelection();
+    if (type == null || service == null){
+      return;
+    }
+    try {
+      service.delete(type.getId());
+      Toasts.success(this, "Type supprimé");
+      reload();
+    } catch (Exception ex){
+      Toasts.error(this, "Suppression impossible : " + ex.getMessage());
+    }
+  }
+
+  private void openDialog(ResourceType initial){
+    if (service == null){
+      return;
+    }
+    Window owner = SwingUtilities.getWindowAncestor(this);
+    JDialog dialog = new JDialog(owner, "Type de ressource", Dialog.ModalityType.APPLICATION_MODAL);
+    JTextField nameField = new JTextField(initial != null ? valueOrEmpty(initial.getName()) : "");
+    JTextField iconField = new JTextField(initial != null ? valueOrEmpty(initial.getIconKey()) : "");
+    iconField.setEditable(false);
+    JButton pickIcon = new JButton("Choisir icône", IconRegistry.small("image"));
+
+    NumberFormat numberFormat = NumberFormat.getNumberInstance(Locale.FRANCE);
+    numberFormat.setMaximumFractionDigits(2);
+    numberFormat.setMinimumFractionDigits(0);
+    numberFormat.setGroupingUsed(true);
+    JFormattedTextField priceField = new JFormattedTextField(numberFormat);
+    priceField.setColumns(10);
+    priceField.setValue(initial != null ? initial.getUnitPriceHt() : null);
+
+    pickIcon.addActionListener(e -> {
+      IconPickerDialog picker = new IconPickerDialog(owner);
+      String chosen = picker.pick();
+      if (chosen != null){
+        iconField.setText(chosen);
+      }
+    });
+
+    JPanel form = new JPanel(new GridBagLayout());
+    GridBagConstraints gc = new GridBagConstraints();
+    gc.insets = new Insets(6, 6, 6, 6);
+    gc.anchor = GridBagConstraints.WEST;
+    gc.fill = GridBagConstraints.HORIZONTAL;
+    gc.gridx = 0;
+    gc.gridy = 0;
+
+    form.add(new JLabel("Nom"), gc);
+    gc.gridx = 1;
+    gc.weightx = 1;
+    form.add(nameField, gc);
+
+    gc.gridx = 0;
+    gc.gridy++;
+    gc.weightx = 0;
+    form.add(new JLabel("Icône"), gc);
+    gc.gridx = 1;
+    gc.weightx = 1;
+    form.add(iconField, gc);
+    gc.gridx = 2;
+    gc.weightx = 0;
+    form.add(pickIcon, gc);
+
+    gc.gridx = 0;
+    gc.gridy++;
+    gc.weightx = 0;
+    form.add(new JLabel("PU HT (€)"), gc);
+    gc.gridx = 1;
+    gc.weightx = 1;
+    form.add(priceField, gc);
+
+    JButton saveButton = new JButton("Enregistrer", IconRegistry.small("success"));
+    JButton cancelButton = new JButton("Annuler");
+    JPanel south = new JPanel(new FlowLayout(FlowLayout.RIGHT, 8, 8));
+    south.add(saveButton);
+    south.add(cancelButton);
+
+    JPanel content = new JPanel(new BorderLayout());
+    content.add(form, BorderLayout.CENTER);
+    content.add(south, BorderLayout.SOUTH);
+    dialog.setContentPane(content);
+    dialog.pack();
+    dialog.setLocationRelativeTo(owner);
+
+    saveButton.addActionListener(e -> {
+      String name = nameField.getText() != null ? nameField.getText().trim() : "";
+      if (name.isEmpty()){
+        Toasts.error(dialog, "Le nom est requis");
+        return;
+      }
+      BigDecimal price = parsePrice(priceField);
+      ResourceType toSave = initial != null ? copyOf(initial) : new ResourceType();
+      toSave.setName(name);
+      String icon = iconField.getText() != null ? iconField.getText().trim() : "";
+      toSave.setIconKey(icon.isEmpty() ? "cube" : icon);
+      toSave.setUnitPriceHt(price);
+      try {
+        ResourceType saved = service.save(toSave);
+        Toasts.success(dialog, "Type enregistré");
+        dialog.dispose();
+        reload();
+        selectById(saved != null ? saved.getId() : toSave.getId());
+      } catch (Exception ex){
+        Toasts.error(dialog, "Enregistrement impossible : " + ex.getMessage());
+      }
+    });
+
+    cancelButton.addActionListener(e -> dialog.dispose());
+    dialog.setVisible(true);
+  }
+
+  private void selectById(String id){
+    if (id == null){
+      return;
+    }
+    for (int i = 0; i < current.size(); i++){
+      ResourceType type = current.get(i);
+      if (id.equals(type.getId())){
+        int viewRow = table.convertRowIndexToView(i);
+        table.getSelectionModel().setSelectionInterval(viewRow, viewRow);
+        table.scrollRectToVisible(table.getCellRect(viewRow, 0, true));
+        break;
+      }
+    }
+  }
+
+  private ResourceType copyOf(ResourceType src){
+    ResourceType copy = new ResourceType();
+    copy.setId(src.getId());
+    copy.setName(src.getName());
+    copy.setIconKey(src.getIconKey());
+    copy.setUnitPriceHt(src.getUnitPriceHt());
+    return copy;
+  }
+
+  private String valueOrEmpty(String value){
+    return value == null ? "" : value;
+  }
+
+  private BigDecimal parsePrice(JFormattedTextField field){
+    try {
+      field.commitEdit();
+    } catch (ParseException ignore){}
+    Object value = field.getValue();
+    if (value == null){
+      return BigDecimal.ZERO;
+    }
+    if (value instanceof BigDecimal bd){
+      return bd;
+    }
+    if (value instanceof Number number){
+      return BigDecimal.valueOf(number.doubleValue());
+    }
+    try {
+      return new BigDecimal(value.toString().replace(',', '.'));
+    } catch (NumberFormatException ex){
+      return BigDecimal.ZERO;
+    }
+  }
+
+  private static class IconCellRenderer extends DefaultTableCellRenderer {
+    @Override
+    public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column){
+      JLabel label = (JLabel) super.getTableCellRendererComponent(table, "", isSelected, hasFocus, row, column);
+      label.setHorizontalAlignment(SwingConstants.CENTER);
+      String key = value != null ? value.toString() : null;
+      Icon icon = IconRegistry.small(key);
+      label.setIcon(icon);
+      label.setText(icon == null && key != null ? key : "");
+      return label;
+    }
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/settings/SettingsPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/settings/SettingsPanel.java
@@ -1,17 +1,12 @@
 package com.materiel.suite.client.ui.settings;
 
-import com.materiel.suite.client.model.ResourceType;
-import com.materiel.suite.client.net.ServiceFactory;
-import com.materiel.suite.client.service.PlanningService;
 import com.materiel.suite.client.ui.icons.IconPickerDialog;
 import com.materiel.suite.client.ui.icons.IconRegistry;
-import com.materiel.suite.client.ui.resources.ResourceTypeEditDialog;
+import com.materiel.suite.client.ui.resources.ResourceTypeEditor;
 
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
-import javax.swing.table.DefaultTableCellRenderer;
-import javax.swing.table.DefaultTableModel;
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -19,25 +14,14 @@ import java.util.Locale;
 
 /** Panneau de paramétrage (types de ressources, bibliothèque d'icônes, etc.). */
 public class SettingsPanel extends JPanel {
-  private final PlanningService planningService;
 
   public SettingsPanel(){
     super(new BorderLayout());
-    this.planningService = ServiceFactory.planning();
 
     JTabbedPane tabs = new JTabbedPane();
-    tabs.addTab("Types de ressources", IconRegistry.small("wrench"), buildResourceTypePanel());
+    tabs.addTab("Types de ressources", IconRegistry.small("wrench"), new ResourceTypeEditor());
     tabs.addTab("Bibliothèque d'icônes", IconRegistry.small("settings"), buildIconLibraryPanel());
     add(tabs, BorderLayout.CENTER);
-  }
-
-  private JComponent buildResourceTypePanel(){
-    if (planningService == null){
-      JPanel panel = new JPanel(new BorderLayout());
-      panel.add(new JLabel("Service de planification indisponible", SwingConstants.CENTER), BorderLayout.CENTER);
-      return panel;
-    }
-    return new ResourceTypePanel(planningService);
   }
 
   private JComponent buildIconLibraryPanel(){
@@ -95,129 +79,6 @@ public class SettingsPanel extends JPanel {
       label.setText(key);
       label.setIcon(IconRegistry.medium(key));
       return label;
-    }
-  }
-
-  private static class ResourceTypePanel extends JPanel {
-    private final PlanningService service;
-    private final DefaultTableModel model = new DefaultTableModel(new Object[]{"Code", "Icône", "Libellé"}, 0){
-      @Override public boolean isCellEditable(int row, int column){ return false; }
-    };
-    private final JTable table = new JTable(model);
-
-    ResourceTypePanel(PlanningService service){
-      super(new BorderLayout(8, 8));
-      this.service = service;
-      buildUI();
-      reload();
-    }
-
-    private void buildUI(){
-      JButton add = new JButton("Ajouter…");
-      JButton edit = new JButton("Modifier…");
-      JButton delete = new JButton("Supprimer");
-
-      add.addActionListener(e -> onCreate());
-      edit.addActionListener(e -> onEdit());
-      delete.addActionListener(e -> onDelete());
-
-      JPanel toolbar = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 4));
-      toolbar.add(add);
-      toolbar.add(edit);
-      toolbar.add(delete);
-
-      table.setRowHeight(28);
-      table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-      if (table.getColumnModel().getColumnCount() > 1){
-        table.getColumnModel().getColumn(1).setMinWidth(80);
-        table.getColumnModel().getColumn(1).setMaxWidth(100);
-        table.getColumnModel().getColumn(1).setCellRenderer(new IconCellRenderer());
-      }
-
-      add(toolbar, BorderLayout.NORTH);
-      add(new JScrollPane(table), BorderLayout.CENTER);
-    }
-
-    private void reload(){
-      model.setRowCount(0);
-      List<ResourceType> types = service.listResourceTypes();
-      for (ResourceType type : types){
-        model.addRow(new Object[]{ type.getCode(), type.getIcon(), type.getLabel() });
-      }
-    }
-
-    private String selectedCode(){
-      int row = table.getSelectedRow();
-      if (row < 0){
-        return null;
-      }
-      int modelRow = table.convertRowIndexToModel(row);
-      Object value = model.getValueAt(modelRow, 0);
-      return value != null ? value.toString() : null;
-    }
-
-    private void onCreate(){
-      ResourceTypeEditDialog dialog = new ResourceTypeEditDialog(SwingUtilities.getWindowAncestor(this), service, null);
-      dialog.setVisible(true);
-      if (dialog.isSaved()){
-        reload();
-      }
-    }
-
-    private void onEdit(){
-      String code = selectedCode();
-      if (code == null){
-        return;
-      }
-      ResourceType existing = service.listResourceTypes().stream()
-          .filter(t -> code.equals(t.getCode()))
-          .findFirst()
-          .orElse(null);
-      if (existing == null){
-        return;
-      }
-      ResourceTypeEditDialog dialog = new ResourceTypeEditDialog(SwingUtilities.getWindowAncestor(this), service, existing);
-      dialog.setVisible(true);
-      if (dialog.isSaved()){
-        reload();
-      }
-    }
-
-    private void onDelete(){
-      String code = selectedCode();
-      if (code == null){
-        return;
-      }
-      int confirm = JOptionPane.showConfirmDialog(this,
-          "Supprimer le type \"" + code + "\" ?",
-          "Confirmation", JOptionPane.OK_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE);
-      if (confirm == JOptionPane.OK_OPTION){
-        try {
-          service.deleteResourceType(code);
-          reload();
-        } catch (Exception ex){
-          JOptionPane.showMessageDialog(this, "Suppression impossible : " + ex.getMessage(),
-              "Erreur", JOptionPane.ERROR_MESSAGE);
-        }
-      }
-    }
-
-    private static class IconCellRenderer extends DefaultTableCellRenderer {
-      @Override
-      public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column){
-        JLabel label = (JLabel) super.getTableCellRendererComponent(table, "", isSelected, hasFocus, row, column);
-        label.setHorizontalAlignment(SwingConstants.CENTER);
-        label.setIcon(null);
-        label.setText("");
-        String key = value != null ? value.toString() : null;
-        Icon icon = IconRegistry.medium(key);
-        if (icon != null){
-          label.setIcon(icon);
-        } else if (key != null && !key.isBlank()){
-          label.setText(key);
-        }
-        return label;
-      }
     }
   }
 


### PR DESCRIPTION
## Summary
- introduce a dedicated client resource type service with API and mock implementations plus a Swing editor for name/icon/price
- extend the client service factory, settings panel and icon registry to surface the new editor and catalog actions
- expose a backend in-memory catalog with CRUD endpoints for resource types v2 and document it in the OpenAPI spec

## Testing
- mvn -pl client -am -DskipTests package *(fails: Maven Central unreachable in environment)*
- mvn -pl backend -am -DskipTests package *(fails: Maven Central unreachable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca90b5c330833084d85445170d0d21