### PR TITLE
Adjust intervention workflow mapping

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/ui/interventions/InterventionDialog.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/interventions/InterventionDialog.java
@@ -132,6 +132,7 @@ public class InterventionDialog extends JDialog {
   }
 
   private void installWorkflowHooks(){
+    // Mapping étapes → onglets (ordre figé) : Intervention(1), Devis(3), Facturation(2)
     workflowStepBar.setOnNavigate(this::navigateToStep);
     ChangeListener spinnerListener = e -> refreshWorkflowState();
     startSpinner.addChangeListener(spinnerListener);
@@ -140,10 +141,16 @@ public class InterventionDialog extends JDialog {
   }
 
   private void navigateToStep(int index){
-    if (index < 0 || index >= tabs.getTabCount()){
+    int target = switch (index){
+      case 0 -> 1; // Intervention
+      case 1 -> 3; // Devis
+      case 2 -> 2; // Facturation
+      default -> 1;
+    };
+    if (target < 0 || target >= tabs.getTabCount()){
       return;
     }
-    tabs.setSelectedIndex(index);
+    tabs.setSelectedIndex(target);
   }
 
   private DocumentListener documentListener(Runnable action){
@@ -163,13 +170,19 @@ public class InterventionDialog extends JDialog {
       current.setGeneralDone(generalReady);
       current.setDetailsDone(detailsReady);
       current.setBillingReady(billingReady);
-      current.setWorkflowStage(quoted ? "DEVIS"
-          : billingReady ? "FACTURATION"
-          : detailsReady ? "INTERVENTION"
-          : "GÉNÉRAL");
+      // Étape courante (prochaine à faire) — ordre figé : Intervention → Devis → Facturation
+      String stage = !detailsReady ? "INTERVENTION" : (!quoted ? "DEVIS" : "FACTURATION");
+      current.setWorkflowStage(stage);
     }
-    int index = Math.max(0, tabs.getSelectedIndex());
-    workflowStepBar.setState(index, generalReady, detailsReady, billingReady, quoted);
+    // Peindre la barre (activeIndex selon l'onglet : Intervention(1)→0, Devis(3)→1, Facturation(2)→2)
+    int tabIdx = tabs.getSelectedIndex();
+    int active = switch (tabIdx){
+      case 1 -> 0;
+      case 3 -> 1;
+      case 2 -> 2;
+      default -> 0;
+    };
+    workflowStepBar.setState(active, detailsReady, quoted, billingReady);
     quoteSummaryLabel.setText(quoteStatusLabel.getText());
   }
 

--- a/client/src/main/java/com/materiel/suite/client/ui/interventions/StepBar.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/interventions/StepBar.java
@@ -6,15 +6,15 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.function.IntConsumer;
 
-/** Barre d'étapes interactive pour l'intervention (Général → Intervention → Facturation → Devis). */
+/** Barre d'étapes interactive pour le suivi Intervention → Devis → Facturation. */
 public class StepBar extends JPanel {
-  private final JLabel[] steps = new JLabel[4];
+  private final JLabel[] steps = new JLabel[3];
   private IntConsumer onNavigate;
 
   public StepBar(){
-    super(new GridLayout(1, 4, 8, 0));
+    super(new GridLayout(1, 3, 8, 0));
     setBorder(BorderFactory.createEmptyBorder(4, 8, 4, 8));
-    String[] labels = {"Général", "Intervention", "Facturation", "Devis"};
+    String[] labels = {"Intervention", "Devis", "Facturation"};
     for (int i = 0; i < steps.length; i++){
       JLabel label = new JLabel(labels[i], SwingConstants.CENTER);
       label.setOpaque(true);
@@ -31,16 +31,16 @@ public class StepBar extends JPanel {
       steps[i] = label;
       add(label);
     }
-    setState(0, false, false, false, false);
+    setState(0, false, false, false);
   }
 
   public void setOnNavigate(IntConsumer onNavigate){
     this.onNavigate = onNavigate;
   }
 
-  public void setState(int active, boolean generalDone, boolean detailsDone, boolean billingReady, boolean quoted){
+  public void setState(int active, boolean interventionReady, boolean quoteGenerated, boolean billingReady){
     int clamped = Math.max(0, Math.min(active, steps.length - 1));
-    boolean[] done = {generalDone, detailsDone, billingReady, quoted};
+    boolean[] done = {interventionReady, quoteGenerated, billingReady};
     for (int i = 0; i < steps.length; i++){
       JLabel label = steps[i];
       boolean isActive = i == clamped;
@@ -54,10 +54,9 @@ public class StepBar extends JPanel {
 
   private String stepLabel(int index, boolean done, boolean active){
     String base = switch (index){
-      case 0 -> "Général";
-      case 1 -> "Intervention";
-      case 2 -> "Facturation";
-      default -> "Devis";
+      case 0 -> "Intervention";
+      case 1 -> "Devis";
+      default -> "Facturation";
     };
     if (done){
       return base + " ✅";


### PR DESCRIPTION
## Summary
- align the intervention dialog workflow navigation with the fixed Intervention → Devis → Facturation order
- update the workflow stage computation and step bar activation to match the new order
- simplify the step bar component to three steps with matching labels and completion indicators

## Testing
- `mvn -pl client -am -DskipTests compile` *(fails: cannot reach Maven Central from execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd10ea41788330bd8d0daac93e6ce3