### PR TITLE
feat: persist general settings and autosave interval

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/service/ServiceLocator.java
+++ b/client/src/main/java/com/materiel/suite/client/service/ServiceLocator.java
@@ -4,6 +4,7 @@ import com.materiel.suite.client.auth.AuthService;
 import com.materiel.suite.client.model.InterventionType;
 import com.materiel.suite.client.model.Resource;
 import com.materiel.suite.client.net.ServiceFactory;
+import com.materiel.suite.client.service.impl.LocalSettingsService;
 import com.materiel.suite.client.users.UserService;
 
 import java.util.List;
@@ -16,6 +17,8 @@ import java.util.UUID;
 public final class ServiceLocator {
   private static final ResourcesGateway RESOURCES = new ResourcesGateway();
   private static final InterventionTypesGateway INTERVENTION_TYPES = new InterventionTypesGateway();
+
+  private static SettingsService SETTINGS;
 
   private ServiceLocator(){
   }
@@ -38,6 +41,13 @@ public final class ServiceLocator {
 
   public static SalesService sales(){
     return ServiceFactory.sales();
+  }
+
+  public static SettingsService settings(){
+    if (SETTINGS == null){
+      SETTINGS = new LocalSettingsService();
+    }
+    return SETTINGS;
   }
 
   public static final class ResourcesGateway {

--- a/client/src/main/java/com/materiel/suite/client/service/SettingsService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/SettingsService.java
@@ -1,0 +1,9 @@
+package com.materiel.suite.client.service;
+
+import com.materiel.suite.client.settings.GeneralSettings;
+
+public interface SettingsService {
+  GeneralSettings getGeneral();
+
+  void saveGeneral(GeneralSettings settings);
+}

--- a/client/src/main/java/com/materiel/suite/client/service/impl/LocalSettingsService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/impl/LocalSettingsService.java
@@ -1,0 +1,25 @@
+package com.materiel.suite.client.service.impl;
+
+import com.materiel.suite.client.service.SettingsService;
+import com.materiel.suite.client.settings.GeneralSettings;
+import com.materiel.suite.client.util.Prefs;
+
+/** Stocke les paramètres localement via {@link Prefs}. */
+public class LocalSettingsService implements SettingsService {
+  @Override
+  public GeneralSettings getGeneral(){
+    GeneralSettings settings = new GeneralSettings();
+    settings.setSessionTimeoutMinutes(Prefs.getSessionTimeoutMinutes());
+    settings.setAutosaveIntervalSeconds(Prefs.getAutosaveIntervalSeconds());
+    return settings;
+  }
+
+  @Override
+  public void saveGeneral(GeneralSettings settings){
+    if (settings == null){
+      return;
+    }
+    Prefs.setSessionTimeoutMinutes(settings.getSessionTimeoutMinutes());
+    Prefs.setAutosaveIntervalSeconds(settings.getAutosaveIntervalSeconds());
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/settings/GeneralSettings.java
+++ b/client/src/main/java/com/materiel/suite/client/settings/GeneralSettings.java
@@ -1,0 +1,23 @@
+package com.materiel.suite.client.settings;
+
+/** Paramètres généraux côté client. */
+public class GeneralSettings {
+  private int sessionTimeoutMinutes = 30;
+  private int autosaveIntervalSeconds = 30;
+
+  public int getSessionTimeoutMinutes(){
+    return sessionTimeoutMinutes;
+  }
+
+  public void setSessionTimeoutMinutes(int minutes){
+    sessionTimeoutMinutes = Math.max(1, minutes);
+  }
+
+  public int getAutosaveIntervalSeconds(){
+    return autosaveIntervalSeconds;
+  }
+
+  public void setAutosaveIntervalSeconds(int seconds){
+    autosaveIntervalSeconds = Math.max(5, seconds);
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/interventions/InterventionDialog.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/interventions/InterventionDialog.java
@@ -17,6 +17,8 @@ import com.materiel.suite.client.service.InterventionTypeService;
 import com.materiel.suite.client.service.PlanningService;
 import com.materiel.suite.client.service.SalesService;
 import com.materiel.suite.client.service.TemplateService;
+import com.materiel.suite.client.service.ServiceLocator;
+import com.materiel.suite.client.settings.GeneralSettings;
 import com.materiel.suite.client.ui.common.KeymapUtil;
 import com.materiel.suite.client.ui.common.Toasts;
 import com.materiel.suite.client.ui.icons.IconRegistry;
@@ -261,8 +263,18 @@ public class InterventionDialog extends JDialog {
       autosaveLabel.setText("Lecture seule");
       return;
     }
+    int delay = 30_000;
+    try {
+      GeneralSettings settings = ServiceLocator.settings().getGeneral();
+      if (settings != null){
+        int seconds = Math.max(5, settings.getAutosaveIntervalSeconds());
+        delay = seconds * 1000;
+      }
+    } catch (RuntimeException ignore){
+    }
+    autosaveTimer.setDelay(delay);
+    autosaveTimer.setInitialDelay(delay);
     autosaveTimer.setRepeats(true);
-    autosaveTimer.setInitialDelay(30_000);
     autosaveTimer.start();
     addWindowListener(new WindowAdapter(){
       @Override public void windowClosing(WindowEvent e){

--- a/client/src/main/java/com/materiel/suite/client/ui/settings/GeneralSettingsPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/settings/GeneralSettingsPanel.java
@@ -2,17 +2,22 @@ package com.materiel.suite.client.ui.settings;
 
 import com.materiel.suite.client.auth.AccessControl;
 import com.materiel.suite.client.auth.SessionManager;
+import com.materiel.suite.client.service.ServiceLocator;
+import com.materiel.suite.client.settings.GeneralSettings;
 import com.materiel.suite.client.ui.common.Toasts;
-import com.materiel.suite.client.util.Prefs;
 
 import javax.swing.*;
 import java.awt.*;
 
-/** Paramètres généraux (durée d'inactivité notamment). */
+/** Paramètres généraux (durée d'inactivité, autosave, etc.). */
 public class GeneralSettingsPanel extends JPanel {
+  private final JSpinner timeoutSpinner;
+  private final JSpinner autosaveSpinner;
 
   public GeneralSettingsPanel(){
     super(new BorderLayout(8, 8));
+
+    GeneralSettings settings = loadSettings();
 
     JPanel form = new JPanel(new GridBagLayout());
     GridBagConstraints gc = new GridBagConstraints();
@@ -23,15 +28,23 @@ public class GeneralSettingsPanel extends JPanel {
     int row = 0;
     gc.gridx = 0; gc.gridy = row; gc.weightx = 0;
     form.add(new JLabel("Durée d'inactivité avant déconnexion (minutes)"), gc);
-    int initial = Prefs.getSessionTimeoutMinutes();
-    SpinnerNumberModel model = new SpinnerNumberModel(initial, 1, 240, 5);
-    JSpinner timeoutSpinner = new JSpinner(model);
+    SpinnerNumberModel timeoutModel = new SpinnerNumberModel(settings.getSessionTimeoutMinutes(), 1, 240, 5);
+    timeoutSpinner = new JSpinner(timeoutModel);
     gc.gridx = 1; gc.weightx = 1;
     form.add(timeoutSpinner, gc);
+
+    row++;
+    gc.gridx = 0; gc.gridy = row; gc.weightx = 0;
+    form.add(new JLabel("Intervalle d'enregistrement automatique (secondes)"), gc);
+    SpinnerNumberModel autosaveModel = new SpinnerNumberModel(Math.max(5, settings.getAutosaveIntervalSeconds()), 5, 600, 5);
+    autosaveSpinner = new JSpinner(autosaveModel);
+    gc.gridx = 1; gc.weightx = 1;
+    form.add(autosaveSpinner, gc);
 
     JButton save = new JButton("Enregistrer");
     boolean canEdit = AccessControl.canEditSettings();
     timeoutSpinner.setEnabled(canEdit);
+    autosaveSpinner.setEnabled(canEdit);
     save.setEnabled(canEdit);
 
     JPanel south = new JPanel(new FlowLayout(FlowLayout.RIGHT));
@@ -40,11 +53,36 @@ public class GeneralSettingsPanel extends JPanel {
     add(form, BorderLayout.CENTER);
     add(south, BorderLayout.SOUTH);
 
-    save.addActionListener(e -> {
-      int minutes = (int) timeoutSpinner.getValue();
-      Prefs.setSessionTimeoutMinutes(minutes);
-      SessionManager.setTimeoutMinutes(minutes);
-      Toasts.success(this, "Durée de session mise à jour (" + minutes + " min)");
-    });
+    save.addActionListener(e -> saveSettings());
+  }
+
+  private GeneralSettings loadSettings(){
+    try {
+      GeneralSettings settings = ServiceLocator.settings().getGeneral();
+      if (settings != null){
+        return settings;
+      }
+    } catch (RuntimeException ignore){
+    }
+    return new GeneralSettings();
+  }
+
+  private void saveSettings(){
+    int minutes = ((Number) timeoutSpinner.getValue()).intValue();
+    int autosave = ((Number) autosaveSpinner.getValue()).intValue();
+
+    GeneralSettings updated = new GeneralSettings();
+    updated.setSessionTimeoutMinutes(minutes);
+    updated.setAutosaveIntervalSeconds(autosave);
+
+    try {
+      ServiceLocator.settings().saveGeneral(updated);
+      SessionManager.setTimeoutMinutes(updated.getSessionTimeoutMinutes());
+      timeoutSpinner.setValue(updated.getSessionTimeoutMinutes());
+      autosaveSpinner.setValue(updated.getAutosaveIntervalSeconds());
+      Toasts.success(this, "Paramètres généraux mis à jour");
+    } catch (RuntimeException ex){
+      Toasts.error(this, "Échec de l'enregistrement des paramètres");
+    }
   }
 }

--- a/client/src/main/java/com/materiel/suite/client/util/Prefs.java
+++ b/client/src/main/java/com/materiel/suite/client/util/Prefs.java
@@ -16,4 +16,12 @@ public final class Prefs {
   public static void setSessionTimeoutMinutes(int minutes){
     PREFS.putInt("session.timeout.minutes", Math.max(1, minutes));
   }
+
+  public static int getAutosaveIntervalSeconds(){
+    return Math.max(5, PREFS.getInt("autosave.interval.seconds", 30));
+  }
+
+  public static void setAutosaveIntervalSeconds(int seconds){
+    PREFS.putInt("autosave.interval.seconds", Math.max(5, seconds));
+  }
 }


### PR DESCRIPTION
## Summary
- add a settings service backed by local preferences and a general settings DTO
- expose the settings service via the service locator and store the autosave interval preference
- update the general settings panel and intervention autosave timer to use persisted values

## Testing
- `mvn -pl client -am test` *(fails: cannot reach Maven Central from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd53c885e48330a763323b407d55b7