### PR TITLE
Add workflow step bar and mock v2 intervention API

### DIFF
--- a/backend/src/main/java/com/materiel/suite/backend/intervention/InterventionV2Controller.java
+++ b/backend/src/main/java/com/materiel/suite/backend/intervention/InterventionV2Controller.java
@@ -1,0 +1,45 @@
+package com.materiel.suite.backend.intervention;
+
+import com.materiel.suite.backend.intervention.dto.InterventionV2Dto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@RestController
+@RequestMapping("/api/v2/interventions")
+public class InterventionV2Controller {
+  private final Map<String, InterventionV2Dto> store = new ConcurrentHashMap<>();
+
+  @GetMapping
+  public ResponseEntity<List<InterventionV2Dto>> list(){
+    return ResponseEntity.ok(new ArrayList<>(store.values()));
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<InterventionV2Dto> get(@PathVariable String id){
+    InterventionV2Dto dto = store.get(id);
+    if (dto == null){
+      return ResponseEntity.notFound().build();
+    }
+    return ResponseEntity.ok(dto);
+  }
+
+  @PutMapping("/{id}")
+  public ResponseEntity<InterventionV2Dto> upsert(@PathVariable String id, @RequestBody InterventionV2Dto body){
+    if (body == null){
+      return ResponseEntity.badRequest().build();
+    }
+    body.setId(id);
+    store.put(id, body);
+    return ResponseEntity.ok(body);
+  }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/intervention/dto/InterventionV2Dto.java
+++ b/backend/src/main/java/com/materiel/suite/backend/intervention/dto/InterventionV2Dto.java
@@ -1,0 +1,125 @@
+package com.materiel.suite.backend.intervention.dto;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/** DTO léger pour l'API mockée d'interventions v2. */
+public class InterventionV2Dto {
+  private String id;
+  private String title;
+  private OffsetDateTime plannedStart;
+  private OffsetDateTime plannedEnd;
+  private String clientId;
+  private String address;
+  private String quoteId;
+  private String quoteReference;
+  private List<Object> billingLines;
+  private String workflowStage;
+  private boolean generalDone;
+  private boolean detailsDone;
+  private boolean billingReady;
+
+  public String getId(){
+    return id;
+  }
+
+  public void setId(String id){
+    this.id = id;
+  }
+
+  public String getTitle(){
+    return title;
+  }
+
+  public void setTitle(String title){
+    this.title = title;
+  }
+
+  public OffsetDateTime getPlannedStart(){
+    return plannedStart;
+  }
+
+  public void setPlannedStart(OffsetDateTime plannedStart){
+    this.plannedStart = plannedStart;
+  }
+
+  public OffsetDateTime getPlannedEnd(){
+    return plannedEnd;
+  }
+
+  public void setPlannedEnd(OffsetDateTime plannedEnd){
+    this.plannedEnd = plannedEnd;
+  }
+
+  public String getClientId(){
+    return clientId;
+  }
+
+  public void setClientId(String clientId){
+    this.clientId = clientId;
+  }
+
+  public String getAddress(){
+    return address;
+  }
+
+  public void setAddress(String address){
+    this.address = address;
+  }
+
+  public String getQuoteId(){
+    return quoteId;
+  }
+
+  public void setQuoteId(String quoteId){
+    this.quoteId = quoteId;
+  }
+
+  public String getQuoteReference(){
+    return quoteReference;
+  }
+
+  public void setQuoteReference(String quoteReference){
+    this.quoteReference = quoteReference;
+  }
+
+  public List<Object> getBillingLines(){
+    return billingLines;
+  }
+
+  public void setBillingLines(List<Object> billingLines){
+    this.billingLines = billingLines;
+  }
+
+  public String getWorkflowStage(){
+    return workflowStage;
+  }
+
+  public void setWorkflowStage(String workflowStage){
+    this.workflowStage = workflowStage;
+  }
+
+  public boolean isGeneralDone(){
+    return generalDone;
+  }
+
+  public void setGeneralDone(boolean generalDone){
+    this.generalDone = generalDone;
+  }
+
+  public boolean isDetailsDone(){
+    return detailsDone;
+  }
+
+  public void setDetailsDone(boolean detailsDone){
+    this.detailsDone = detailsDone;
+  }
+
+  public boolean isBillingReady(){
+    return billingReady;
+  }
+
+  public void setBillingReady(boolean billingReady){
+    this.billingReady = billingReady;
+  }
+}

--- a/backend/src/main/resources/openapi/gestion-materiel-v1.yaml
+++ b/backend/src/main/resources/openapi/gestion-materiel-v1.yaml
@@ -111,6 +111,57 @@ paths:
       responses:
         '204':
           description: Updated
+  /api/v2/interventions:
+    get:
+      summary: Lister les interventions (v2, mock)
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/InterventionV2'
+  /api/v2/interventions/{id}:
+    get:
+      summary: Récupérer une intervention (v2)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InterventionV2'
+        '404':
+          description: Not Found
+    put:
+      summary: Mettre à jour une intervention (v2)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InterventionV2'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InterventionV2'
   /api/v1/quotes:
     get:
       summary: List quotes
@@ -515,6 +566,42 @@ components:
           type: string
         name:
           type: string
+    InterventionV2:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        plannedStart:
+          type: string
+          format: date-time
+        plannedEnd:
+          type: string
+          format: date-time
+        clientId:
+          type: string
+        address:
+          type: string
+        quoteId:
+          type: string
+          description: 'Lien devis si généré'
+        quoteReference:
+          type: string
+          description: 'Référence devis lisible'
+        workflowStage:
+          type: string
+          enum: [ 'GÉNÉRAL', 'INTERVENTION', 'FACTURATION', 'DEVIS' ]
+        generalDone:
+          type: boolean
+        detailsDone:
+          type: boolean
+        billingReady:
+          type: boolean
+        billingLines:
+          type: array
+          items:
+            type: object
     UserV2:
       type: object
       properties:

--- a/client/src/main/java/com/materiel/suite/client/model/Intervention.java
+++ b/client/src/main/java/com/materiel/suite/client/model/Intervention.java
@@ -33,6 +33,10 @@ public class Intervention {
   private final List<BillingLine> billingLines = new ArrayList<>();
   private UUID quoteId;
   private String quoteReference;
+  private String workflowStage;
+  private boolean generalDone;
+  private boolean detailsDone;
+  private boolean billingReady;
 
   // Champs enrichis pour rendu "carte"
   private String clientName;
@@ -307,6 +311,14 @@ public class Intervention {
   public void setQuoteId(UUID quoteId){ this.quoteId = quoteId; }
   public String getQuoteReference(){ return quoteReference; }
   public void setQuoteReference(String quoteReference){ this.quoteReference = quoteReference; }
+  public String getWorkflowStage(){ return workflowStage; }
+  public void setWorkflowStage(String workflowStage){ this.workflowStage = workflowStage; }
+  public boolean isGeneralDone(){ return generalDone; }
+  public void setGeneralDone(boolean generalDone){ this.generalDone = generalDone; }
+  public boolean isDetailsDone(){ return detailsDone; }
+  public void setDetailsDone(boolean detailsDone){ this.detailsDone = detailsDone; }
+  public boolean isBillingReady(){ return billingReady; }
+  public void setBillingReady(boolean billingReady){ this.billingReady = billingReady; }
   public boolean hasQuote(){
     if (quoteId != null){
       return true;

--- a/client/src/main/java/com/materiel/suite/client/ui/interventions/ContactPickerPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/interventions/ContactPickerPanel.java
@@ -27,6 +27,7 @@ public class ContactPickerPanel extends JPanel {
   private final List<Contact> allContacts = new ArrayList<>();
   private final Map<String, Contact> selectedContacts = new LinkedHashMap<>();
   private boolean readOnly;
+  private Runnable selectionListener;
 
   public ContactPickerPanel(){
     super(new BorderLayout(8, 8));
@@ -88,6 +89,7 @@ public class ContactPickerPanel extends JPanel {
       }
     }
     model.refreshAll();
+    notifySelectionChanged();
   }
 
   public void setContacts(List<Contact> contacts){
@@ -102,6 +104,7 @@ public class ContactPickerPanel extends JPanel {
     }
     ensureSelectedContactsPresent();
     applyFilter();
+    notifySelectionChanged();
   }
 
   public void setSelectedContacts(List<Contact> contacts){
@@ -117,6 +120,17 @@ public class ContactPickerPanel extends JPanel {
     }
     ensureSelectedContactsPresent();
     applyFilter();
+    notifySelectionChanged();
+  }
+
+  public void setSelectionListener(Runnable listener){
+    this.selectionListener = listener;
+  }
+
+  private void notifySelectionChanged(){
+    if (selectionListener != null){
+      selectionListener.run();
+    }
   }
 
   public List<Contact> getSelectedContacts(){
@@ -289,6 +303,7 @@ public class ContactPickerPanel extends JPanel {
         selectedContacts.remove(key);
       }
       fireTableRowsUpdated(rowIndex, rowIndex);
+      notifySelectionChanged();
     }
 
     void setRows(List<Contact> list){

--- a/client/src/main/java/com/materiel/suite/client/ui/interventions/StepBar.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/interventions/StepBar.java
@@ -1,0 +1,70 @@
+package com.materiel.suite.client.ui.interventions;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.function.IntConsumer;
+
+/** Barre d'étapes interactive pour l'intervention (Général → Intervention → Facturation → Devis). */
+public class StepBar extends JPanel {
+  private final JLabel[] steps = new JLabel[4];
+  private IntConsumer onNavigate;
+
+  public StepBar(){
+    super(new GridLayout(1, 4, 8, 0));
+    setBorder(BorderFactory.createEmptyBorder(4, 8, 4, 8));
+    String[] labels = {"Général", "Intervention", "Facturation", "Devis"};
+    for (int i = 0; i < steps.length; i++){
+      JLabel label = new JLabel(labels[i], SwingConstants.CENTER);
+      label.setOpaque(true);
+      label.setBorder(BorderFactory.createEmptyBorder(6, 10, 6, 10));
+      label.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+      final int index = i;
+      label.addMouseListener(new MouseAdapter(){
+        @Override public void mouseClicked(MouseEvent e){
+          if (onNavigate != null){
+            onNavigate.accept(index);
+          }
+        }
+      });
+      steps[i] = label;
+      add(label);
+    }
+    setState(0, false, false, false, false);
+  }
+
+  public void setOnNavigate(IntConsumer onNavigate){
+    this.onNavigate = onNavigate;
+  }
+
+  public void setState(int active, boolean generalDone, boolean detailsDone, boolean billingReady, boolean quoted){
+    int clamped = Math.max(0, Math.min(active, steps.length - 1));
+    boolean[] done = {generalDone, detailsDone, billingReady, quoted};
+    for (int i = 0; i < steps.length; i++){
+      JLabel label = steps[i];
+      boolean isActive = i == clamped;
+      boolean isDone = done[i];
+      label.setBackground(isActive ? new Color(0xDCEAFB) : new Color(0xF5F7FA));
+      label.setForeground(isDone ? new Color(0x1B5E20) : (isActive ? new Color(0x0D47A1) : new Color(0x455A64)));
+      label.setText(stepLabel(i, isDone, isActive));
+    }
+    repaint();
+  }
+
+  private String stepLabel(int index, boolean done, boolean active){
+    String base = switch (index){
+      case 0 -> "Général";
+      case 1 -> "Intervention";
+      case 2 -> "Facturation";
+      default -> "Devis";
+    };
+    if (done){
+      return base + " ✅";
+    }
+    if (active){
+      return base + " ⏳";
+    }
+    return base;
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable StepBar widget and integrate it into InterventionDialog with workflow state tracking
- persist workflow stage booleans on the Intervention model and surface them in the mock v2 API DTO/controller
- expose the new endpoints and schema in the OpenAPI document and propagate contact selection notifications

## Testing
- mvn -DskipTests package *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1fbc17c48330bd7a75ea791bfda3