### PR TITLE
Add user management services and UI

### DIFF
--- a/backend/src/main/java/com/materiel/suite/backend/auth/UserAdminV2Controller.java
+++ b/backend/src/main/java/com/materiel/suite/backend/auth/UserAdminV2Controller.java
@@ -1,0 +1,46 @@
+package com.materiel.suite.backend.auth;
+
+import com.materiel.suite.backend.auth.dto.PasswordUpdateRequest;
+import com.materiel.suite.backend.auth.dto.UserCreateRequest;
+import com.materiel.suite.backend.auth.dto.UserV2Dto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v2/users")
+public class UserAdminV2Controller {
+  private final AuthCatalogService service;
+
+  public UserAdminV2Controller(AuthCatalogService service){
+    this.service = service;
+  }
+
+  @GetMapping
+  public ResponseEntity<List<UserV2Dto>> list(){
+    return ResponseEntity.ok(service.listUsers());
+  }
+
+  @PostMapping
+  public ResponseEntity<UserV2Dto> create(@RequestBody UserCreateRequest request){
+    return ResponseEntity.ok(service.createUser(request));
+  }
+
+  @PutMapping("/{id}")
+  public ResponseEntity<UserV2Dto> update(@PathVariable String id, @RequestBody UserV2Dto body){
+    return ResponseEntity.ok(service.updateUser(id, body));
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> delete(@PathVariable String id){
+    service.deleteUser(id);
+    return ResponseEntity.noContent().build();
+  }
+
+  @PostMapping("/{id}/password")
+  public ResponseEntity<Void> updatePassword(@PathVariable String id, @RequestBody PasswordUpdateRequest request){
+    service.updatePassword(id, request != null ? request.getNewPassword() : null);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/auth/dto/PasswordUpdateRequest.java
+++ b/backend/src/main/java/com/materiel/suite/backend/auth/dto/PasswordUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.materiel.suite.backend.auth.dto;
+
+/** Requête pour changer le mot de passe d'un utilisateur. */
+public class PasswordUpdateRequest {
+  private String newPassword;
+
+  public String getNewPassword(){
+    return newPassword;
+  }
+
+  public void setNewPassword(String newPassword){
+    this.newPassword = newPassword;
+  }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/auth/dto/UserCreateRequest.java
+++ b/backend/src/main/java/com/materiel/suite/backend/auth/dto/UserCreateRequest.java
@@ -1,0 +1,23 @@
+package com.materiel.suite.backend.auth.dto;
+
+/** Requête de création d'utilisateur (mode administrateur). */
+public class UserCreateRequest {
+  private UserV2Dto user;
+  private String password;
+
+  public UserV2Dto getUser(){
+    return user;
+  }
+
+  public void setUser(UserV2Dto user){
+    this.user = user;
+  }
+
+  public String getPassword(){
+    return password;
+  }
+
+  public void setPassword(String password){
+    this.password = password;
+  }
+}

--- a/backend/src/main/resources/openapi/gestion-materiel-v1.yaml
+++ b/backend/src/main/resources/openapi/gestion-materiel-v1.yaml
@@ -33,6 +33,84 @@ paths:
                 $ref: '#/components/schemas/UserV2'
         '401':
           description: Unauthorized
+  /api/v2/users:
+    get:
+      summary: Lister les utilisateurs (v2)
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserV2'
+    post:
+      summary: Créer un utilisateur (v2)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserCreateRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserV2'
+  /api/v2/users/{id}:
+    put:
+      summary: Mettre à jour un utilisateur (v2)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserV2'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserV2'
+    delete:
+      summary: Supprimer un utilisateur (v2)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Deleted
+  /api/v2/users/{id}/password:
+    post:
+      summary: Définir le mot de passe d'un utilisateur (v2)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasswordUpdateRequest'
+      responses:
+        '204':
+          description: Updated
   /api/v1/quotes:
     get:
       summary: List quotes
@@ -451,6 +529,22 @@ components:
           enum: [ADMIN, SALES, CONFIG]
         agency:
           $ref: '#/components/schemas/AgencyV2'
+        token:
+          type: string
+          description: "Jeton optionnel (mock) — support pour JWT ultérieur"
+    UserCreateRequest:
+      type: object
+      properties:
+        user:
+          $ref: '#/components/schemas/UserV2'
+        password:
+          type: string
+    PasswordUpdateRequest:
+      type: object
+      required: [newPassword]
+      properties:
+        newPassword:
+          type: string
     LoginV2Request:
       type: object
       required: [agencyId, username, password]

--- a/client/src/main/java/com/materiel/suite/client/auth/AccessControl.java
+++ b/client/src/main/java/com/materiel/suite/client/auth/AccessControl.java
@@ -50,4 +50,12 @@ public final class AccessControl {
     Role role = currentRole();
     return role == Role.ADMIN || role == Role.CONFIG;
   }
+
+  public static boolean canManageUsers(){
+    return currentRole() == Role.ADMIN;
+  }
+
+  public static boolean canChangeOwnPassword(){
+    return currentRole() != null;
+  }
 }

--- a/client/src/main/java/com/materiel/suite/client/auth/Role.java
+++ b/client/src/main/java/com/materiel/suite/client/auth/Role.java
@@ -2,7 +2,7 @@ package com.materiel.suite.client.auth;
 
 /** Rôles utilisateurs pour les droits applicatifs côté client. */
 public enum Role {
-  ADMIN,
-  SALES,
-  CONFIG
+  ADMIN, // tous les droits
+  SALES, // lecture planning + droits devis/BC/BL/factures, pas de config
+  CONFIG // lecture générale, édition ressources + paramètres
 }

--- a/client/src/main/java/com/materiel/suite/client/net/ServiceFactory.java
+++ b/client/src/main/java/com/materiel/suite/client/net/ServiceFactory.java
@@ -6,6 +6,7 @@ import com.materiel.suite.client.config.AppConfig;
 import com.materiel.suite.client.service.*;
 import com.materiel.suite.client.service.api.*;
 import com.materiel.suite.client.service.mock.*;
+import com.materiel.suite.client.users.UserService;
 
 public class ServiceFactory {
   private static AppConfig cfg;
@@ -20,11 +21,13 @@ public class ServiceFactory {
   private static InterventionTypeService interventionTypeService;
   private static ResourceTypeService resourceTypeService;
   private static AuthService authService;
+  private static UserService userService;
 
   public static void init(AppConfig c) {
     cfg = c;
     AuthContext.clear();
     authService = null;
+    userService = null;
     switch (cfg.getMode()) {
       case "mock" -> initMock();
       case "backend" -> initBackend();
@@ -44,7 +47,9 @@ public class ServiceFactory {
     clientService = new MockClientService();
     interventionTypeService = new MockInterventionTypeService();
     resourceTypeService = new MockResourceTypeService();
-    authService = new MockAuthService();
+    MockUserService mockUsers = new MockUserService();
+    userService = mockUsers;
+    authService = new MockAuthService(mockUsers);
   }
 
   private static void initBackend() {
@@ -62,7 +67,9 @@ public class ServiceFactory {
     clientService = new ApiClientService(rc, new MockClientService());
     interventionTypeService = new ApiInterventionTypeService(rc, new MockInterventionTypeService());
     resourceTypeService = new ApiResourceTypeService(rc, new MockResourceTypeService());
-    authService = new ApiAuthService(rc, new MockAuthService());
+    MockUserService mockUsers = new MockUserService();
+    userService = new ApiUserService(rc, mockUsers);
+    authService = new ApiAuthService(rc, new MockAuthService(mockUsers));
   }
 
   public static QuoteService quotes(){ return quoteService; }
@@ -76,5 +83,6 @@ public class ServiceFactory {
   public static ResourceTypeService resourceTypes(){ return resourceTypeService; }
   public static RestClient http(){ return restClient; }
   public static AuthService auth(){ return authService; }
+  public static UserService users(){ return userService; }
 }
 

--- a/client/src/main/java/com/materiel/suite/client/service/ServiceLocator.java
+++ b/client/src/main/java/com/materiel/suite/client/service/ServiceLocator.java
@@ -4,6 +4,7 @@ import com.materiel.suite.client.auth.AuthService;
 import com.materiel.suite.client.model.InterventionType;
 import com.materiel.suite.client.model.Resource;
 import com.materiel.suite.client.net.ServiceFactory;
+import com.materiel.suite.client.users.UserService;
 
 import java.util.List;
 import java.util.UUID;
@@ -29,6 +30,10 @@ public final class ServiceLocator {
 
   public static AuthService auth(){
     return ServiceFactory.auth();
+  }
+
+  public static UserService users(){
+    return ServiceFactory.users();
   }
 
   public static final class ResourcesGateway {

--- a/client/src/main/java/com/materiel/suite/client/service/api/ApiUserService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/api/ApiUserService.java
@@ -1,0 +1,229 @@
+package com.materiel.suite.client.service.api;
+
+import com.materiel.suite.client.auth.Agency;
+import com.materiel.suite.client.auth.Role;
+import com.materiel.suite.client.net.RestClient;
+import com.materiel.suite.client.net.SimpleJson;
+import com.materiel.suite.client.users.UserAccount;
+import com.materiel.suite.client.users.UserService;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/** Implémentation REST pour la gestion des comptes utilisateurs. */
+public class ApiUserService implements UserService {
+  private final RestClient rc;
+  private final UserService fallback;
+
+  public ApiUserService(RestClient rc, UserService fallback){
+    this.rc = rc;
+    this.fallback = fallback;
+  }
+
+  @Override
+  public List<UserAccount> list(){
+    if (rc == null){
+      return fallback != null ? fallback.list() : List.of();
+    }
+    try {
+      String body = rc.get("/api/v2/users");
+      List<Object> arr = SimpleJson.asArr(SimpleJson.parse(body));
+      List<UserAccount> accounts = new ArrayList<>();
+      for (Object item : arr){
+        Map<String, Object> map = SimpleJson.asObj(item);
+        UserAccount account = toAccount(map);
+        if (account != null){
+          accounts.add(account);
+        }
+      }
+      return accounts;
+    } catch (InterruptedException ex){
+      Thread.currentThread().interrupt();
+      return fallback != null ? fallback.list() : List.of();
+    } catch (Exception ex){
+      return fallback != null ? fallback.list() : List.of();
+    }
+  }
+
+  @Override
+  public UserAccount create(UserAccount account, String password){
+    if (rc == null){
+      return fallback != null ? fallback.create(account, password) : account;
+    }
+    try {
+      String payload = buildCreatePayload(account, password);
+      String response = rc.post("/api/v2/users", payload);
+      Map<String, Object> map = SimpleJson.asObj(SimpleJson.parse(response));
+      UserAccount created = toAccount(map);
+      return created != null ? created : account;
+    } catch (InterruptedException ex){
+      Thread.currentThread().interrupt();
+      return fallback != null ? fallback.create(account, password) : account;
+    } catch (Exception ex){
+      return fallback != null ? fallback.create(account, password) : account;
+    }
+  }
+
+  @Override
+  public UserAccount update(UserAccount account){
+    if (rc == null){
+      return fallback != null ? fallback.update(account) : account;
+    }
+    try {
+      String payload = buildUserPayload(account);
+      String response = rc.put("/api/v2/users/" + encode(account.getId()), payload);
+      Map<String, Object> map = SimpleJson.asObj(SimpleJson.parse(response));
+      UserAccount updated = toAccount(map);
+      return updated != null ? updated : account;
+    } catch (InterruptedException ex){
+      Thread.currentThread().interrupt();
+      return fallback != null ? fallback.update(account) : account;
+    } catch (Exception ex){
+      return fallback != null ? fallback.update(account) : account;
+    }
+  }
+
+  @Override
+  public void delete(String id){
+    if (rc == null){
+      if (fallback != null){
+        fallback.delete(id);
+      }
+      return;
+    }
+    try {
+      rc.delete("/api/v2/users/" + encode(id));
+    } catch (InterruptedException ex){
+      Thread.currentThread().interrupt();
+      if (fallback != null){
+        fallback.delete(id);
+      }
+    } catch (Exception ex){
+      if (fallback != null){
+        fallback.delete(id);
+      }
+    }
+  }
+
+  @Override
+  public void updatePassword(String id, String newPassword){
+    if (rc == null){
+      if (fallback != null){
+        fallback.updatePassword(id, newPassword);
+      }
+      return;
+    }
+    try {
+      String payload = buildPasswordPayload(newPassword);
+      rc.post("/api/v2/users/" + encode(id) + "/password", payload);
+    } catch (InterruptedException ex){
+      Thread.currentThread().interrupt();
+      if (fallback != null){
+        fallback.updatePassword(id, newPassword);
+      }
+    } catch (Exception ex){
+      if (fallback != null){
+        fallback.updatePassword(id, newPassword);
+      }
+    }
+  }
+
+  private UserAccount toAccount(Map<String, Object> map){
+    if (map == null){
+      return null;
+    }
+    UserAccount account = new UserAccount();
+    account.setId(SimpleJson.str(map.get("id")));
+    account.setUsername(SimpleJson.str(map.get("username")));
+    account.setDisplayName(SimpleJson.str(map.get("displayName")));
+    account.setRole(parseRole(SimpleJson.str(map.get("role"))));
+    Object agencyObj = map.get("agency");
+    if (agencyObj instanceof Map<?,?> raw){
+      @SuppressWarnings("unchecked")
+      Map<String, Object> agencyMap = (Map<String, Object>) raw;
+      account.setAgency(toAgency(agencyMap));
+    }
+    return account;
+  }
+
+  private Agency toAgency(Map<String, Object> map){
+    if (map == null){
+      return null;
+    }
+    Agency agency = new Agency();
+    agency.setId(SimpleJson.str(map.get("id")));
+    agency.setName(SimpleJson.str(map.get("name")));
+    return agency;
+  }
+
+  private Role parseRole(String value){
+    if (value == null){
+      return null;
+    }
+    try {
+      return Role.valueOf(value.trim().toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException ex){
+      return null;
+    }
+  }
+
+  private String buildCreatePayload(UserAccount account, String password){
+    String userJson = buildUserPayload(account);
+    return new StringBuilder("{")
+        .append("\"user\":").append(userJson == null ? "null" : userJson)
+        .append(',')
+        .append("\"password\":").append(stringOrNull(password))
+        .append('}')
+        .toString();
+  }
+
+  private String buildUserPayload(UserAccount account){
+    if (account == null){
+      return "null";
+    }
+    StringBuilder sb = new StringBuilder("{");
+    sb.append("\"id\":").append(stringOrNull(account.getId())).append(',');
+    sb.append("\"username\":").append(stringOrNull(account.getUsername())).append(',');
+    sb.append("\"displayName\":").append(stringOrNull(account.getDisplayName())).append(',');
+    sb.append("\"role\":").append(stringOrNull(account.getRole() != null ? account.getRole().name() : null)).append(',');
+    sb.append("\"agency\":").append(buildAgencyPayload(account.getAgency()));
+    sb.append('}');
+    return sb.toString();
+  }
+
+  private String buildAgencyPayload(Agency agency){
+    if (agency == null){
+      return "null";
+    }
+    return new StringBuilder("{")
+        .append("\"id\":").append(stringOrNull(agency.getId())).append(',')
+        .append("\"name\":").append(stringOrNull(agency.getName()))
+        .append('}')
+        .toString();
+  }
+
+  private String buildPasswordPayload(String password){
+    return new StringBuilder("{")
+        .append("\"newPassword\":").append(stringOrNull(password))
+        .append('}')
+        .toString();
+  }
+
+  private String stringOrNull(String value){
+    if (value == null){
+      return "null";
+    }
+    return '"' + value.replace("\\", "\\\\").replace("\"", "\\\"") + '"';
+  }
+
+  private String encode(String value){
+    if (value == null){
+      return "";
+    }
+    return URLEncoder.encode(value, StandardCharsets.UTF_8);
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/service/mock/MockUserService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/mock/MockUserService.java
@@ -1,0 +1,148 @@
+package com.materiel.suite.client.service.mock;
+
+import com.materiel.suite.client.auth.Agency;
+import com.materiel.suite.client.auth.Role;
+import com.materiel.suite.client.users.UserAccount;
+import com.materiel.suite.client.users.UserService;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Stockage en mémoire des comptes utilisateurs pour le mode mock. */
+public class MockUserService implements UserService {
+  private final Map<String, UserAccount> byId = new ConcurrentHashMap<>();
+  private final Map<String, String> byUsername = new ConcurrentHashMap<>();
+  private final Map<String, String> passwords = new ConcurrentHashMap<>();
+
+  public MockUserService(){
+    seed("1", "admin", "Administrateur", Role.ADMIN, "A1", "Agence Lyon", "admin");
+    seed("2", "sales", "Commercial", Role.SALES, "A1", "Agence Lyon", "sales");
+    seed("3", "config", "Configurateur", Role.CONFIG, "A2", "Agence Paris", "config");
+  }
+
+  private void seed(String id, String username, String displayName, Role role, String agencyId, String agencyName, String password){
+    UserAccount account = new UserAccount();
+    account.setId(id);
+    account.setUsername(username);
+    account.setDisplayName(displayName);
+    account.setRole(role);
+    Agency agency = new Agency();
+    agency.setId(agencyId);
+    agency.setName(agencyName);
+    account.setAgency(agency);
+    create(account, password);
+  }
+
+  @Override
+  public synchronized List<UserAccount> list(){
+    List<UserAccount> accounts = new ArrayList<>();
+    for (UserAccount account : byId.values()){
+      accounts.add(clone(account));
+    }
+    accounts.sort(Comparator.comparing(account -> account.getUsername() == null ? "" : account.getUsername(),
+        String.CASE_INSENSITIVE_ORDER));
+    return accounts;
+  }
+
+  @Override
+  public synchronized UserAccount create(UserAccount account, String password){
+    if (account == null){
+      return null;
+    }
+    UserAccount copy = clone(account);
+    if (copy.getId() == null || copy.getId().isBlank()){
+      copy.setId(UUID.randomUUID().toString());
+    }
+    store(copy);
+    passwords.put(copy.getId(), password == null || password.isBlank() ? "changeme" : password);
+    return clone(copy);
+  }
+
+  @Override
+  public synchronized UserAccount update(UserAccount account){
+    if (account == null || account.getId() == null){
+      return account;
+    }
+    UserAccount copy = clone(account);
+    UserAccount previous = byId.get(copy.getId());
+    if (previous != null && previous.getUsername() != null){
+      byUsername.remove(normalize(previous.getUsername()));
+    }
+    store(copy);
+    return clone(copy);
+  }
+
+  @Override
+  public synchronized void delete(String id){
+    if (id == null){
+      return;
+    }
+    UserAccount removed = byId.remove(id);
+    if (removed != null && removed.getUsername() != null){
+      byUsername.remove(normalize(removed.getUsername()));
+    }
+    passwords.remove(id);
+  }
+
+  @Override
+  public synchronized void updatePassword(String id, String newPassword){
+    if (id == null){
+      return;
+    }
+    passwords.put(id, newPassword == null || newPassword.isBlank() ? "changeme" : newPassword);
+  }
+
+  public synchronized UserAccount findByUsername(String username){
+    if (username == null){
+      return null;
+    }
+    String id = byUsername.get(normalize(username));
+    if (id == null){
+      return null;
+    }
+    UserAccount account = byId.get(id);
+    return account != null ? clone(account) : null;
+  }
+
+  public synchronized boolean matchesPassword(String id, String password){
+    if (id == null){
+      return false;
+    }
+    String expected = passwords.get(id);
+    return Objects.equals(expected, password);
+  }
+
+  private void store(UserAccount account){
+    byId.put(account.getId(), clone(account));
+    if (account.getUsername() != null){
+      byUsername.put(normalize(account.getUsername()), account.getId());
+    }
+  }
+
+  private String normalize(String username){
+    return username == null ? "" : username.trim().toLowerCase();
+  }
+
+  private UserAccount clone(UserAccount source){
+    if (source == null){
+      return null;
+    }
+    UserAccount copy = new UserAccount();
+    copy.setId(source.getId());
+    copy.setUsername(source.getUsername());
+    copy.setDisplayName(source.getDisplayName());
+    copy.setRole(source.getRole());
+    if (source.getAgency() != null){
+      Agency agency = new Agency();
+      agency.setId(source.getAgency().getId());
+      agency.setName(source.getAgency().getName());
+      copy.setAgency(agency);
+    }
+    return copy;
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/settings/SettingsPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/settings/SettingsPanel.java
@@ -4,6 +4,7 @@ import com.materiel.suite.client.auth.AccessControl;
 import com.materiel.suite.client.ui.icons.IconPickerDialog;
 import com.materiel.suite.client.ui.icons.IconRegistry;
 import com.materiel.suite.client.ui.resources.ResourceTypeEditor;
+import com.materiel.suite.client.ui.users.UserAdminPanel;
 
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
@@ -32,6 +33,9 @@ public class SettingsPanel extends JPanel {
     tabs.addTab("Types de ressources", IconRegistry.small("wrench"), new ResourceTypeEditor());
     tabs.addTab("Types d'intervention", IconRegistry.small("task"), new InterventionTypeEditor());
     tabs.addTab("Bibliothèque d'icônes", IconRegistry.small("settings"), buildIconLibraryPanel());
+    if (AccessControl.canManageUsers()){
+      tabs.addTab("Comptes utilisateurs", IconRegistry.small("user"), new UserAdminPanel());
+    }
     add(tabs, BorderLayout.CENTER);
   }
 

--- a/client/src/main/java/com/materiel/suite/client/ui/users/ChangePasswordDialog.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/users/ChangePasswordDialog.java
@@ -1,0 +1,75 @@
+package com.materiel.suite.client.ui.users;
+
+import com.materiel.suite.client.auth.AuthContext;
+import com.materiel.suite.client.auth.User;
+import com.materiel.suite.client.service.ServiceLocator;
+import com.materiel.suite.client.ui.common.Toasts;
+import com.materiel.suite.client.ui.icons.IconRegistry;
+
+import javax.swing.*;
+import java.awt.*;
+
+/** Boîte de dialogue permettant à l'utilisateur courant de modifier son mot de passe. */
+public class ChangePasswordDialog extends JDialog {
+  public ChangePasswordDialog(Window owner){
+    super(owner, "Changer mon mot de passe", ModalityType.APPLICATION_MODAL);
+    User current = AuthContext.get();
+    if (current == null){
+      dispose();
+      return;
+    }
+    String username = current.getUsername() != null ? current.getUsername() : current.getDisplayName();
+    if (username != null && !username.isBlank()){
+      setTitle("Changer mon mot de passe — " + username);
+    }
+    setLayout(new BorderLayout(8, 8));
+
+    JPasswordField password = new JPasswordField();
+    JPasswordField confirm = new JPasswordField();
+    JButton save = new JButton("Enregistrer", IconRegistry.small("success"));
+
+    JPanel form = new JPanel(new GridBagLayout());
+    GridBagConstraints gc = new GridBagConstraints();
+    gc.insets = new Insets(6, 6, 6, 6);
+    gc.anchor = GridBagConstraints.WEST;
+    gc.fill = GridBagConstraints.HORIZONTAL;
+    gc.gridx = 0; gc.gridy = 0; gc.weightx = 0;
+    form.add(new JLabel("Nouveau mot de passe"), gc);
+    gc.gridx = 1; gc.weightx = 1;
+    form.add(password, gc);
+    gc.gridx = 0; gc.gridy = 1; gc.weightx = 0;
+    form.add(new JLabel("Confirmer"), gc);
+    gc.gridx = 1; gc.weightx = 1;
+    form.add(confirm, gc);
+
+    JPanel actions = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+    actions.add(save);
+
+    add(form, BorderLayout.CENTER);
+    add(actions, BorderLayout.SOUTH);
+
+    save.addActionListener(e -> {
+      String first = new String(password.getPassword());
+      String second = new String(confirm.getPassword());
+      if (first == null || first.isBlank() || !first.equals(second)){
+        Toasts.error(this, "Mot de passe invalide");
+        return;
+      }
+      try {
+        User fresh = AuthContext.get();
+        if (fresh == null || ServiceLocator.users() == null){
+          throw new IllegalStateException("Utilisateur absent");
+        }
+        ServiceLocator.users().updatePassword(fresh.getId(), first);
+        Toasts.success(this, "Mot de passe mis à jour");
+        dispose();
+      } catch (Exception ex){
+        Toasts.error(this, "Impossible de mettre à jour le mot de passe");
+      }
+    });
+
+    getRootPane().setDefaultButton(save);
+    setSize(420, 180);
+    setLocationRelativeTo(owner);
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/users/UserAdminPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/users/UserAdminPanel.java
@@ -1,0 +1,348 @@
+package com.materiel.suite.client.ui.users;
+
+import com.materiel.suite.client.auth.Agency;
+import com.materiel.suite.client.auth.Role;
+import com.materiel.suite.client.service.ServiceLocator;
+import com.materiel.suite.client.ui.common.Toasts;
+import com.materiel.suite.client.ui.icons.IconRegistry;
+import com.materiel.suite.client.users.UserAccount;
+import com.materiel.suite.client.users.UserService;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableModel;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/** Interface d'administration des comptes utilisateurs. */
+public class UserAdminPanel extends JPanel {
+  private final DefaultTableModel model = new DefaultTableModel(new Object[]{"Utilisateur", "Nom affiché", "Rôle", "Agence", "__ID"}, 0){
+    @Override public boolean isCellEditable(int row, int column){
+      return false;
+    }
+  };
+  private final JTable table = new JTable(model);
+  private final JButton addButton = new JButton("Ajouter", IconRegistry.small("plus"));
+  private final JButton editButton = new JButton("Modifier", IconRegistry.small("edit"));
+  private final JButton deleteButton = new JButton("Supprimer", IconRegistry.small("trash"));
+  private final JButton passwordButton = new JButton("Définir mot de passe…", IconRegistry.small("lock"));
+  private final JButton refreshButton = new JButton("Recharger", IconRegistry.small("refresh"));
+  private List<UserAccount> cache = new ArrayList<>();
+
+  public UserAdminPanel(){
+    super(new BorderLayout(8, 8));
+    table.setRowHeight(24);
+    table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+    hideIdColumn();
+    add(new JScrollPane(table), BorderLayout.CENTER);
+
+    JToolBar toolbar = new JToolBar();
+    toolbar.setFloatable(false);
+    toolbar.add(addButton);
+    toolbar.add(editButton);
+    toolbar.add(deleteButton);
+    toolbar.addSeparator();
+    toolbar.add(passwordButton);
+    toolbar.addSeparator();
+    toolbar.add(refreshButton);
+    add(toolbar, BorderLayout.NORTH);
+
+    addButton.addActionListener(e -> openEditor(null));
+    editButton.addActionListener(e -> {
+      UserAccount current = current();
+      if (current != null){
+        openEditor(current);
+      }
+    });
+    deleteButton.addActionListener(e -> deleteCurrent());
+    passwordButton.addActionListener(e -> {
+      UserAccount current = current();
+      if (current != null){
+        new SetPasswordDialog(SwingUtilities.getWindowAncestor(this), current, this::reload).setVisible(true);
+      }
+    });
+    refreshButton.addActionListener(e -> reload());
+
+    table.getSelectionModel().addListSelectionListener(e -> updateActions());
+    updateActions();
+
+    reload();
+  }
+
+  private void hideIdColumn(){
+    var column = table.getColumnModel().getColumn(4);
+    column.setMinWidth(0);
+    column.setMaxWidth(0);
+    column.setPreferredWidth(0);
+  }
+
+  private void updateActions(){
+    boolean hasSelection = table.getSelectedRow() >= 0;
+    editButton.setEnabled(hasSelection);
+    deleteButton.setEnabled(hasSelection);
+    passwordButton.setEnabled(hasSelection);
+  }
+
+  private UserAccount current(){
+    int viewRow = table.getSelectedRow();
+    if (viewRow < 0){
+      return null;
+    }
+    int modelRow = table.convertRowIndexToModel(viewRow);
+    String id = Objects.toString(model.getValueAt(modelRow, 4), null);
+    return cache.stream().filter(user -> Objects.equals(user.getId(), id)).findFirst().orElse(null);
+  }
+
+  private void reload(){
+    UserService svc = ServiceLocator.users();
+    if (svc == null){
+      Toasts.error(this, "Service utilisateur indisponible");
+      return;
+    }
+    try {
+      cache = svc.list();
+      model.setRowCount(0);
+      for (UserAccount account : cache){
+        model.addRow(new Object[]{
+            account.getUsername(),
+            account.getDisplayName(),
+            account.getRole(),
+            account.getAgency() != null ? account.getAgency().getName() : "",
+            account.getId()
+        });
+      }
+      updateActions();
+    } catch (Exception ex){
+      Toasts.error(this, "Impossible de charger les comptes");
+    }
+  }
+
+  private void deleteCurrent(){
+    UserAccount current = current();
+    if (current == null){
+      return;
+    }
+    int confirm = JOptionPane.showConfirmDialog(this,
+        "Supprimer l'utilisateur " + current.getUsername() + " ?",
+        "Confirmation",
+        JOptionPane.YES_NO_OPTION,
+        JOptionPane.WARNING_MESSAGE);
+    if (confirm != JOptionPane.YES_OPTION){
+      return;
+    }
+    try {
+      ServiceLocator.users().delete(current.getId());
+      Toasts.success(this, "Compte supprimé");
+      reload();
+    } catch (Exception ex){
+      Toasts.error(this, "Impossible de supprimer le compte");
+    }
+  }
+
+  private void openEditor(UserAccount initial){
+    new UserEditorDialog(SwingUtilities.getWindowAncestor(this), initial, this::reload).setVisible(true);
+  }
+
+  private static Agency cloneAgency(Agency source){
+    if (source == null){
+      return null;
+    }
+    Agency copy = new Agency();
+    copy.setId(source.getId());
+    copy.setName(source.getName());
+    return copy;
+  }
+
+  private static class UserEditorDialog extends JDialog {
+    private final JTextField usernameField = new JTextField();
+    private final JTextField displayNameField = new JTextField();
+    private final JComboBox<Role> roleCombo = new JComboBox<>(Role.values());
+    private final JComboBox<Agency> agencyCombo = new JComboBox<>();
+    private final JPasswordField passwordField = new JPasswordField();
+    private final JButton saveButton = new JButton("Enregistrer", IconRegistry.small("success"));
+    private final UserAccount workingCopy;
+
+    UserEditorDialog(Window owner, UserAccount initial, Runnable onSaved){
+      super(owner, initial == null ? "Créer un utilisateur" : "Modifier un utilisateur", ModalityType.APPLICATION_MODAL);
+      setLayout(new BorderLayout(8, 8));
+      workingCopy = initial != null ? copyOf(initial) : new UserAccount();
+
+      DefaultComboBoxModel<Agency> agenciesModel = new DefaultComboBoxModel<>();
+      try {
+        List<Agency> agencies = ServiceLocator.auth() != null ? ServiceLocator.auth().listAgencies() : List.of();
+        for (Agency agency : agencies){
+          agenciesModel.addElement(cloneAgency(agency));
+        }
+      } catch (Exception ex){
+        // ignore, combo vide
+      }
+      agencyCombo.setModel(agenciesModel);
+
+      JPanel form = new JPanel(new GridBagLayout());
+      GridBagConstraints gc = new GridBagConstraints();
+      gc.insets = new Insets(6, 6, 6, 6);
+      gc.anchor = GridBagConstraints.WEST;
+      gc.fill = GridBagConstraints.HORIZONTAL;
+      gc.gridx = 0; gc.gridy = 0; gc.weightx = 0;
+      form.add(new JLabel("Utilisateur"), gc);
+      gc.gridx = 1; gc.weightx = 1;
+      form.add(usernameField, gc);
+
+      gc.gridx = 0; gc.gridy = 1; gc.weightx = 0;
+      form.add(new JLabel("Nom affiché"), gc);
+      gc.gridx = 1; gc.weightx = 1;
+      form.add(displayNameField, gc);
+
+      gc.gridx = 0; gc.gridy = 2; gc.weightx = 0;
+      form.add(new JLabel("Rôle"), gc);
+      gc.gridx = 1; gc.weightx = 1;
+      form.add(roleCombo, gc);
+
+      gc.gridx = 0; gc.gridy = 3; gc.weightx = 0;
+      form.add(new JLabel("Agence"), gc);
+      gc.gridx = 1; gc.weightx = 1;
+      form.add(agencyCombo, gc);
+
+      if (initial == null){
+        gc.gridx = 0; gc.gridy = 4; gc.weightx = 0;
+        form.add(new JLabel("Mot de passe"), gc);
+        gc.gridx = 1; gc.weightx = 1;
+        form.add(passwordField, gc);
+      }
+
+      add(form, BorderLayout.CENTER);
+
+      JPanel actions = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+      actions.add(saveButton);
+      add(actions, BorderLayout.SOUTH);
+
+      if (initial != null){
+        usernameField.setText(initial.getUsername());
+        usernameField.setEditable(false);
+        displayNameField.setText(initial.getDisplayName());
+        roleCombo.setSelectedItem(initial.getRole());
+        selectAgency(initial.getAgency());
+      }
+
+      saveButton.addActionListener(e -> {
+        if (usernameField.getText() == null || usernameField.getText().isBlank()){
+          Toasts.error(this, "Identifiant requis");
+          return;
+        }
+        workingCopy.setUsername(usernameField.getText().trim());
+        workingCopy.setDisplayName(displayNameField.getText());
+        workingCopy.setRole((Role) roleCombo.getSelectedItem());
+        workingCopy.setAgency((Agency) agencyCombo.getSelectedItem());
+        try {
+          UserService svc = ServiceLocator.users();
+          if (svc == null){
+            throw new IllegalStateException("Service indisponible");
+          }
+          if (initial == null){
+            String pwd = new String(passwordField.getPassword());
+            if (pwd.isBlank()){
+              Toasts.error(this, "Mot de passe requis");
+              return;
+            }
+            svc.create(workingCopy, pwd);
+          } else {
+            svc.update(workingCopy);
+          }
+          Toasts.success(this, "Compte enregistré");
+          dispose();
+          if (onSaved != null){
+            onSaved.run();
+          }
+        } catch (Exception ex){
+          Toasts.error(this, "Impossible d'enregistrer le compte");
+        }
+      });
+
+      getRootPane().setDefaultButton(saveButton);
+      setSize(520, 280);
+      setLocationRelativeTo(owner);
+    }
+
+    private void selectAgency(Agency agency){
+      if (agency == null){
+        return;
+      }
+      for (int i = 0; i < agencyCombo.getItemCount(); i++){
+        Agency item = agencyCombo.getItemAt(i);
+        if (item != null && Objects.equals(item.getId(), agency.getId())){
+          agencyCombo.setSelectedIndex(i);
+          return;
+        }
+      }
+    }
+
+    private UserAccount copyOf(UserAccount source){
+      UserAccount copy = new UserAccount();
+      copy.setId(source.getId());
+      copy.setUsername(source.getUsername());
+      copy.setDisplayName(source.getDisplayName());
+      copy.setRole(source.getRole());
+      copy.setAgency(cloneAgency(source.getAgency()));
+      return copy;
+    }
+  }
+
+  private static class SetPasswordDialog extends JDialog {
+    SetPasswordDialog(Window owner, UserAccount user, Runnable onSaved){
+      super(owner, "Définir mot de passe — " + user.getUsername(), ModalityType.APPLICATION_MODAL);
+      setLayout(new BorderLayout(8, 8));
+
+      JPasswordField password = new JPasswordField();
+      JPasswordField confirm = new JPasswordField();
+      JButton save = new JButton("Enregistrer", IconRegistry.small("success"));
+
+      JPanel form = new JPanel(new GridBagLayout());
+      GridBagConstraints gc = new GridBagConstraints();
+      gc.insets = new Insets(6, 6, 6, 6);
+      gc.anchor = GridBagConstraints.WEST;
+      gc.fill = GridBagConstraints.HORIZONTAL;
+      gc.gridx = 0; gc.gridy = 0; gc.weightx = 0;
+      form.add(new JLabel("Nouveau mot de passe"), gc);
+      gc.gridx = 1; gc.weightx = 1;
+      form.add(password, gc);
+      gc.gridx = 0; gc.gridy = 1; gc.weightx = 0;
+      form.add(new JLabel("Confirmer"), gc);
+      gc.gridx = 1; gc.weightx = 1;
+      form.add(confirm, gc);
+
+      JPanel actions = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+      actions.add(save);
+
+      add(form, BorderLayout.CENTER);
+      add(actions, BorderLayout.SOUTH);
+
+      save.addActionListener(e -> {
+        String first = new String(password.getPassword());
+        String second = new String(confirm.getPassword());
+        if (first == null || first.isBlank() || !first.equals(second)){
+          Toasts.error(this, "Mot de passe invalide");
+          return;
+        }
+        try {
+          UserService svc = ServiceLocator.users();
+          if (svc == null){
+            throw new IllegalStateException("Service indisponible");
+          }
+          svc.updatePassword(user.getId(), first);
+          Toasts.success(this, "Mot de passe mis à jour");
+          dispose();
+          if (onSaved != null){
+            onSaved.run();
+          }
+        } catch (Exception ex){
+          Toasts.error(this, "Impossible de modifier le mot de passe");
+        }
+      });
+
+      getRootPane().setDefaultButton(save);
+      setSize(420, 200);
+      setLocationRelativeTo(owner);
+    }
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/users/UserAccount.java
+++ b/client/src/main/java/com/materiel/suite/client/users/UserAccount.java
@@ -1,13 +1,15 @@
-package com.materiel.suite.backend.auth.dto;
+package com.materiel.suite.client.users;
 
-public class UserV2Dto {
+import com.materiel.suite.client.auth.Agency;
+import com.materiel.suite.client.auth.Role;
+
+/** Représente un compte utilisateur administrable. */
+public class UserAccount {
   private String id;
   private String username;
   private String displayName;
-  private String role;
-  private AgencyV2Dto agency;
-  /** Jeton optionnel pour préparer un passage ultérieur à JWT. */
-  private String token;
+  private Role role;
+  private Agency agency;
 
   public String getId(){
     return id;
@@ -33,27 +35,19 @@ public class UserV2Dto {
     this.displayName = displayName;
   }
 
-  public String getRole(){
+  public Role getRole(){
     return role;
   }
 
-  public void setRole(String role){
+  public void setRole(Role role){
     this.role = role;
   }
 
-  public AgencyV2Dto getAgency(){
+  public Agency getAgency(){
     return agency;
   }
 
-  public void setAgency(AgencyV2Dto agency){
+  public void setAgency(Agency agency){
     this.agency = agency;
-  }
-
-  public String getToken(){
-    return token;
-  }
-
-  public void setToken(String token){
-    this.token = token;
   }
 }

--- a/client/src/main/java/com/materiel/suite/client/users/UserService.java
+++ b/client/src/main/java/com/materiel/suite/client/users/UserService.java
@@ -1,0 +1,16 @@
+package com.materiel.suite.client.users;
+
+import java.util.List;
+
+/** Contrat minimal pour gérer les comptes utilisateurs côté client. */
+public interface UserService {
+  List<UserAccount> list();
+
+  UserAccount create(UserAccount account, String password);
+
+  UserAccount update(UserAccount account);
+
+  void delete(String id);
+
+  void updatePassword(String id, String newPassword);
+}


### PR DESCRIPTION
## Summary
- add client-side user account model/service abstractions plus backend API plumbing
- introduce administration and self-service password UI gated by access control
- extend backend auth catalog to manage passwords and document the new endpoints

## Testing
- mvn -pl backend -am test *(fails: unable to reach Maven Central in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cba2a9d2d08330b53ea8fa8045d6e5