### PR TITLE
feat: make command palette contextual with built-in help

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
@@ -580,6 +580,33 @@ public class PlanningPanel extends JPanel {
 
   }
 
+  public void actionFilterCycle(){
+    cycleQuoteFilter();
+  }
+
+  public int getSelectedCount(){
+    if (tabs == null || tableView == null){
+      return 0;
+    }
+    Component selectedComponent = tabs.getSelectedComponent();
+    if (selectedComponent != tableView.getComponent()){
+      return 0;
+    }
+    List<Intervention> selection = tableView.getSelection();
+    return selection == null ? 0 : selection.size();
+  }
+
+  public String getCurrentFilterLabel(){
+    if (quoteFilter == null){
+      return QuoteFilter.TOUS.toString();
+    }
+    Object value = quoteFilter.getSelectedItem();
+    if (value instanceof QuoteFilter filter){
+      return filter.toString();
+    }
+    return value != null ? value.toString() : QuoteFilter.TOUS.toString();
+  }
+
   private void refreshPlanning(){
     PlanningService planning = ServiceFactory.planning();
     if (planning == null){


### PR DESCRIPTION
## Summary
- add contextual suppliers to the command palette, including a help footer and default shortcuts view
- expose planning panel selection/filter helpers so palette commands can reflect the current context
- refresh main frame palette binding to build commands on demand and surface dynamic planning actions

## Testing
- mvn -pl client test *(fails: Maven cannot reach central repository in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd43b062a48330b18042fa0624174c