### PR TITLE
Add agency metadata and CGV export support

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/service/impl/LocalSettingsService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/impl/LocalSettingsService.java
@@ -12,6 +12,11 @@ public class LocalSettingsService implements SettingsService {
     settings.setSessionTimeoutMinutes(Prefs.getSessionTimeoutMinutes());
     settings.setAutosaveIntervalSeconds(Prefs.getAutosaveIntervalSeconds());
     settings.setAgencyLogoPngBase64(Prefs.getAgencyLogoPngBase64());
+    settings.setAgencyName(Prefs.getAgencyName());
+    settings.setAgencyPhone(Prefs.getAgencyPhone());
+    settings.setAgencyAddress(Prefs.getAgencyAddress());
+    settings.setCgvPdfBase64(Prefs.getCgvPdfBase64());
+    settings.setCgvText(Prefs.getCgvText());
     return settings;
   }
 
@@ -23,5 +28,10 @@ public class LocalSettingsService implements SettingsService {
     Prefs.setSessionTimeoutMinutes(settings.getSessionTimeoutMinutes());
     Prefs.setAutosaveIntervalSeconds(settings.getAutosaveIntervalSeconds());
     Prefs.setAgencyLogoPngBase64(settings.getAgencyLogoPngBase64());
+    Prefs.setAgencyName(settings.getAgencyName());
+    Prefs.setAgencyPhone(settings.getAgencyPhone());
+    Prefs.setAgencyAddress(settings.getAgencyAddress());
+    Prefs.setCgvPdfBase64(settings.getCgvPdfBase64());
+    Prefs.setCgvText(settings.getCgvText());
   }
 }

--- a/client/src/main/java/com/materiel/suite/client/settings/GeneralSettings.java
+++ b/client/src/main/java/com/materiel/suite/client/settings/GeneralSettings.java
@@ -6,6 +6,12 @@ public class GeneralSettings {
   private int autosaveIntervalSeconds = 30;
   /** PNG encodé en Base64 (optionnel) utilisé en en-tête PDF (logo d’agence). */
   private String agencyLogoPngBase64;
+  private String agencyName;
+  private String agencyPhone;
+  private String agencyAddress;
+  /** CGV : soit un PDF encodé base64, soit un texte brut (fallback si PDF absent). */
+  private String cgvPdfBase64;
+  private String cgvText;
 
   public int getSessionTimeoutMinutes(){
     return sessionTimeoutMinutes;
@@ -28,6 +34,54 @@ public class GeneralSettings {
   }
 
   public void setAgencyLogoPngBase64(String b64){
-    agencyLogoPngBase64 = b64;
+    agencyLogoPngBase64 = trimToNull(b64);
+  }
+
+  public String getAgencyName(){
+    return agencyName;
+  }
+
+  public void setAgencyName(String value){
+    agencyName = trimToNull(value);
+  }
+
+  public String getAgencyPhone(){
+    return agencyPhone;
+  }
+
+  public void setAgencyPhone(String value){
+    agencyPhone = trimToNull(value);
+  }
+
+  public String getAgencyAddress(){
+    return agencyAddress;
+  }
+
+  public void setAgencyAddress(String value){
+    agencyAddress = trimToNull(value);
+  }
+
+  public String getCgvPdfBase64(){
+    return cgvPdfBase64;
+  }
+
+  public void setCgvPdfBase64(String value){
+    cgvPdfBase64 = trimToNull(value);
+  }
+
+  public String getCgvText(){
+    return cgvText;
+  }
+
+  public void setCgvText(String value){
+    cgvText = trimToNull(value);
+  }
+
+  private static String trimToNull(String value){
+    if (value == null){
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
   }
 }

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
@@ -915,6 +915,19 @@ public class PlanningPanel extends JPanel {
     if (choice == JOptionPane.CLOSED_OPTION){
       return;
     }
+    boolean includeCgv = false;
+    if (choice == 0){
+      int cgvChoice = JOptionPane.showConfirmDialog(
+          this,
+          "Inclure les CGV (si configurées) ?",
+          "CGV",
+          JOptionPane.YES_NO_OPTION
+      );
+      if (cgvChoice == JOptionPane.CLOSED_OPTION){
+        return;
+      }
+      includeCgv = (cgvChoice == JOptionPane.YES_OPTION);
+    }
     JFileChooser chooser = new JFileChooser();
     chooser.setSelectedFile(new File(choice == 0 ? "ordre-de-mission.pdf" : "ordre-de-mission-par-ressource.zip"));
     int result = chooser.showSaveDialog(this);
@@ -925,8 +938,12 @@ public class PlanningPanel extends JPanel {
     try {
       if (choice == 0){
         MissionOrderPdfExporter.export(destination, selection);
+        if (includeCgv){
+          MissionOrderPdfExporter.appendCgvIfAny(destination);
+        }
       } else {
         MissionOrderPdfExporter.exportPerResourceZip(destination, selection);
+        // CGV non injectées dans ce mode (un PDF par ressource) : à étendre si besoin.
       }
       Toasts.success(this, "Export généré : " + destination.getName());
     } catch (Exception ex){

--- a/client/src/main/java/com/materiel/suite/client/util/Prefs.java
+++ b/client/src/main/java/com/materiel/suite/client/util/Prefs.java
@@ -26,7 +26,55 @@ public final class Prefs {
   }
 
   public static String getAgencyLogoPngBase64(){
-    String value = PREFS.get("agency.logo.png.base64", null);
+    return readTrimmed("agency.logo.png.base64");
+  }
+
+  public static void setAgencyLogoPngBase64(String base64){
+    writeTrimmed("agency.logo.png.base64", base64);
+  }
+
+  public static String getAgencyName(){
+    return readTrimmed("agency.name");
+  }
+
+  public static void setAgencyName(String value){
+    writeTrimmed("agency.name", value);
+  }
+
+  public static String getAgencyPhone(){
+    return readTrimmed("agency.phone");
+  }
+
+  public static void setAgencyPhone(String value){
+    writeTrimmed("agency.phone", value);
+  }
+
+  public static String getAgencyAddress(){
+    return readTrimmed("agency.address");
+  }
+
+  public static void setAgencyAddress(String value){
+    writeTrimmed("agency.address", value);
+  }
+
+  public static String getCgvPdfBase64(){
+    return readTrimmed("agency.cgv.pdf.base64");
+  }
+
+  public static void setCgvPdfBase64(String base64){
+    writeTrimmed("agency.cgv.pdf.base64", base64);
+  }
+
+  public static String getCgvText(){
+    return readTrimmed("agency.cgv.text");
+  }
+
+  public static void setCgvText(String value){
+    writeTrimmed("agency.cgv.text", value);
+  }
+
+  private static String readTrimmed(String key){
+    String value = PREFS.get(key, null);
     if (value == null){
       return null;
     }
@@ -34,16 +82,16 @@ public final class Prefs {
     return trimmed.isEmpty() ? null : trimmed;
   }
 
-  public static void setAgencyLogoPngBase64(String base64){
-    if (base64 == null){
-      PREFS.remove("agency.logo.png.base64");
+  private static void writeTrimmed(String key, String value){
+    if (value == null){
+      PREFS.remove(key);
       return;
     }
-    String trimmed = base64.trim();
+    String trimmed = value.trim();
     if (trimmed.isEmpty()){
-      PREFS.remove("agency.logo.png.base64");
+      PREFS.remove(key);
       return;
     }
-    PREFS.put("agency.logo.png.base64", trimmed);
+    PREFS.put(key, trimmed);
   }
 }


### PR DESCRIPTION
## Summary
- add agency identity and CGV fields to the general settings model, preferences storage, and settings UI
- enrich mission order PDF generation with the agency footer and optional CGV annex (PDF or fallback text)
- prompt users during mission order export to optionally append CGV pages

## Testing
- mvn -pl client -am test *(fails: unable to reach Maven Central from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6b85bd508330bc502a31755b96d5