### PR TITLE
Improve resource picker and billing table ergonomics

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/ui/common/OverridableCellRenderers.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/common/OverridableCellRenderers.java
@@ -4,6 +4,8 @@ import javax.swing.*;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableModel;
 import java.awt.*;
+import java.text.NumberFormat;
+import java.util.Locale;
 
 /** Renderers that highlight cells manually overridden by the user. */
 public final class OverridableCellRenderers {
@@ -16,6 +18,8 @@ public final class OverridableCellRenderers {
 
   /** Highlights cells when the underlying model marks them as manually overridden. */
   public static class ManualOverrideHighlightRenderer extends DefaultTableCellRenderer {
+    private final NumberFormat currencyFormat = NumberFormat.getCurrencyInstance(Locale.FRANCE);
+
     public ManualOverrideHighlightRenderer(){
       setHorizontalAlignment(SwingConstants.RIGHT);
     }
@@ -38,6 +42,13 @@ public final class OverridableCellRenderers {
         int modelColumn = table.convertColumnIndexToModel(column);
         if (aware.isManualOverride(modelRow, modelColumn)){
           component.setBackground(new Color(0xFFF8E1));
+        }
+      }
+      String columnName = table.getColumnName(column);
+      if (value instanceof Number number && columnName != null){
+        String lower = columnName.toLowerCase(Locale.ROOT);
+        if (lower.contains("total") || lower.contains("pu") || lower.contains("prix")){
+          setText(currencyFormat.format(number.doubleValue()));
         }
       }
       return component;

--- a/client/src/main/java/com/materiel/suite/client/ui/common/TableUtils.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/common/TableUtils.java
@@ -1,0 +1,48 @@
+package com.materiel.suite.client.ui.common;
+
+import javax.swing.*;
+import javax.swing.event.TableColumnModelEvent;
+import javax.swing.event.TableColumnModelListener;
+import javax.swing.table.TableColumnModel;
+import java.util.prefs.Preferences;
+
+/** Persistance simple des largeurs de colonnes par clé. */
+public final class TableUtils {
+  private static final String NODE_PATH = "gestion-materiel/tablewidths";
+
+  private TableUtils(){
+  }
+
+  public static void persistColumnWidths(JTable table, String key){
+    if (table == null || key == null || key.isBlank()){
+      return;
+    }
+    TableColumnModel columnModel = table.getColumnModel();
+    if (columnModel == null){
+      return;
+    }
+    Preferences prefs = Preferences.userRoot().node(NODE_PATH);
+    for (int i = 0; i < columnModel.getColumnCount(); i++){
+      int stored = prefs.getInt(key + "#" + i, -1);
+      if (stored > 0){
+        columnModel.getColumn(i).setPreferredWidth(stored);
+      }
+    }
+    columnModel.addColumnModelListener(new TableColumnModelListener(){
+      @Override public void columnAdded(TableColumnModelEvent e){ }
+      @Override public void columnRemoved(TableColumnModelEvent e){ }
+      @Override public void columnMoved(TableColumnModelEvent e){ }
+      @Override public void columnSelectionChanged(javax.swing.event.ListSelectionEvent e){ }
+
+      @Override
+      public void columnMarginChanged(javax.swing.event.ChangeEvent e){
+        for (int i = 0; i < columnModel.getColumnCount(); i++){
+          int width = columnModel.getColumn(i).getWidth();
+          if (width > 0){
+            prefs.putInt(key + "#" + i, width);
+          }
+        }
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add a resource type filter and quick-pick shortcut to the chips selector
- format monetary columns and persist billing table column widths via a shared utility
- enhance the billing tab with numeric editors, keyboard shortcuts, undoable delete, duplication and totals footer

## Testing
- `mvn -pl client -am test` *(fails: unable to reach Maven Central from the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb0223ccc8330bbe8786b771fff34