### PR TITLE
feat: support agency logo and resource PDF exports

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/service/impl/LocalSettingsService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/impl/LocalSettingsService.java
@@ -11,6 +11,7 @@ public class LocalSettingsService implements SettingsService {
     GeneralSettings settings = new GeneralSettings();
     settings.setSessionTimeoutMinutes(Prefs.getSessionTimeoutMinutes());
     settings.setAutosaveIntervalSeconds(Prefs.getAutosaveIntervalSeconds());
+    settings.setAgencyLogoPngBase64(Prefs.getAgencyLogoPngBase64());
     return settings;
   }
 
@@ -21,5 +22,6 @@ public class LocalSettingsService implements SettingsService {
     }
     Prefs.setSessionTimeoutMinutes(settings.getSessionTimeoutMinutes());
     Prefs.setAutosaveIntervalSeconds(settings.getAutosaveIntervalSeconds());
+    Prefs.setAgencyLogoPngBase64(settings.getAgencyLogoPngBase64());
   }
 }

--- a/client/src/main/java/com/materiel/suite/client/settings/GeneralSettings.java
+++ b/client/src/main/java/com/materiel/suite/client/settings/GeneralSettings.java
@@ -4,6 +4,8 @@ package com.materiel.suite.client.settings;
 public class GeneralSettings {
   private int sessionTimeoutMinutes = 30;
   private int autosaveIntervalSeconds = 30;
+  /** PNG encodé en Base64 (optionnel) utilisé en en-tête PDF (logo d’agence). */
+  private String agencyLogoPngBase64;
 
   public int getSessionTimeoutMinutes(){
     return sessionTimeoutMinutes;
@@ -19,5 +21,13 @@ public class GeneralSettings {
 
   public void setAutosaveIntervalSeconds(int seconds){
     autosaveIntervalSeconds = Math.max(5, seconds);
+  }
+
+  public String getAgencyLogoPngBase64(){
+    return agencyLogoPngBase64;
+  }
+
+  public void setAgencyLogoPngBase64(String b64){
+    agencyLogoPngBase64 = b64;
   }
 }

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
@@ -901,16 +901,34 @@ public class PlanningPanel extends JPanel {
       Toasts.info(this, "Sélectionnez au moins une intervention.");
       return;
     }
+    Object[] modes = {"Un seul PDF (multi-pages)", "Un .zip (1 PDF par ressource)"};
+    int choice = JOptionPane.showOptionDialog(
+        this,
+        "Choisir le format d’export :",
+        "Ordre de mission",
+        JOptionPane.DEFAULT_OPTION,
+        JOptionPane.QUESTION_MESSAGE,
+        null,
+        modes,
+        modes[0]
+    );
+    if (choice == JOptionPane.CLOSED_OPTION){
+      return;
+    }
     JFileChooser chooser = new JFileChooser();
-    chooser.setSelectedFile(new File("ordre-de-mission.pdf"));
+    chooser.setSelectedFile(new File(choice == 0 ? "ordre-de-mission.pdf" : "ordre-de-mission-par-ressource.zip"));
     int result = chooser.showSaveDialog(this);
     if (result != JFileChooser.APPROVE_OPTION){
       return;
     }
     File destination = chooser.getSelectedFile();
     try {
-      MissionOrderPdfExporter.export(destination, selection);
-      Toasts.success(this, "PDF généré : " + destination.getName());
+      if (choice == 0){
+        MissionOrderPdfExporter.export(destination, selection);
+      } else {
+        MissionOrderPdfExporter.exportPerResourceZip(destination, selection);
+      }
+      Toasts.success(this, "Export généré : " + destination.getName());
     } catch (Exception ex){
       Toasts.error(this, "Échec génération PDF : " + ex.getMessage());
     }

--- a/client/src/main/java/com/materiel/suite/client/util/Prefs.java
+++ b/client/src/main/java/com/materiel/suite/client/util/Prefs.java
@@ -24,4 +24,26 @@ public final class Prefs {
   public static void setAutosaveIntervalSeconds(int seconds){
     PREFS.putInt("autosave.interval.seconds", Math.max(5, seconds));
   }
+
+  public static String getAgencyLogoPngBase64(){
+    String value = PREFS.get("agency.logo.png.base64", null);
+    if (value == null){
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+
+  public static void setAgencyLogoPngBase64(String base64){
+    if (base64 == null){
+      PREFS.remove("agency.logo.png.base64");
+      return;
+    }
+    String trimmed = base64.trim();
+    if (trimmed.isEmpty()){
+      PREFS.remove("agency.logo.png.base64");
+      return;
+    }
+    PREFS.put("agency.logo.png.base64", trimmed);
+  }
 }


### PR DESCRIPTION
## Summary
- add an agency logo field to general settings with persistence via preferences and a UI to upload or clear the logo
- embed the agency logo in mission order PDFs, add optional safety/equipment sections, and enable exporting one PDF per resource inside a zip
- update planning export workflow to let users choose between single PDF and per-resource zip outputs

## Testing
- mvn -pl client -am test *(fails: Non-resolvable import POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cd698e4e2c833092668e60747cea81