### PR TITLE
Add quote preview and dry-run features for interventions

### DIFF
--- a/backend/src/main/java/com/materiel/suite/backend/sales/SalesV2Controller.java
+++ b/backend/src/main/java/com/materiel/suite/backend/sales/SalesV2Controller.java
@@ -1,0 +1,68 @@
+package com.materiel.suite.backend.sales;
+
+import com.materiel.suite.backend.sales.dto.BillingLineV2Dto;
+import com.materiel.suite.backend.sales.dto.CreateQuoteFromInterventionV2Request;
+import com.materiel.suite.backend.sales.dto.InterventionV2Dto;
+import com.materiel.suite.backend.sales.dto.QuoteV2Dto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.math.BigDecimal;
+import java.time.Year;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@RestController
+public class SalesV2Controller {
+  private final AtomicInteger seq = new AtomicInteger(1);
+  /** stockage in-memory pour pouvoir récupérer un devis par ID (preview/ouverture) */
+  private final Map<String, QuoteV2Dto> store = new ConcurrentHashMap<>();
+
+  @PostMapping("/api/v2/quotes/from-intervention")
+  public ResponseEntity<QuoteV2Dto> createFromIntervention(@RequestBody CreateQuoteFromInterventionV2Request body){
+    if (body == null || body.getIntervention() == null){
+      return ResponseEntity.badRequest().build();
+    }
+    InterventionV2Dto itv = body.getIntervention();
+    BigDecimal total = BigDecimal.ZERO;
+    if (itv.getBillingLines() != null){
+      for (BillingLineV2Dto bl : itv.getBillingLines()){
+        if (bl == null){
+          continue;
+        }
+        BigDecimal line = bl.getTotalHt();
+        if (line == null){
+          BigDecimal unit = bl.getUnitPriceHt();
+          BigDecimal qty = bl.getQuantity();
+          if (unit != null && qty != null){
+            line = unit.multiply(qty);
+          }
+        }
+        if (line != null){
+          total = total.add(line);
+        }
+      }
+    }
+    QuoteV2Dto out = new QuoteV2Dto();
+    String id = UUID.randomUUID().toString();
+    out.setId(id);
+    out.setReference(String.format("Q%s-%04d", Year.now(), seq.getAndIncrement()));
+    out.setStatus("DRAFT");
+    out.setTotalHt(total);
+    out.setTotalTtc(total); // TVA ignorée en v2 mock
+    store.put(id, out);
+    return ResponseEntity.ok(out);
+  }
+
+  @GetMapping("/api/v2/quotes/{id}")
+  public ResponseEntity<QuoteV2Dto> getById(@PathVariable String id){
+    QuoteV2Dto q = store.get(id);
+    return q == null ? ResponseEntity.notFound().build() : ResponseEntity.ok(q);
+  }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/sales/dto/BillingLineV2Dto.java
+++ b/backend/src/main/java/com/materiel/suite/backend/sales/dto/BillingLineV2Dto.java
@@ -1,0 +1,61 @@
+package com.materiel.suite.backend.sales.dto;
+
+import java.math.BigDecimal;
+
+/** Ligne de facturation simplifiée pour la génération de devis v2. */
+public class BillingLineV2Dto {
+  private String id;
+  private String designation;
+  private BigDecimal quantity;
+  private String unit;
+  private BigDecimal unitPriceHt;
+  private BigDecimal totalHt;
+
+  public String getId(){
+    return id;
+  }
+
+  public void setId(String id){
+    this.id = id;
+  }
+
+  public String getDesignation(){
+    return designation;
+  }
+
+  public void setDesignation(String designation){
+    this.designation = designation;
+  }
+
+  public BigDecimal getQuantity(){
+    return quantity;
+  }
+
+  public void setQuantity(BigDecimal quantity){
+    this.quantity = quantity;
+  }
+
+  public String getUnit(){
+    return unit;
+  }
+
+  public void setUnit(String unit){
+    this.unit = unit;
+  }
+
+  public BigDecimal getUnitPriceHt(){
+    return unitPriceHt;
+  }
+
+  public void setUnitPriceHt(BigDecimal unitPriceHt){
+    this.unitPriceHt = unitPriceHt;
+  }
+
+  public BigDecimal getTotalHt(){
+    return totalHt;
+  }
+
+  public void setTotalHt(BigDecimal totalHt){
+    this.totalHt = totalHt;
+  }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/sales/dto/CreateQuoteFromInterventionV2Request.java
+++ b/backend/src/main/java/com/materiel/suite/backend/sales/dto/CreateQuoteFromInterventionV2Request.java
@@ -1,0 +1,14 @@
+package com.materiel.suite.backend.sales.dto;
+
+/** Payload d'entrée pour générer un devis à partir d'une intervention. */
+public class CreateQuoteFromInterventionV2Request {
+  private InterventionV2Dto intervention;
+
+  public InterventionV2Dto getIntervention(){
+    return intervention;
+  }
+
+  public void setIntervention(InterventionV2Dto intervention){
+    this.intervention = intervention;
+  }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/sales/dto/InterventionV2Dto.java
+++ b/backend/src/main/java/com/materiel/suite/backend/sales/dto/InterventionV2Dto.java
@@ -1,0 +1,44 @@
+package com.materiel.suite.backend.sales.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Représente les informations utiles d'une intervention pour générer un devis v2. */
+public class InterventionV2Dto {
+  private String id;
+  private String title;
+  private String clientId;
+  private List<BillingLineV2Dto> billingLines = new ArrayList<>();
+
+  public String getId(){
+    return id;
+  }
+
+  public void setId(String id){
+    this.id = id;
+  }
+
+  public String getTitle(){
+    return title;
+  }
+
+  public void setTitle(String title){
+    this.title = title;
+  }
+
+  public String getClientId(){
+    return clientId;
+  }
+
+  public void setClientId(String clientId){
+    this.clientId = clientId;
+  }
+
+  public List<BillingLineV2Dto> getBillingLines(){
+    return billingLines;
+  }
+
+  public void setBillingLines(List<BillingLineV2Dto> billingLines){
+    this.billingLines = billingLines == null ? new ArrayList<>() : new ArrayList<>(billingLines);
+  }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/sales/dto/QuoteV2Dto.java
+++ b/backend/src/main/java/com/materiel/suite/backend/sales/dto/QuoteV2Dto.java
@@ -1,0 +1,52 @@
+package com.materiel.suite.backend.sales.dto;
+
+import java.math.BigDecimal;
+
+/** DTO minimal pour exposer un devis v2 via l'API mock. */
+public class QuoteV2Dto {
+  private String id;
+  private String reference;
+  private String status;
+  private BigDecimal totalHt;
+  private BigDecimal totalTtc;
+
+  public String getId(){
+    return id;
+  }
+
+  public void setId(String id){
+    this.id = id;
+  }
+
+  public String getReference(){
+    return reference;
+  }
+
+  public void setReference(String reference){
+    this.reference = reference;
+  }
+
+  public String getStatus(){
+    return status;
+  }
+
+  public void setStatus(String status){
+    this.status = status;
+  }
+
+  public BigDecimal getTotalHt(){
+    return totalHt;
+  }
+
+  public void setTotalHt(BigDecimal totalHt){
+    this.totalHt = totalHt;
+  }
+
+  public BigDecimal getTotalTtc(){
+    return totalTtc;
+  }
+
+  public void setTotalTtc(BigDecimal totalTtc){
+    this.totalTtc = totalTtc;
+  }
+}

--- a/backend/src/main/resources/openapi/gestion-materiel-v1.yaml
+++ b/backend/src/main/resources/openapi/gestion-materiel-v1.yaml
@@ -174,6 +174,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InterventionV2'
+  /api/v2/quotes/from-intervention:
+    post:
+      summary: Créer un devis (v2) à partir d'une intervention
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuoteFromInterventionV2Request'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuoteV2'
+  /api/v2/quotes/{id}:
+    get:
+      summary: Récupérer un devis (v2) par son identifiant
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuoteV2'
+        '404':
+          description: Not Found
   /api/v1/quotes:
     get:
       summary: List quotes
@@ -611,7 +645,7 @@ components:
         billingLines:
           type: array
           items:
-            type: object
+            $ref: '#/components/schemas/BillingLineV2'
     InterventionTemplateV2:
       type: object
       properties:
@@ -643,6 +677,43 @@ components:
                 type: number
                 format: double
                 nullable: true
+    BillingLineV2:
+      type: object
+      properties:
+        id:
+          type: string
+        designation:
+          type: string
+        quantity:
+          type: number
+        unit:
+          type: string
+        unitPriceHt:
+          type: number
+        totalHt:
+          type: number
+    QuoteV2:
+      type: object
+      properties:
+        id:
+          type: string
+        reference:
+          type: string
+        status:
+          type: string
+        totalHt:
+          type: number
+          format: double
+        totalTtc:
+          type: number
+          format: double
+    QuoteFromInterventionV2Request:
+      type: object
+      properties:
+        intervention:
+          $ref: '#/components/schemas/InterventionV2'
+      required:
+        - intervention
     UserV2:
       type: object
       properties:

--- a/client/src/main/java/com/materiel/suite/client/model/QuoteV2.java
+++ b/client/src/main/java/com/materiel/suite/client/model/QuoteV2.java
@@ -1,0 +1,52 @@
+package com.materiel.suite.client.model;
+
+import java.math.BigDecimal;
+
+/** Représentation légère d'un devis retourné par l'API v2. */
+public class QuoteV2 {
+  private String id;
+  private String reference;
+  private String status;
+  private BigDecimal totalHt;
+  private BigDecimal totalTtc;
+
+  public String getId(){
+    return id;
+  }
+
+  public void setId(String id){
+    this.id = id;
+  }
+
+  public String getReference(){
+    return reference;
+  }
+
+  public void setReference(String reference){
+    this.reference = reference;
+  }
+
+  public String getStatus(){
+    return status;
+  }
+
+  public void setStatus(String status){
+    this.status = status;
+  }
+
+  public BigDecimal getTotalHt(){
+    return totalHt;
+  }
+
+  public void setTotalHt(BigDecimal totalHt){
+    this.totalHt = totalHt;
+  }
+
+  public BigDecimal getTotalTtc(){
+    return totalTtc;
+  }
+
+  public void setTotalTtc(BigDecimal totalTtc){
+    this.totalTtc = totalTtc;
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/net/ServiceFactory.java
+++ b/client/src/main/java/com/materiel/suite/client/net/ServiceFactory.java
@@ -12,6 +12,7 @@ public class ServiceFactory {
   private static AppConfig cfg;
   private static RestClient restClient;
   private static QuoteService quoteService;
+  private static SalesService salesService;
   private static OrderService orderService;
   private static DeliveryNoteService deliveryNoteService;
   private static InvoiceService invoiceService;
@@ -30,6 +31,7 @@ public class ServiceFactory {
     authService = null;
     userService = null;
     templateService = null;
+    salesService = null;
     switch (cfg.getMode()) {
       case "mock" -> initMock();
       case "backend" -> initBackend();
@@ -41,6 +43,7 @@ public class ServiceFactory {
     MockData.seedIfEmpty();
     restClient = null;
     quoteService = new MockQuoteService();
+    salesService = new MockSalesService();
     orderService = new MockOrderService();
     deliveryNoteService = new MockDeliveryNoteService();
     invoiceService = new MockInvoiceService();
@@ -62,6 +65,7 @@ public class ServiceFactory {
     RestClient rc = new RestClient(base, token);
     restClient = rc;
     quoteService = new ApiQuoteService(rc, new MockQuoteService());
+    salesService = new ApiSalesService(rc, new MockSalesService());
     orderService = new ApiOrderService(rc, new MockOrderService());
     deliveryNoteService = new ApiDeliveryNoteService(rc, new MockDeliveryNoteService());
     invoiceService = new ApiInvoiceService(rc, new MockInvoiceService());
@@ -77,6 +81,7 @@ public class ServiceFactory {
   }
 
   public static QuoteService quotes(){ return quoteService; }
+  public static SalesService sales(){ return salesService; }
   public static OrderService orders(){ return orderService; }
   public static DeliveryNoteService deliveryNotes(){ return deliveryNoteService; }
   public static InvoiceService invoices(){ return invoiceService; }

--- a/client/src/main/java/com/materiel/suite/client/service/SalesService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/SalesService.java
@@ -1,0 +1,13 @@
+package com.materiel.suite.client.service;
+
+import com.materiel.suite.client.model.Intervention;
+import com.materiel.suite.client.model.QuoteV2;
+
+/** Services liés à la génération de devis v2 à partir des interventions. */
+public interface SalesService {
+  /** Crée un devis à partir d'une intervention (lignes de facturation + méta). */
+  QuoteV2 createQuoteFromIntervention(Intervention intervention);
+
+  /** Récupère un devis par son identifiant (prévisualisation). */
+  QuoteV2 getQuote(String id);
+}

--- a/client/src/main/java/com/materiel/suite/client/service/ServiceLocator.java
+++ b/client/src/main/java/com/materiel/suite/client/service/ServiceLocator.java
@@ -36,6 +36,10 @@ public final class ServiceLocator {
     return ServiceFactory.users();
   }
 
+  public static SalesService sales(){
+    return ServiceFactory.sales();
+  }
+
   public static final class ResourcesGateway {
     public List<Resource> listAll(){
       PlanningService svc = ServiceFactory.planning();

--- a/client/src/main/java/com/materiel/suite/client/service/api/ApiSalesService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/api/ApiSalesService.java
@@ -1,0 +1,153 @@
+package com.materiel.suite.client.service.api;
+
+import com.materiel.suite.client.model.BillingLine;
+import com.materiel.suite.client.model.Intervention;
+import com.materiel.suite.client.model.QuoteV2;
+import com.materiel.suite.client.net.RestClient;
+import com.materiel.suite.client.net.SimpleJson;
+import com.materiel.suite.client.service.SalesService;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/** Client REST minimal pour les opérations de ventes v2. */
+public class ApiSalesService implements SalesService {
+  private final RestClient rc;
+  private final SalesService fallback;
+
+  public ApiSalesService(RestClient rc, SalesService fallback){
+    this.rc = rc;
+    this.fallback = fallback;
+  }
+
+  @Override public QuoteV2 createQuoteFromIntervention(Intervention intervention){
+    if (intervention == null){
+      return null;
+    }
+    try {
+      String body = rc.post("/api/v2/quotes/from-intervention", toJson(intervention));
+      return parseQuote(body);
+    } catch (Exception e){
+      return fallback.createQuoteFromIntervention(intervention);
+    }
+  }
+
+  @Override public QuoteV2 getQuote(String id){
+    if (id == null || id.isBlank()){
+      return null;
+    }
+    try {
+      String body = rc.get("/api/v2/quotes/" + id);
+      return parseQuote(body);
+    } catch (Exception e){
+      return fallback.getQuote(id);
+    }
+  }
+
+  private QuoteV2 parseQuote(String body){
+    if (body == null || body.isBlank()){
+      return null;
+    }
+    var map = SimpleJson.asObj(SimpleJson.parse(body));
+    QuoteV2 quote = new QuoteV2();
+    quote.setId(SimpleJson.str(map.get("id")));
+    quote.setReference(SimpleJson.str(map.get("reference")));
+    quote.setStatus(SimpleJson.str(map.get("status")));
+    quote.setTotalHt(parseBigDecimal(map.get("totalHt")));
+    quote.setTotalTtc(parseBigDecimal(map.get("totalTtc")));
+    return quote;
+  }
+
+  private BigDecimal parseBigDecimal(Object value){
+    if (value == null){
+      return null;
+    }
+    if (value instanceof BigDecimal bd){
+      return bd;
+    }
+    if (value instanceof Number number){
+      return new BigDecimal(number.toString());
+    }
+    try {
+      return new BigDecimal(value.toString());
+    } catch (NumberFormatException ex){
+      return null;
+    }
+  }
+
+  private String toJson(Intervention intervention){
+    StringBuilder sb = new StringBuilder();
+    sb.append("{\"intervention\":{");
+    boolean firstField = true;
+    String id = intervention.getId() == null ? null : intervention.getId().toString();
+    firstField = appendStringField(sb, firstField, "id", id);
+    firstField = appendStringField(sb, firstField, "title", intervention.getLabel());
+    String clientId = intervention.getClientId() == null ? null : intervention.getClientId().toString();
+    firstField = appendStringField(sb, firstField, "clientId", clientId);
+    if (!firstField){
+      sb.append(',');
+    }
+    sb.append("\"billingLines\":[");
+    List<BillingLine> lines = intervention.getBillingLines();
+    boolean firstLine = true;
+    for (BillingLine line : lines){
+      if (line == null){
+        continue;
+      }
+      if (!firstLine){
+        sb.append(',');
+      }
+      firstLine = false;
+      sb.append('{');
+      boolean firstProp = true;
+      firstProp = appendStringField(sb, firstProp, "id", line.getId());
+      firstProp = appendStringField(sb, firstProp, "designation", line.getDesignation());
+      firstProp = appendNumberField(sb, firstProp, "quantity", line.getQuantity());
+      firstProp = appendStringField(sb, firstProp, "unit", line.getUnit());
+      firstProp = appendNumberField(sb, firstProp, "unitPriceHt", line.getUnitPriceHt());
+      appendNumberField(sb, firstProp, "totalHt", line.getTotalHt());
+      sb.append('}');
+    }
+    sb.append(']');
+    sb.append("}}");
+    return sb.toString();
+  }
+
+  private boolean appendStringField(StringBuilder sb, boolean first, String name, String value){
+    if (!first){
+      sb.append(',');
+    }
+    sb.append('"').append(name).append('"').append(':');
+    if (value == null){
+      sb.append("null");
+    } else {
+      sb.append('"').append(escape(value)).append('"');
+    }
+    return false;
+  }
+
+  private boolean appendNumberField(StringBuilder sb, boolean first, String name, BigDecimal value){
+    if (!first){
+      sb.append(',');
+    }
+    sb.append('"').append(name).append('"').append(':');
+    if (value == null){
+      sb.append("null");
+    } else {
+      sb.append(value.toPlainString());
+    }
+    return false;
+  }
+
+  private String escape(String value){
+    StringBuilder out = new StringBuilder();
+    for (int i = 0; i < value.length(); i++){
+      char c = value.charAt(i);
+      if (c == '"' || c == '\\'){
+        out.append('\\');
+      }
+      out.append(c);
+    }
+    return out.toString();
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/service/mock/MockSalesService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/mock/MockSalesService.java
@@ -1,0 +1,54 @@
+package com.materiel.suite.client.service.mock;
+
+import com.materiel.suite.client.model.BillingLine;
+import com.materiel.suite.client.model.Intervention;
+import com.materiel.suite.client.model.QuoteV2;
+import com.materiel.suite.client.service.SalesService;
+
+import java.math.BigDecimal;
+import java.time.Year;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** Implémentation mock en mémoire pour la génération de devis v2. */
+public class MockSalesService implements SalesService {
+  private final AtomicInteger seq = new AtomicInteger(1);
+  private final Map<String, QuoteV2> store = new ConcurrentHashMap<>();
+
+  @Override public QuoteV2 createQuoteFromIntervention(Intervention intervention){
+    BigDecimal total = BigDecimal.ZERO;
+    List<BillingLine> lines = intervention == null ? List.of() : intervention.getBillingLines();
+    for (BillingLine line : lines){
+      if (line == null){
+        continue;
+      }
+      BigDecimal amount = line.getTotalHt();
+      if (amount == null){
+        BigDecimal unit = line.getUnitPriceHt();
+        BigDecimal qty = line.getQuantity();
+        if (unit != null && qty != null){
+          amount = unit.multiply(qty);
+        }
+      }
+      if (amount != null){
+        total = total.add(amount);
+      }
+    }
+    QuoteV2 quote = new QuoteV2();
+    String id = UUID.randomUUID().toString();
+    quote.setId(id);
+    quote.setReference(String.format("Q%s-%04d", Year.now(), seq.getAndIncrement()));
+    quote.setStatus("DRAFT");
+    quote.setTotalHt(total);
+    quote.setTotalTtc(total);
+    store.put(id, quote);
+    return quote;
+  }
+
+  @Override public QuoteV2 getQuote(String id){
+    return id == null ? null : store.get(id);
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/interventions/QuotePreviewDialog.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/interventions/QuotePreviewDialog.java
@@ -1,0 +1,76 @@
+package com.materiel.suite.client.ui.interventions;
+
+import com.materiel.suite.client.model.QuoteV2;
+
+import javax.swing.*;
+import java.awt.*;
+import java.math.BigDecimal;
+import java.text.NumberFormat;
+import java.util.Locale;
+
+/** Aperçu simple d'un devis v2 pour consultation rapide. */
+public class QuotePreviewDialog extends JDialog {
+  private static final NumberFormat CURRENCY = NumberFormat.getCurrencyInstance(Locale.FRANCE);
+
+  public QuotePreviewDialog(Window parent, QuoteV2 quote){
+    super(parent, titleFor(quote), ModalityType.MODELESS);
+    setSize(420, 220);
+    setLocationRelativeTo(parent);
+    setResizable(false);
+    setContentPane(buildContent(quote));
+  }
+
+  private static String titleFor(QuoteV2 quote){
+    if (quote == null){
+      return "Devis";
+    }
+    String ref = quote.getReference();
+    return ref == null || ref.isBlank() ? "Devis" : "Devis " + ref;
+  }
+
+  private JPanel buildContent(QuoteV2 quote){
+    JPanel panel = new JPanel(new GridBagLayout());
+    GridBagConstraints gc = new GridBagConstraints();
+    gc.insets = new Insets(8, 8, 8, 8);
+    gc.fill = GridBagConstraints.HORIZONTAL;
+    gc.gridx = 0;
+    gc.gridy = 0;
+    panel.add(new JLabel("Référence"), gc);
+    gc.gridx = 1;
+    panel.add(new JLabel(valueOrDash(quote != null ? quote.getReference() : null)), gc);
+    gc.gridx = 0;
+    gc.gridy++;
+    panel.add(new JLabel("Statut"), gc);
+    gc.gridx = 1;
+    panel.add(new JLabel(valueOrDash(quote != null ? quote.getStatus() : null)), gc);
+    gc.gridx = 0;
+    gc.gridy++;
+    panel.add(new JLabel("Total HT"), gc);
+    gc.gridx = 1;
+    panel.add(new JLabel(formatCurrency(quote != null ? quote.getTotalHt() : null)), gc);
+    gc.gridx = 0;
+    gc.gridy++;
+    panel.add(new JLabel("Total TTC"), gc);
+    gc.gridx = 1;
+    panel.add(new JLabel(formatCurrency(quote != null ? quote.getTotalTtc() : null)), gc);
+    gc.gridx = 0;
+    gc.gridy++;
+    gc.gridwidth = 2;
+    gc.anchor = GridBagConstraints.CENTER;
+    JButton close = new JButton("Fermer");
+    close.addActionListener(e -> dispose());
+    panel.add(close, gc);
+    return panel;
+  }
+
+  private static String valueOrDash(String value){
+    return value == null || value.isBlank() ? "—" : value;
+  }
+
+  private static String formatCurrency(BigDecimal value){
+    if (value == null){
+      return "—";
+    }
+    return CURRENCY.format(value);
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/QuoteDryRunDialog.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/QuoteDryRunDialog.java
@@ -1,0 +1,99 @@
+package com.materiel.suite.client.ui.planning;
+
+import com.materiel.suite.client.model.Intervention;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.List;
+import java.util.function.Consumer;
+
+/** Aperçu avant génération de devis pour une sélection d'interventions. */
+public class QuoteDryRunDialog extends JDialog {
+  public QuoteDryRunDialog(Window owner,
+                           List<Intervention> willCreate,
+                           List<Intervention> willSkip,
+                           Consumer<Boolean> onClose){
+    super(owner, "Prévisualisation — Génération de devis", ModalityType.APPLICATION_MODAL);
+    setSize(640, 420);
+    setLocationRelativeTo(owner);
+    setContentPane(buildContent(willCreate, willSkip, onClose));
+  }
+
+  private JComponent buildContent(List<Intervention> willCreate,
+                                  List<Intervention> willSkip,
+                                  Consumer<Boolean> onClose){
+    JPanel root = new JPanel(new BorderLayout(8, 8));
+    root.setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
+    JPanel header = new JPanel(new GridLayout(1, 2, 8, 8));
+    header.add(summaryPanel("Seront générés", willCreate.size(), new Color(0x43A047)));
+    header.add(summaryPanel("Ignorés", willSkip.size(), new Color(0xFB8C00)));
+    root.add(header, BorderLayout.NORTH);
+
+    JSplitPane split = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
+        listPanel("À créer", willCreate),
+        listPanel("Ignorés", willSkip));
+    split.setResizeWeight(0.5);
+    root.add(split, BorderLayout.CENTER);
+
+    JPanel actions = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+    JButton cancel = new JButton("Annuler");
+    JButton confirm = new JButton("Lancer la génération");
+    actions.add(cancel);
+    actions.add(confirm);
+    cancel.addActionListener(e -> {
+      dispose();
+      if (onClose != null){
+        onClose.accept(false);
+      }
+    });
+    confirm.addActionListener(e -> {
+      dispose();
+      if (onClose != null){
+        onClose.accept(true);
+      }
+    });
+    root.add(actions, BorderLayout.SOUTH);
+    return root;
+  }
+
+  private JPanel summaryPanel(String title, int count, Color color){
+    JPanel panel = new JPanel(new GridBagLayout());
+    GridBagConstraints gc = new GridBagConstraints();
+    gc.insets = new Insets(8, 8, 8, 8);
+    gc.gridx = 0;
+    gc.gridy = 0;
+    JLabel titleLabel = new JLabel(title);
+    titleLabel.setForeground(color);
+    titleLabel.setFont(titleLabel.getFont().deriveFont(Font.BOLD));
+    panel.add(titleLabel, gc);
+    gc.gridy++;
+    JLabel countLabel = new JLabel(String.valueOf(count));
+    countLabel.setFont(countLabel.getFont().deriveFont(24f));
+    panel.add(countLabel, gc);
+    return panel;
+  }
+
+  private JScrollPane listPanel(String title, List<Intervention> interventions){
+    DefaultListModel<String> model = new DefaultListModel<>();
+    for (Intervention intervention : interventions){
+      if (intervention == null){
+        continue;
+      }
+      String label = intervention.getLabel();
+      if (label == null || label.isBlank()){
+        label = "(Sans titre)";
+      }
+      String client = intervention.getClientName();
+      if (client != null && !client.isBlank()){
+        label = label + " — " + client;
+      }
+      model.addElement(label);
+    }
+    JList<String> list = new JList<>(model);
+    list.setVisibleRowCount(12);
+    JPanel wrapper = new JPanel(new BorderLayout());
+    wrapper.add(new JLabel(title), BorderLayout.NORTH);
+    wrapper.add(new JScrollPane(list), BorderLayout.CENTER);
+    return new JScrollPane(wrapper);
+  }
+}


### PR DESCRIPTION
## Summary
- expose mock sales v2 controller and DTOs to create and fetch quotes and document the endpoints in OpenAPI
- add a client-side sales service with quote preview dialog and planning dry-run workflow tied into ServiceFactory and ServiceLocator

## Testing
- `mvn -pl backend -am test` *(fails: network unreachable for Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68cd38e998a48330999fa758b3542b4b