### PR TITLE
feat(client): badge for quoted interventions

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/ui/icons/IconRegistry.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/icons/IconRegistry.java
@@ -18,7 +18,8 @@ public final class IconRegistry {
       "search", "success", "error", "info", "settings", "signature", "task", "invoice",
       "maximize", "minimize", "plus", "edit", "trash", "refresh", "image", "cube", "file",
       "calendar", "user", "wrench", "lock", "building",
-      "crane", "truck", "forklift", "container", "excavator", "generator", "hook", "helmet", "pallet"
+      "crane", "truck", "forklift", "container", "excavator", "generator", "hook", "helmet", "pallet",
+      "badge"
   );
   private static final Set<String> ICON_SET = Set.copyOf(ICON_KEYS);
   private static final Map<Integer, Icon> PLACEHOLDER_CACHE = new ConcurrentHashMap<>();

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/BadgeBorder.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/BadgeBorder.java
@@ -1,0 +1,46 @@
+package com.materiel.suite.client.ui.planning;
+
+import javax.swing.Icon;
+import javax.swing.border.AbstractBorder;
+import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.Insets;
+
+/** Dessine une petite icône en surcouche dans le coin supérieur droit d'un composant. */
+final class BadgeBorder extends AbstractBorder {
+  private final Icon icon;
+  private final int margin;
+
+  BadgeBorder(Icon icon){
+    this(icon, 4);
+  }
+
+  BadgeBorder(Icon icon, int margin){
+    this.icon = icon;
+    this.margin = Math.max(0, margin);
+  }
+
+  @Override public void paintBorder(Component c, Graphics g, int x, int y, int width, int height){
+    if (icon == null){
+      return;
+    }
+    int ix = x + width - icon.getIconWidth() - margin;
+    int iy = y + margin;
+    icon.paintIcon(c, g, ix, iy);
+  }
+
+  @Override public Insets getBorderInsets(Component c){
+    return new Insets(0, 0, 0, 0);
+  }
+
+  @Override public Insets getBorderInsets(Component c, Insets insets){
+    if (insets == null){
+      return new Insets(0, 0, 0, 0);
+    }
+    insets.top = 0;
+    insets.left = 0;
+    insets.bottom = 0;
+    insets.right = 0;
+    return insets;
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionCalendarView.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionCalendarView.java
@@ -35,6 +35,7 @@ public class InterventionCalendarView implements InterventionView {
   private static final int SLOT_MINUTES = 15;
   private static final int COLUMN_WIDTH = 180;
   private static final int RESIZE_HANDLE = 6;
+  private static final Icon QUOTE_BADGE = IconRegistry.small("badge");
 
   private final JPanel root = new JPanel(new BorderLayout());
   private final JPanel days = new JPanel();
@@ -211,10 +212,14 @@ public class InterventionCalendarView implements InterventionView {
     JPanel panel = new JPanel(new BorderLayout(8, 0));
     panel.setOpaque(true);
     panel.setBackground(Color.WHITE);
-    panel.setBorder(BorderFactory.createCompoundBorder(
+    String quote = quoteReference(it);
+    panel.setBorder(badgeBorder(BorderFactory.createCompoundBorder(
         BorderFactory.createMatteBorder(0, 0, 1, 0, new Color(235, 235, 235)),
         BorderFactory.createEmptyBorder(6, 8, 6, 8)
-    ));
+    ), quote));
+    if (quote != null){
+      panel.setToolTipText("Devis " + quote);
+    }
     panel.setAlignmentX(Component.LEFT_ALIGNMENT);
 
     JLabel iconLabel = new JLabel();
@@ -443,6 +448,27 @@ public class InterventionCalendarView implements InterventionView {
     return value.substring(0, 1).toUpperCase(Locale.FRENCH) + value.substring(1);
   }
 
+  private javax.swing.border.Border badgeBorder(javax.swing.border.Border base, String quote){
+    if (quote != null && !quote.isBlank() && QUOTE_BADGE != null){
+      return BorderFactory.createCompoundBorder(new BadgeBorder(QUOTE_BADGE), base);
+    }
+    return base;
+  }
+
+  private String quoteReference(Intervention it){
+    if (it == null){
+      return null;
+    }
+    String ref = it.getQuoteReference();
+    if (ref == null || ref.isBlank()){
+      ref = it.getQuoteNumber();
+    }
+    if (ref == null || ref.isBlank()){
+      return null;
+    }
+    return ref;
+  }
+
   private class DayColumn extends JPanel {
     private final LocalDate day;
 
@@ -495,7 +521,12 @@ public class InterventionCalendarView implements InterventionView {
         {
           setOpaque(true);
           setBackground(new Color(197, 225, 250));
-          setBorder(BorderFactory.createLineBorder(new Color(144, 202, 249)));
+          String quoteInfo = quoteReference(it);
+          javax.swing.border.Border baseBorder = BorderFactory.createLineBorder(new Color(144, 202, 249));
+          setBorder(badgeBorder(baseBorder, quoteInfo));
+          if (quoteInfo != null){
+            setToolTipText("Devis " + quoteInfo);
+          }
           JLabel label = new JLabel(blockLabel(it, localStart, localEnd));
           InterventionType type = it.getType();
           if (type != null && type.getIconKey() != null){

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionTableView.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionTableView.java
@@ -46,6 +46,10 @@ public class InterventionTableView implements InterventionView {
     table.getColumnModel().getColumn(0).setCellRenderer(dateRenderer());
     table.getColumnModel().getColumn(1).setCellRenderer(dateRenderer());
     table.getColumnModel().getColumn(2).setCellRenderer(typeRenderer());
+    table.getColumnModel().getColumn(6).setCellRenderer(quoteRenderer());
+    table.getColumnModel().getColumn(6).setMaxWidth(48);
+    table.getColumnModel().getColumn(6).setMinWidth(36);
+    table.getColumnModel().getColumn(6).setPreferredWidth(40);
     table.getColumnModel().getColumn(7).setCellRenderer(resourceRenderer());
     table.addMouseListener(new MouseAdapter(){
       @Override public void mousePressed(MouseEvent e){
@@ -169,6 +173,33 @@ public class InterventionTableView implements InterventionView {
           label.setIconTextGap(6);
         } else {
           label.setText("");
+        }
+        return label;
+      }
+    };
+  }
+
+  private DefaultTableCellRenderer quoteRenderer(){
+    return new DefaultTableCellRenderer(){
+      private final Icon badge = IconRegistry.small("badge");
+      private final Icon fallback = IconRegistry.small("file");
+
+      @Override public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column){
+        JLabel label = (JLabel) super.getTableCellRendererComponent(table, "", isSelected, hasFocus, row, column);
+        label.setHorizontalAlignment(SwingConstants.CENTER);
+        label.setText("");
+        label.setIcon(null);
+        label.setToolTipText(null);
+        String ref = value instanceof String ? (String) value : null;
+        boolean show = ref != null && !ref.isBlank();
+        if (show){
+          Icon icon = badge != null ? badge : fallback;
+          if (icon != null){
+            label.setIcon(icon);
+          } else {
+            label.setText("•");
+          }
+          label.setToolTipText(ref);
         }
         return label;
       }

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionTileRenderer.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionTileRenderer.java
@@ -1,6 +1,9 @@
 package com.materiel.suite.client.ui.planning;
 
 import com.materiel.suite.client.model.Intervention;
+import com.materiel.suite.client.ui.icons.IconRegistry;
+
+import javax.swing.Icon;
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -11,6 +14,7 @@ final class InterventionTileRenderer {
   private static final int R = PlanningUx.RADIUS;
   private static final int CHIP_H = 24;
   private static final int CHIP_GAP = 8;
+  private static final Icon QUOTE_BADGE = IconRegistry.small("badge");
   private boolean compact = false;
   private UiDensity density = UiDensity.NORMAL;
   private double scaleY = 1.0;
@@ -172,6 +176,15 @@ final class InterventionTileRenderer {
       g2.setStroke(old);
     } else {
       PlanningUx.strokeRound(g2, r);
+    }
+
+    if (QUOTE_BADGE != null){
+      String quoteRef = quoteReference(it);
+      if (quoteRef != null){
+        int ix = r.x + r.width - QUOTE_BADGE.getIconWidth() - PAD;
+        int iy = r.y + PAD;
+        QUOTE_BADGE.paintIcon(null, g2, ix, iy);
+      }
     }
 
     int x = r.x + PAD;

--- a/client/src/main/resources/icons/badge.svg
+++ b/client/src/main/resources/icons/badge.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <circle cx="12" cy="12" r="9" fill="#1f4fd8"/>
+  <circle cx="12" cy="12" r="9" fill="none" stroke="#0d3c9e" stroke-width="2"/>
+  <path d="M9.2 12.8 11.1 14.7 15.5 10.3" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- add the `badge` icon asset and expose it through `IconRegistry`
- overlay a quote badge on calendar blocks using `BadgeBorder`
- render the quote badge in the list and planning tile views when a quote exists

## Testing
- `mvn -pl client test` *(fails: unable to reach Maven Central from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbea4b90cc8330af4e6a06f4513800