### PR TITLE
Add quote filter to planning views

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/ui/icons/IconRegistry.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/icons/IconRegistry.java
@@ -16,8 +16,8 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class IconRegistry {
   private static final List<String> ICON_KEYS = List.of(
       "search", "success", "error", "info", "settings", "signature", "task", "invoice",
-      "maximize", "minimize", "plus", "edit", "trash", "refresh", "image", "cube", "file",
-      "calendar", "user", "wrench", "lock", "building",
+      "maximize", "minimize", "plus", "edit", "trash", "refresh", "image", "cube", "file", "file-plus",
+      "calendar", "user", "wrench", "lock", "building", "filter",
       "crane", "truck", "forklift", "container", "excavator", "generator", "hook", "helmet", "pallet",
       "badge"
   );

--- a/client/src/main/resources/icons/file-plus.svg
+++ b/client/src/main/resources/icons/file-plus.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <path d="M6 3h7l5 5v13a1.5 1.5 0 0 1-1.5 1.5h-10A1.5 1.5 0 0 1 5 21V4.5A1.5 1.5 0 0 1 6.5 3Z" fill="#64b5f6"/>
+  <path d="M13 3v5h5l-5-5z" fill="#1e88e5"/>
+  <rect x="7.5" y="11" width="9" height="1.6" rx="0.8" fill="#e3f2fd"/>
+  <rect x="7.5" y="14" width="9" height="1.6" rx="0.8" fill="#e3f2fd"/>
+  <rect x="7.5" y="17" width="6" height="1.6" rx="0.8" fill="#e3f2fd"/>
+  <circle cx="17.5" cy="17.5" r="4.5" fill="#1e88e5"/>
+  <rect x="17" y="14.5" width="1" height="6" rx="0.5" fill="#e3f2fd"/>
+  <rect x="14.5" y="17" width="6" height="1" rx="0.5" fill="#e3f2fd"/>
+</svg>

--- a/client/src/main/resources/icons/filter.svg
+++ b/client/src/main/resources/icons/filter.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <path d="M4 5h16L14 13v5.5a1 1 0 0 1-.53.88l-3.5 1.75a1 1 0 0 1-1.45-.89v-7.24L4 5Z" fill="#90caf9"/>
+  <path d="M4 5h16L14 13v5.5a1 1 0 0 1-.53.88l-3.5 1.75a1 1 0 0 1-1.45-.89v-7.24L4 5Z" fill="none" stroke="#1e88e5" stroke-width="1.8" stroke-linejoin="round"/>
+  <path d="M9 10h6" stroke="#1e88e5" stroke-width="1.6" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- add a toolbar combo to filter interventions by quote status in the planning views
- keep the loaded interventions in memory and reuse them when applying the current filter
- register dedicated SVG assets for the new filter control and bulk quote button

## Testing
- `mvn -pl client -am -DskipTests package` *(fails: cannot reach repo.maven.apache.org from the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbee89638883308d98b50d27c26d1e