### PR TITLE
feat: support html mission emails with tracking

### DIFF
--- a/backend/src/main/java/com/materiel/suite/backend/intervention/TimelineEventStore.java
+++ b/backend/src/main/java/com/materiel/suite/backend/intervention/TimelineEventStore.java
@@ -1,0 +1,54 @@
+package com.materiel.suite.backend.intervention;
+
+import com.materiel.suite.backend.intervention.dto.TimelineEventV2Dto;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class TimelineEventStore {
+  private final Map<String, List<TimelineEventV2Dto>> store = new ConcurrentHashMap<>();
+
+  public List<TimelineEventV2Dto> list(String interventionId){
+    List<TimelineEventV2Dto> events = store.getOrDefault(interventionId, List.of());
+    List<TimelineEventV2Dto> copy = new ArrayList<>(events);
+    copy.sort(Comparator.comparing(TimelineEventV2Dto::getTimestamp,
+        Comparator.nullsLast(Comparator.naturalOrder())));
+    return copy;
+  }
+
+  public TimelineEventV2Dto append(String interventionId, TimelineEventV2Dto body){
+    if (interventionId == null || interventionId.isBlank() || body == null){
+      return null;
+    }
+    TimelineEventV2Dto event = new TimelineEventV2Dto();
+    event.setId(UUID.randomUUID().toString());
+    event.setInterventionId(interventionId);
+    Instant timestamp = body.getTimestamp() != null ? body.getTimestamp() : Instant.now();
+    event.setTimestamp(timestamp);
+    String type = body.getType();
+    event.setType(type == null || type.isBlank() ? "INFO" : type);
+    event.setMessage(body.getMessage());
+    event.setAuthor(body.getAuthor());
+    store.computeIfAbsent(interventionId,
+            key -> Collections.synchronizedList(new ArrayList<>()))
+        .add(event);
+    return event;
+  }
+
+  public void appendAction(String interventionId, String message, String author, Instant timestamp){
+    TimelineEventV2Dto dto = new TimelineEventV2Dto();
+    dto.setType("ACTION");
+    dto.setMessage(message);
+    dto.setAuthor(author);
+    dto.setTimestamp(timestamp);
+    append(interventionId, dto);
+  }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/web/MailTrackingController.java
+++ b/backend/src/main/java/com/materiel/suite/backend/web/MailTrackingController.java
@@ -1,0 +1,45 @@
+package com.materiel.suite.backend.web;
+
+import com.materiel.suite.backend.intervention.TimelineEventStore;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.util.Base64;
+
+@RestController
+public class MailTrackingController {
+  private final TimelineEventStore timelineStore;
+
+  public MailTrackingController(TimelineEventStore timelineStore){
+    this.timelineStore = timelineStore;
+  }
+
+  @GetMapping(value = "/api/v2/mail/open", produces = MediaType.IMAGE_PNG_VALUE)
+  public ResponseEntity<byte[]> open(
+      @RequestParam(name = "ids", required = false) String idsCsv,
+      @RequestParam(name = "to", required = false) String to
+  ){
+    if (idsCsv != null && !idsCsv.isBlank()){
+      String actor = to == null || to.isBlank() ? "destinataire inconnu" : to;
+      for (String raw : idsCsv.split(",")){
+        String id = raw.trim();
+        if (id.isEmpty()){
+          continue;
+        }
+        timelineStore.appendAction(id, "Ouverture email par " + actor, actor, Instant.now());
+      }
+    }
+    return ResponseEntity.ok()
+        .header(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate")
+        .body(PIXEL);
+  }
+
+  private static final byte[] PIXEL = Base64.getDecoder().decode(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA" +
+      "AAC0lEQVR42mP8/x8AAwMB/axv7j8AAAAASUVORK5CYII=");
+}

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -78,6 +78,11 @@
       <artifactId>jakarta.mail</artifactId>
       <version>2.0.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>1.10.0</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/client/src/main/java/com/materiel/suite/client/service/impl/LocalSettingsService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/impl/LocalSettingsService.java
@@ -56,6 +56,13 @@ public class LocalSettingsService implements SettingsService {
     if (body != null){
       settings.setBodyTemplate(body);
     }
+    String html = Prefs.getMailHtmlTemplate();
+    if (html != null){
+      settings.setHtmlTemplate(html);
+    }
+    settings.setEnableHtml(Prefs.isMailHtmlEnabled());
+    settings.setEnableOpenTracking(Prefs.isMailTrackingEnabled());
+    settings.setTrackingBaseUrl(Prefs.getMailTrackingBaseUrl());
     return settings;
   }
 
@@ -75,5 +82,9 @@ public class LocalSettingsService implements SettingsService {
     Prefs.setMailCcAddress(settings.getCcAddress());
     Prefs.setMailSubjectTemplate(settings.getSubjectTemplate());
     Prefs.setMailBodyTemplate(settings.getBodyTemplate());
+    Prefs.setMailHtmlTemplate(settings.getHtmlTemplate());
+    Prefs.setMailHtmlEnabled(settings.isEnableHtml());
+    Prefs.setMailTrackingEnabled(settings.isEnableOpenTracking());
+    Prefs.setMailTrackingBaseUrl(settings.getTrackingBaseUrl());
   }
 }

--- a/client/src/main/java/com/materiel/suite/client/settings/EmailSettings.java
+++ b/client/src/main/java/com/materiel/suite/client/settings/EmailSettings.java
@@ -22,7 +22,20 @@ Intervention: ${title}
 Ressources associées: ${resourceList}
 
 — Ce message a été généré automatiquement par la planification.
+${pixel}
 """;
+  private String htmlTemplate = """
+<p>Bonjour,</p>
+<p>Veuillez trouver ci-joint votre ordre de mission pour <strong>${date}</strong> (<em>${timeRange}</em>)${clientLine}.<br/>
+Adresse : ${address}<br/>
+Intervention : ${title}</p>
+<p>Ressources associées : ${resourceList}</p>
+<p style="color:#666;font-size:12px">— Ce message a été généré automatiquement par la planification.</p>
+${pixel}
+""";
+  private boolean enableHtml = true;
+  private boolean enableOpenTracking = true;
+  private String trackingBaseUrl;
 
   public String getSmtpHost(){
     return smtpHost;
@@ -112,6 +125,38 @@ Ressources associées: ${resourceList}
     bodyTemplate = template == null || template.isBlank() ? defaultBody() : template;
   }
 
+  public String getHtmlTemplate(){
+    return htmlTemplate;
+  }
+
+  public void setHtmlTemplate(String template){
+    htmlTemplate = template == null || template.isBlank() ? defaultHtml() : template;
+  }
+
+  public boolean isEnableHtml(){
+    return enableHtml;
+  }
+
+  public void setEnableHtml(boolean enable){
+    enableHtml = enable;
+  }
+
+  public boolean isEnableOpenTracking(){
+    return enableOpenTracking;
+  }
+
+  public void setEnableOpenTracking(boolean enable){
+    enableOpenTracking = enable;
+  }
+
+  public String getTrackingBaseUrl(){
+    return trackingBaseUrl;
+  }
+
+  public void setTrackingBaseUrl(String value){
+    trackingBaseUrl = trimToNull(value);
+  }
+
   private static String trimToNull(String value){
     if (value == null){
       return null;
@@ -135,6 +180,19 @@ Intervention: ${title}
 Ressources associées: ${resourceList}
 
 — Ce message a été généré automatiquement par la planification.
+${pixel}
+""";
+  }
+
+  private static String defaultHtml(){
+    return """
+<p>Bonjour,</p>
+<p>Veuillez trouver ci-joint votre ordre de mission pour <strong>${date}</strong> (<em>${timeRange}</em>)${clientLine}.<br/>
+Adresse : ${address}<br/>
+Intervention : ${title}</p>
+<p>Ressources associées : ${resourceList}</p>
+<p style="color:#666;font-size:12px">— Ce message a été généré automatiquement par la planification.</p>
+${pixel}
 """;
   }
 }

--- a/client/src/main/java/com/materiel/suite/client/ui/common/EmailPreviewDialog.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/common/EmailPreviewDialog.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 /** Aperçu simple avant envoi des emails générés. */
 public class EmailPreviewDialog extends JDialog {
-  public record EmailJob(String to, String cc, String subject, String body, List<File> attachments){
+  public record EmailJob(String to, String cc, String subject, String body, String bodyHtml, List<File> attachments){
     public EmailJob{
       attachments = attachments == null ? List.of() : List.copyOf(attachments);
     }
@@ -97,7 +97,8 @@ public class EmailPreviewDialog extends JDialog {
       toLabel.setText(job.to());
       ccLabel.setText(job.cc() == null ? "" : job.cc());
       subjectField.setText(job.subject());
-      bodyArea.setText(job.body());
+      String preview = job.bodyHtml() != null && !job.bodyHtml().isBlank() ? job.bodyHtml() : job.body();
+      bodyArea.setText(preview);
       attachmentsModel.clear();
       for (File attachment : job.attachments()){
         attachmentsModel.addElement(attachment);

--- a/client/src/main/java/com/materiel/suite/client/ui/settings/EmailSettingsPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/settings/EmailSettingsPanel.java
@@ -22,6 +22,10 @@ public class EmailSettingsPanel extends JPanel {
   private final JTextField ccField = new JTextField();
   private final JTextField subjectField = new JTextField();
   private final JTextArea bodyArea = new JTextArea(8, 32);
+  private final JCheckBox htmlCheck = new JCheckBox("Envoyer en HTML (multipart)");
+  private final JTextArea htmlArea = new JTextArea(10, 32);
+  private final JCheckBox trackingCheck = new JCheckBox("Activer le tracking d'ouverture (pixel 1×1)");
+  private final JTextField trackingBaseField = new JTextField();
   private final JButton saveButton = new JButton("Enregistrer");
   private final JButton testButton = new JButton("Envoyer un email de test");
 
@@ -30,6 +34,8 @@ public class EmailSettingsPanel extends JPanel {
 
     bodyArea.setLineWrap(true);
     bodyArea.setWrapStyleWord(true);
+    htmlArea.setLineWrap(true);
+    htmlArea.setWrapStyleWord(true);
 
     JPanel form = new JPanel(new GridBagLayout());
     GridBagConstraints gc = new GridBagConstraints();
@@ -98,10 +104,34 @@ public class EmailSettingsPanel extends JPanel {
     row++;
     gc.gridx = 0; gc.gridy = row; gc.weightx = 0;
     gc.anchor = GridBagConstraints.NORTHWEST;
-    form.add(new JLabel("Corps (template)"), gc);
+    form.add(new JLabel("Corps TEXTE (template)"), gc);
     gc.gridx = 1; gc.weightx = 1;
     form.add(new JScrollPane(bodyArea), gc);
     gc.anchor = GridBagConstraints.WEST;
+
+    row++;
+    gc.gridx = 0; gc.gridy = row; gc.gridwidth = 2;
+    form.add(htmlCheck, gc);
+    gc.gridwidth = 1;
+
+    row++;
+    gc.gridx = 0; gc.gridy = row; gc.weightx = 0;
+    gc.anchor = GridBagConstraints.NORTHWEST;
+    form.add(new JLabel("Corps HTML (template)"), gc);
+    gc.gridx = 1; gc.weightx = 1;
+    form.add(new JScrollPane(htmlArea), gc);
+    gc.anchor = GridBagConstraints.WEST;
+
+    row++;
+    gc.gridx = 0; gc.gridy = row; gc.gridwidth = 2;
+    form.add(trackingCheck, gc);
+    gc.gridwidth = 1;
+
+    row++;
+    gc.gridx = 0; gc.gridy = row; gc.weightx = 0;
+    form.add(new JLabel("Tracking base URL"), gc);
+    gc.gridx = 1; gc.weightx = 1;
+    form.add(trackingBaseField, gc);
 
     add(form, BorderLayout.CENTER);
 
@@ -130,6 +160,10 @@ public class EmailSettingsPanel extends JPanel {
     ccField.setText(settings.getCcAddress() == null ? "" : settings.getCcAddress());
     subjectField.setText(settings.getSubjectTemplate());
     bodyArea.setText(settings.getBodyTemplate());
+    htmlCheck.setSelected(settings.isEnableHtml());
+    htmlArea.setText(settings.getHtmlTemplate());
+    trackingCheck.setSelected(settings.isEnableOpenTracking());
+    trackingBaseField.setText(settings.getTrackingBaseUrl() == null ? "" : settings.getTrackingBaseUrl());
   }
 
   private void configureAccess(){
@@ -146,6 +180,11 @@ public class EmailSettingsPanel extends JPanel {
     subjectField.setEnabled(canEdit);
     bodyArea.setEnabled(canEdit);
     bodyArea.setEditable(canEdit);
+    htmlCheck.setEnabled(canEdit);
+    htmlArea.setEnabled(canEdit);
+    htmlArea.setEditable(canEdit);
+    trackingCheck.setEnabled(canEdit);
+    trackingBaseField.setEnabled(canEdit);
     saveButton.setEnabled(canEdit);
     testButton.setEnabled(canEdit);
   }
@@ -163,6 +202,10 @@ public class EmailSettingsPanel extends JPanel {
     settings.setCcAddress(ccField.getText());
     settings.setSubjectTemplate(subjectField.getText());
     settings.setBodyTemplate(bodyArea.getText());
+    settings.setEnableHtml(htmlCheck.isSelected());
+    settings.setHtmlTemplate(htmlArea.getText());
+    settings.setEnableOpenTracking(trackingCheck.isSelected());
+    settings.setTrackingBaseUrl(trackingBaseField.getText());
     try {
       ServiceLocator.saveEmailSettings(settings);
       Toasts.success(this, "Paramètres email enregistrés");

--- a/client/src/main/java/com/materiel/suite/client/util/Prefs.java
+++ b/client/src/main/java/com/materiel/suite/client/util/Prefs.java
@@ -189,6 +189,47 @@ public final class Prefs {
     }
   }
 
+  public static String getMailHtmlTemplate(){
+    String value = PREFS.get("mail.body.html.template", null);
+    if (value == null){
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : value;
+  }
+
+  public static void setMailHtmlTemplate(String value){
+    if (value == null || value.isBlank()){
+      PREFS.remove("mail.body.html.template");
+    } else {
+      PREFS.put("mail.body.html.template", value);
+    }
+  }
+
+  public static boolean isMailHtmlEnabled(){
+    return PREFS.getBoolean("mail.body.html.enabled", true);
+  }
+
+  public static void setMailHtmlEnabled(boolean enabled){
+    PREFS.putBoolean("mail.body.html.enabled", enabled);
+  }
+
+  public static boolean isMailTrackingEnabled(){
+    return PREFS.getBoolean("mail.tracking.enabled", true);
+  }
+
+  public static void setMailTrackingEnabled(boolean enabled){
+    PREFS.putBoolean("mail.tracking.enabled", enabled);
+  }
+
+  public static String getMailTrackingBaseUrl(){
+    return readTrimmed("mail.tracking.base");
+  }
+
+  public static void setMailTrackingBaseUrl(String value){
+    writeTrimmed("mail.tracking.base", value);
+  }
+
   private static String readTrimmed(String key){
     String value = PREFS.get(key, null);
     if (value == null){


### PR DESCRIPTION
## Summary
- allow configuring HTML mission order templates, tracking flags and base URL in the client settings UI
- send multipart text/HTML emails with optional tracking pixels and escape mission data for HTML rendering
- expose a backend pixel endpoint that records openings in the in-memory timeline store

## Testing
- `mvn -DskipTests compile` *(fails: central repository unreachable in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6e85d9388330b272c9276b7848dc