### PR TITLE
Add ordering controls to intervention types and expose order index

### DIFF
--- a/backend/src/main/java/com/materiel/suite/backend/interventions/dto/InterventionTypeV2Dto.java
+++ b/backend/src/main/java/com/materiel/suite/backend/interventions/dto/InterventionTypeV2Dto.java
@@ -5,6 +5,7 @@ public class InterventionTypeV2Dto {
   private String id;
   private String name;
   private String iconKey;
+  private Integer orderIndex;
 
   public String getId(){
     return id;
@@ -28,5 +29,13 @@ public class InterventionTypeV2Dto {
 
   public void setIconKey(String iconKey){
     this.iconKey = iconKey;
+  }
+
+  public Integer getOrderIndex(){
+    return orderIndex;
+  }
+
+  public void setOrderIndex(Integer orderIndex){
+    this.orderIndex = orderIndex;
   }
 }

--- a/backend/src/main/resources/openapi/gestion-materiel-v1.yaml
+++ b/backend/src/main/resources/openapi/gestion-materiel-v1.yaml
@@ -409,6 +409,9 @@ components:
           type: string
         iconKey:
           type: string
+        orderIndex:
+          type: integer
+          description: "Ordre d'affichage (0 = premier)"
     Intervention:
       type: object
       properties:

--- a/client/src/main/java/com/materiel/suite/client/model/InterventionType.java
+++ b/client/src/main/java/com/materiel/suite/client/model/InterventionType.java
@@ -7,17 +7,23 @@ public class InterventionType {
   private String code;
   private String label;
   private String iconKey;
+  private Integer orderIndex;
 
   public InterventionType(){}
 
   public InterventionType(String code, String label){
-    this(code, label, null);
+    this(code, label, null, null);
   }
 
   public InterventionType(String code, String label, String iconKey){
+    this(code, label, iconKey, null);
+  }
+
+  public InterventionType(String code, String label, String iconKey, Integer orderIndex){
     this.code = code;
     this.label = label;
     this.iconKey = iconKey;
+    this.orderIndex = orderIndex;
   }
 
   public String getCode(){ return code; }
@@ -28,6 +34,8 @@ public class InterventionType {
 
   public String getIconKey(){ return iconKey; }
   public void setIconKey(String iconKey){ this.iconKey = iconKey; }
+  public Integer getOrderIndex(){ return orderIndex; }
+  public void setOrderIndex(Integer orderIndex){ this.orderIndex = orderIndex; }
 
   @Override public boolean equals(Object o){
     if (this == o) return true;

--- a/client/src/main/java/com/materiel/suite/client/service/api/ApiInterventionTypeService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/api/ApiInterventionTypeService.java
@@ -87,6 +87,15 @@ public class ApiInterventionTypeService implements InterventionTypeService {
     String code = SimpleJson.str(map.get("id"));
     String label = SimpleJson.str(map.get("name"));
     String icon = SimpleJson.str(map.get("iconKey"));
+    Integer orderIndex = null;
+    Object orderValue = map.get("orderIndex");
+    if (orderValue instanceof Number number){
+      orderIndex = number.intValue();
+    } else if (orderValue != null){
+      try {
+        orderIndex = Integer.parseInt(orderValue.toString());
+      } catch (NumberFormatException ignore){}
+    }
     if (code == null || code.isBlank()){
       return null;
     }
@@ -94,6 +103,7 @@ public class ApiInterventionTypeService implements InterventionTypeService {
     type.setCode(code);
     type.setLabel(label != null && !label.isBlank() ? label : code);
     type.setIconKey(icon);
+    type.setOrderIndex(orderIndex);
     return type;
   }
 
@@ -106,19 +116,22 @@ public class ApiInterventionTypeService implements InterventionTypeService {
     }
     appendField(sb, "name", name);
     appendField(sb, "iconKey", type.getIconKey());
+    appendField(sb, "orderIndex", type.getOrderIndex());
     sb.append('}');
     return sb.toString();
   }
 
-  private void appendField(StringBuilder sb, String key, String value){
+  private void appendField(StringBuilder sb, String key, Object value){
     if (sb.length() > 1){
       sb.append(',');
     }
     sb.append('"').append(key).append('"').append(':');
     if (value == null){
       sb.append("null");
+    } else if (value instanceof Number || value instanceof Boolean){
+      sb.append(value);
     } else {
-      sb.append('"').append(escape(value)).append('"');
+      sb.append('"').append(escape(value.toString())).append('"');
     }
   }
 


### PR DESCRIPTION
## Summary
- add an order index to intervention type models/services on both client and backend sides and keep seeded data sorted
- update API integration plus the OpenAPI contract to read/write the new order index value
- enhance the settings UI with an order column and buttons to reorder or duplicate types

## Testing
- mvn test *(fails: cannot download dependencies from Maven Central in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cabb00d48883308f44bd7a4e2d3fc1