### PR TITLE
Clarify navigation button references in MainFrame

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/ui/MainFrame.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/MainFrame.java
@@ -149,12 +149,12 @@ public class MainFrame extends JFrame implements SessionManager.SessionAware {
 
   /** Navigation inter-panneaux depuis menus contextuels */
   public void openCard(String key){
-    SidebarButton button = navButtons.get(key);
-    if (button != null && !button.isVisible()){
+    SidebarButton targetBtn = navButtons.get(key);
+    if (targetBtn != null && !targetBtn.isVisible()){
       return;
     }
     cards.show(center, key);
-    navButtons.forEach((card, button) -> button.setActive(card.equals(key)));
+    navButtons.forEach((card, btn) -> btn.setActive(card.equals(key)));
     currentCard = key;
   }
 


### PR DESCRIPTION
## Summary
- rename the navigation button variable in `MainFrame.openCard` for clarity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbbc0a8d488330af074e36309e9d6b