### PR TITLE
Add intervention type editor and improve icon fallbacks

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/service/InterventionTypeService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/InterventionTypeService.java
@@ -8,4 +8,10 @@ import java.util.List;
 public interface InterventionTypeService {
   /** Retourne la liste des types disponibles (peut être vide). */
   List<InterventionType> list();
+
+  /** Crée ou met à jour un type d'intervention. */
+  InterventionType save(InterventionType type);
+
+  /** Supprime le type correspondant au code fourni. */
+  void delete(String code);
 }

--- a/client/src/main/java/com/materiel/suite/client/service/ServiceLocator.java
+++ b/client/src/main/java/com/materiel/suite/client/service/ServiceLocator.java
@@ -1,7 +1,9 @@
 package com.materiel.suite.client.service;
 
+import com.materiel.suite.client.model.InterventionType;
 import com.materiel.suite.client.model.Resource;
 import com.materiel.suite.client.net.ServiceFactory;
+import com.materiel.suite.client.service.InterventionTypeService;
 
 import java.util.List;
 import java.util.UUID;
@@ -12,12 +14,17 @@ import java.util.UUID;
  */
 public final class ServiceLocator {
   private static final ResourcesGateway RESOURCES = new ResourcesGateway();
+  private static final InterventionTypesGateway INTERVENTION_TYPES = new InterventionTypesGateway();
 
   private ServiceLocator(){
   }
 
   public static ResourcesGateway resources(){
     return RESOURCES;
+  }
+
+  public static InterventionTypesGateway interventionTypes(){
+    return INTERVENTION_TYPES;
   }
 
   public static final class ResourcesGateway {
@@ -43,6 +50,31 @@ public final class ServiceLocator {
 
     public boolean isAvailable(){
       return ServiceFactory.planning() != null;
+    }
+  }
+
+  public static final class InterventionTypesGateway {
+    public List<InterventionType> list(){
+      InterventionTypeService svc = ServiceFactory.interventionTypes();
+      return svc != null ? svc.list() : List.of();
+    }
+
+    public InterventionType save(InterventionType type){
+      if (type == null){
+        return null;
+      }
+      InterventionTypeService svc = ServiceFactory.interventionTypes();
+      return svc != null ? svc.save(type) : type;
+    }
+
+    public void delete(String code){
+      if (code == null || code.isBlank()){
+        return;
+      }
+      InterventionTypeService svc = ServiceFactory.interventionTypes();
+      if (svc != null){
+        svc.delete(code);
+      }
     }
   }
 }

--- a/client/src/main/java/com/materiel/suite/client/service/api/ApiInterventionTypeService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/api/ApiInterventionTypeService.java
@@ -5,8 +5,11 @@ import com.materiel.suite.client.net.RestClient;
 import com.materiel.suite.client.net.SimpleJson;
 import com.materiel.suite.client.service.InterventionTypeService;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /** Récupère les types d'intervention via l'API (v2). */
 public class ApiInterventionTypeService implements InterventionTypeService {
@@ -20,33 +23,110 @@ public class ApiInterventionTypeService implements InterventionTypeService {
 
   @Override
   public List<InterventionType> list(){
+    if (rc == null){
+      return fallback != null ? fallback.list() : List.of();
+    }
     try {
       String body = rc.get("/api/v2/intervention-types");
       List<Object> arr = SimpleJson.asArr(SimpleJson.parse(body));
       List<InterventionType> list = new ArrayList<>();
       for (Object o : arr){
-        if (!(o instanceof java.util.Map<?,?> map)) continue;
-        String code = SimpleJson.str(map.get("id"));
-        String label = SimpleJson.str(map.get("name"));
-        String icon = SimpleJson.str(map.get("iconKey"));
-        if (code == null || code.isBlank()){
-          if (label == null || label.isBlank()){
-            continue;
-          }
-          code = label.trim();
+        InterventionType type = fromMap(SimpleJson.asObj(o));
+        if (type != null){
+          list.add(type);
         }
-        InterventionType type = new InterventionType();
-        type.setCode(code);
-        type.setLabel(label != null && !label.isBlank() ? label : code);
-        type.setIconKey(icon);
-        list.add(type);
       }
-      if (!list.isEmpty()){
-        return list;
-      }
+      return list;
     } catch (Exception ignore){
-      // fallback ci-dessous
+      return fallback != null ? fallback.list() : List.of();
     }
-    return fallback != null ? fallback.list() : List.of();
+  }
+
+  @Override
+  public InterventionType save(InterventionType type){
+    if (type == null){
+      return null;
+    }
+    if (rc == null){
+      return fallback != null ? fallback.save(type) : type;
+    }
+    try {
+      boolean create = type.getCode() == null || type.getCode().isBlank();
+      String payload = toJson(type);
+      String response;
+      if (create){
+        response = rc.post("/api/v2/intervention-types", payload);
+      } else {
+        response = rc.put("/api/v2/intervention-types/" + encode(type.getCode()), payload);
+      }
+      return fromMap(SimpleJson.asObj(SimpleJson.parse(response)));
+    } catch (Exception ignore){
+      return fallback != null ? fallback.save(type) : type;
+    }
+  }
+
+  @Override
+  public void delete(String code){
+    if (code == null || code.isBlank()){
+      return;
+    }
+    if (rc != null){
+      try {
+        rc.delete("/api/v2/intervention-types/" + encode(code));
+      } catch (Exception ignore){}
+    }
+    if (fallback != null){
+      fallback.delete(code);
+    }
+  }
+
+  private InterventionType fromMap(Map<String, Object> map){
+    if (map == null){
+      return null;
+    }
+    String code = SimpleJson.str(map.get("id"));
+    String label = SimpleJson.str(map.get("name"));
+    String icon = SimpleJson.str(map.get("iconKey"));
+    if (code == null || code.isBlank()){
+      return null;
+    }
+    InterventionType type = new InterventionType();
+    type.setCode(code);
+    type.setLabel(label != null && !label.isBlank() ? label : code);
+    type.setIconKey(icon);
+    return type;
+  }
+
+  private String toJson(InterventionType type){
+    StringBuilder sb = new StringBuilder("{");
+    appendField(sb, "id", type.getCode());
+    String name = type.getLabel();
+    if (name == null || name.isBlank()){
+      name = type.getCode();
+    }
+    appendField(sb, "name", name);
+    appendField(sb, "iconKey", type.getIconKey());
+    sb.append('}');
+    return sb.toString();
+  }
+
+  private void appendField(StringBuilder sb, String key, String value){
+    if (sb.length() > 1){
+      sb.append(',');
+    }
+    sb.append('"').append(key).append('"').append(':');
+    if (value == null){
+      sb.append("null");
+    } else {
+      sb.append('"').append(escape(value)).append('"');
+    }
+  }
+
+  private String escape(String s){
+    return s.replace("\\", "\\\\").replace("\"", "\\\"");
+  }
+
+  private String encode(String value){
+    return URLEncoder.encode(value, StandardCharsets.UTF_8);
   }
 }

--- a/client/src/main/java/com/materiel/suite/client/service/mock/MockInterventionTypeService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/mock/MockInterventionTypeService.java
@@ -3,19 +3,90 @@ package com.materiel.suite.client.service.mock;
 import com.materiel.suite.client.model.InterventionType;
 import com.materiel.suite.client.service.InterventionTypeService;
 
-import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /** Fournit un catalogue statique pour l'utilisation hors-ligne. */
 public class MockInterventionTypeService implements InterventionTypeService {
-  private static final List<InterventionType> DEFAULTS = List.of(
-      new InterventionType("LIFT", "Levage", "crane"),
-      new InterventionType("TRANSPORT", "Transport", "truck"),
-      new InterventionType("MANUT", "Manutention", "forklift")
-  );
+  private final Map<String, InterventionType> store = new ConcurrentHashMap<>();
+
+  public MockInterventionTypeService(){
+    seedDefaults();
+  }
 
   @Override
   public List<InterventionType> list(){
-    return new ArrayList<>(DEFAULTS);
+    return store.values().stream()
+        .map(this::copy)
+        .sorted(Comparator.comparing(type -> type.getLabel() == null ? "" : type.getLabel(), String.CASE_INSENSITIVE_ORDER))
+        .toList();
+  }
+
+  @Override
+  public InterventionType save(InterventionType type){
+    if (type == null){
+      return null;
+    }
+    InterventionType copy = copy(type);
+    if (copy.getCode() == null || copy.getCode().isBlank()){
+      copy.setCode(generateCode(copy.getLabel()));
+    }
+    store.put(copy.getCode(), copy(copy));
+    return copy(copy);
+  }
+
+  @Override
+  public void delete(String code){
+    if (code == null || code.isBlank()){
+      return;
+    }
+    store.remove(code);
+  }
+
+  private void seedDefaults(){
+    if (!store.isEmpty()){
+      return;
+    }
+    put(new InterventionType("LIFT", "Levage", "crane"));
+    put(new InterventionType("TRANSPORT", "Transport", "truck"));
+    put(new InterventionType("MANUT", "Manutention", "forklift"));
+  }
+
+  private void put(InterventionType type){
+    if (type == null || type.getCode() == null){
+      return;
+    }
+    store.put(type.getCode(), copy(type));
+  }
+
+  private InterventionType copy(InterventionType type){
+    if (type == null){
+      return null;
+    }
+    InterventionType copy = new InterventionType();
+    copy.setCode(type.getCode());
+    copy.setLabel(type.getLabel());
+    copy.setIconKey(type.getIconKey());
+    return copy;
+  }
+
+  private String generateCode(String label){
+    String base = label == null ? "TYPE" : label.trim();
+    if (base.isBlank()){
+      base = "TYPE";
+    }
+    base = base.replaceAll("[^A-Za-z0-9]+", "_").toUpperCase(Locale.ROOT);
+    if (base.isBlank()){
+      base = "TYPE";
+    }
+    String code = base;
+    int i = 1;
+    while (store.containsKey(code)){
+      code = base + "_" + i++;
+    }
+    return code;
   }
 }

--- a/client/src/main/java/com/materiel/suite/client/ui/icons/IconRegistry.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/icons/IconRegistry.java
@@ -3,8 +3,11 @@ package com.materiel.suite.client.ui.icons;
 import com.formdev.flatlaf.extras.FlatSVGIcon;
 
 import javax.swing.*;
+import java.awt.*;
+import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -12,14 +15,18 @@ import java.util.concurrent.ConcurrentHashMap;
 /** Registre centralisant les icônes SVG intégrées à l'application. */
 public final class IconRegistry {
   private static final List<String> ICON_KEYS = List.of(
-      "crane", "truck", "forklift", "excavator", "generator", "container",
-      "hook", "helmet", "wrench", "pallet", "calendar", "user",
-      "file", "invoice", "search", "success", "error", "info",
-      "settings", "signature", "task", "plus", "edit", "trash",
-      "refresh", "image", "cube"
+      "search", "success", "error", "info", "settings", "signature", "task", "invoice",
+      "maximize", "minimize", "plus", "edit", "trash", "refresh", "image", "cube", "file",
+      "calendar", "user", "wrench",
+      "crane", "truck", "forklift", "container", "excavator", "generator", "hook", "helmet", "pallet"
   );
   private static final Set<String> ICON_SET = Set.copyOf(ICON_KEYS);
   private static final Map<Integer, Icon> PLACEHOLDER_CACHE = new ConcurrentHashMap<>();
+  private static final Map<String, Icon> FALLBACK_CACHE = new ConcurrentHashMap<>();
+  private static final Color[] FALLBACK_COLORS = {
+      new Color(0x2962FF), new Color(0x00B8D4), new Color(0x00C853),
+      new Color(0xFF8F00), new Color(0xD81B60), new Color(0x8E24AA)
+  };
 
   private IconRegistry(){}
 
@@ -56,15 +63,18 @@ public final class IconRegistry {
   }
 
   public static Icon small(String key){
-    return load(key, 16);
+    Icon icon = load(key, 16);
+    return icon != null ? icon : fallback(key, 16);
   }
 
   public static Icon medium(String key){
-    return load(key, 20);
+    Icon icon = load(key, 20);
+    return icon != null ? icon : fallback(key, 20);
   }
 
   public static Icon large(String key){
-    return load(key, 28);
+    Icon icon = load(key, 28);
+    return icon != null ? icon : fallback(key, 28);
   }
 
   /** Icône par défaut lorsqu'aucune n'est définie. */
@@ -81,7 +91,69 @@ public final class IconRegistry {
    */
   public static Icon loadOrPlaceholder(String key, int size){
     Icon icon = load(key, size);
-    return icon != null ? icon : placeholder(size);
+    if (icon != null){
+      return icon;
+    }
+    Icon generated = fallback(key, size);
+    return generated != null ? generated : placeholder(size);
+  }
+
+  private static Icon fallback(String key, int size){
+    if (size <= 0){
+      return null;
+    }
+    String normalized = key == null ? "" : key.trim();
+    String cacheKey = normalized.toLowerCase(Locale.ROOT) + "|" + size;
+    return FALLBACK_CACHE.computeIfAbsent(cacheKey, k -> createFallbackIcon(normalized, size));
+  }
+
+  private static Icon createFallbackIcon(String key, int size){
+    BufferedImage image = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
+    Graphics2D g = image.createGraphics();
+    try {
+      g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+      g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+
+      int diameter = size - 2;
+      Color base = fallbackColor(key);
+      g.setColor(base);
+      g.fillOval(1, 1, diameter, diameter);
+
+      g.setColor(Color.WHITE);
+      String letter = fallbackLetter(key);
+      Font font = new Font(Font.SANS_SERIF, Font.BOLD, Math.max(10, Math.round(size * 0.6f)));
+      g.setFont(font);
+      FontMetrics fm = g.getFontMetrics();
+      int textWidth = fm.stringWidth(letter);
+      int textX = (size - textWidth) / 2;
+      int textY = (size + fm.getAscent() - fm.getDescent()) / 2 - 1;
+      g.drawString(letter, Math.max(1, textX), Math.max(fm.getAscent(), textY));
+    } finally {
+      g.dispose();
+    }
+    return new ImageIcon(image);
+  }
+
+  private static Color fallbackColor(String key){
+    if (FALLBACK_COLORS.length == 0){
+      return new Color(0x546E7A);
+    }
+    String normalized = key == null ? "" : key.toLowerCase(Locale.ROOT);
+    int idx = Math.abs(normalized.hashCode()) % FALLBACK_COLORS.length;
+    return FALLBACK_COLORS[idx];
+  }
+
+  private static String fallbackLetter(String key){
+    if (key == null || key.isBlank()){
+      return "?";
+    }
+    for (int i = 0; i < key.length(); i++){
+      char c = key.charAt(i);
+      if (Character.isLetterOrDigit(c)){
+        return String.valueOf(Character.toUpperCase(c));
+      }
+    }
+    return "?";
   }
 }
 

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionCalendarView.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionCalendarView.java
@@ -242,6 +242,7 @@ public class InterventionCalendarView implements InterventionView {
     panel.add(text, BorderLayout.CENTER);
 
     panel.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+    JPopupMenu menu = buildContextMenu(it);
     panel.addMouseListener(new MouseAdapter(){
       @Override public void mouseClicked(MouseEvent e){
         if (e.getClickCount() == 2){
@@ -249,12 +250,23 @@ public class InterventionCalendarView implements InterventionView {
         }
       }
       @Override public void mousePressed(MouseEvent e){
+        if (e.isPopupTrigger()){
+          menu.show(panel, e.getX(), e.getY());
+          return;
+        }
+        if (SwingUtilities.isRightMouseButton(e)){
+          return;
+        }
         dragging = it;
         dragSource = panel;
         panel.setCursor(Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR));
       }
       @Override public void mouseReleased(MouseEvent e){
         panel.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        if (e.isPopupTrigger() || SwingUtilities.isRightMouseButton(e)){
+          menu.show(panel, e.getX(), e.getY());
+          return;
+        }
         if (dragging == it){
           dragging = null;
         }
@@ -264,6 +276,14 @@ public class InterventionCalendarView implements InterventionView {
       }
     });
     return panel;
+  }
+
+  private JPopupMenu buildContextMenu(Intervention intervention){
+    JPopupMenu menu = new JPopupMenu();
+    JMenuItem edit = new JMenuItem("Modifier…", IconRegistry.small("edit"));
+    edit.addActionListener(e -> onOpen.accept(intervention));
+    menu.add(edit);
+    return menu;
   }
 
   private void renderWeek(){
@@ -478,6 +498,7 @@ public class InterventionCalendarView implements InterventionView {
           }
           label.setBorder(BorderFactory.createEmptyBorder(2, 4, 2, 4));
           add(label, BorderLayout.CENTER);
+          JPopupMenu menu = buildContextMenu(it);
           addMouseListener(new MouseAdapter(){
             @Override public void mouseClicked(MouseEvent e){
               if (e.getClickCount() == 2){
@@ -485,6 +506,13 @@ public class InterventionCalendarView implements InterventionView {
               }
             }
             @Override public void mousePressed(MouseEvent e){
+              if (e.isPopupTrigger()){
+                menu.show(JPanel.this, e.getX(), e.getY());
+                return;
+              }
+              if (SwingUtilities.isRightMouseButton(e)){
+                return;
+              }
               pressY = e.getYOnScreen();
               pressHeight = getHeight();
               pressBlockY = getY();
@@ -493,6 +521,10 @@ public class InterventionCalendarView implements InterventionView {
             }
             @Override public void mouseReleased(MouseEvent e){
               setCursor(Cursor.getDefaultCursor());
+              if (e.isPopupTrigger() || SwingUtilities.isRightMouseButton(e)){
+                menu.show(JPanel.this, e.getX(), e.getY());
+                return;
+              }
               LocalDateTime baseStart = startOfY(getY());
               if (resizing){
                 LocalDateTime newEnd = snapQuarter(baseStart.plusMinutes(heightToMinutes(getHeight())));

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionTableView.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionTableView.java
@@ -48,6 +48,12 @@ public class InterventionTableView implements InterventionView {
     table.getColumnModel().getColumn(2).setCellRenderer(typeRenderer());
     table.getColumnModel().getColumn(6).setCellRenderer(resourceRenderer());
     table.addMouseListener(new MouseAdapter(){
+      @Override public void mousePressed(MouseEvent e){
+        maybeShowPopup(e);
+      }
+      @Override public void mouseReleased(MouseEvent e){
+        maybeShowPopup(e);
+      }
       @Override public void mouseClicked(MouseEvent e){
         if (e.getClickCount() == 2){
           int row = table.getSelectedRow();
@@ -94,6 +100,34 @@ public class InterventionTableView implements InterventionView {
 
   @Override public void setOnOpen(Consumer<Intervention> onOpen){
     this.onOpen = onOpen != null ? onOpen : it -> {};
+  }
+
+  private void maybeShowPopup(MouseEvent e){
+    if (!e.isPopupTrigger()){
+      return;
+    }
+    int row = table.rowAtPoint(e.getPoint());
+    if (row < 0){
+      return;
+    }
+    table.setRowSelectionInterval(row, row);
+    int modelRow = table.convertRowIndexToModel(row);
+    if (modelRow < 0 || modelRow >= current.size()){
+      return;
+    }
+    Intervention it = current.get(modelRow);
+    JPopupMenu menu = buildContextMenu(it);
+    if (menu.getComponentCount() > 0){
+      menu.show(table, e.getX(), e.getY());
+    }
+  }
+
+  private JPopupMenu buildContextMenu(Intervention it){
+    JPopupMenu menu = new JPopupMenu();
+    JMenuItem edit = new JMenuItem("Modifier…", IconRegistry.small("edit"));
+    edit.addActionListener(evt -> onOpen.accept(it));
+    menu.add(edit);
+    return menu;
   }
 
   private DefaultTableCellRenderer dateRenderer(){

--- a/client/src/main/java/com/materiel/suite/client/ui/settings/SettingsPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/settings/SettingsPanel.java
@@ -20,6 +20,7 @@ public class SettingsPanel extends JPanel {
 
     JTabbedPane tabs = new JTabbedPane();
     tabs.addTab("Types de ressources", IconRegistry.small("wrench"), new ResourceTypeEditor());
+    tabs.addTab("Types d'intervention", IconRegistry.small("task"), new InterventionTypeEditor());
     tabs.addTab("Bibliothèque d'icônes", IconRegistry.small("settings"), buildIconLibraryPanel());
     add(tabs, BorderLayout.CENTER);
   }


### PR DESCRIPTION
## Summary
- add letter-based fallbacks to the icon registry so missing keys still render nicely
- expose CRUD operations for intervention types and surface them through a new settings tab
- add quick-edit context menus to calendar and tabular intervention views

## Testing
- `mvn -q -pl client -am test` *(fails: dependency download blocked by network policy)*

------
https://chatgpt.com/codex/tasks/task_e_68caab5f167c8330bb7393f49a1b006d