### PR TITLE
Propagate agency header and track agency IDs in client models

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/agency/AgencyHttp.java
+++ b/client/src/main/java/com/materiel/suite/client/agency/AgencyHttp.java
@@ -1,0 +1,58 @@
+package com.materiel.suite.client.agency;
+
+import java.net.HttpURLConnection;
+import java.net.http.HttpRequest;
+import java.util.Map;
+
+/**
+ * Utilitaires pour propager l'agence courante dans les entêtes HTTP.
+ */
+public final class AgencyHttp {
+  public static final String HEADER = "X-Agency-Id";
+
+  private AgencyHttp(){
+  }
+
+  /**
+   * Ajoute l'entête {@code X-Agency-Id} si une agence est sélectionnée.
+   *
+   * @param builder constructeur de requête HTTP, éventuellement {@code null}
+   */
+  public static void apply(HttpRequest.Builder builder){
+    String agencyId = AgencyContext.agencyId();
+    if (builder == null || agencyId == null || agencyId.isBlank()){
+      return;
+    }
+    builder.setHeader(HEADER, agencyId);
+  }
+
+  /**
+   * Variante pour {@link HttpURLConnection}, utilisée par certains clients.
+   *
+   * @param connection connexion HTTP éventuellement {@code null}
+   */
+  public static void apply(HttpURLConnection connection){
+    String agencyId = AgencyContext.agencyId();
+    if (connection == null || agencyId == null || agencyId.isBlank()){
+      return;
+    }
+    connection.setRequestProperty(HEADER, agencyId);
+  }
+
+  /**
+   * Variante pour une map d'entêtes. Si la map est non modifiable, l'entête est ignorée.
+   *
+   * @param headers map potentiellement {@code null}
+   */
+  public static void apply(Map<String, String> headers){
+    String agencyId = AgencyContext.agencyId();
+    if (headers == null || agencyId == null || agencyId.isBlank()){
+      return;
+    }
+    try {
+      headers.put(HEADER, agencyId);
+    } catch (UnsupportedOperationException ignore){
+      // Map non modifiable : dans ce cas, l'appelant devra gérer l'entête différemment.
+    }
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/model/Client.java
+++ b/client/src/main/java/com/materiel/suite/client/model/Client.java
@@ -12,6 +12,7 @@ public class Client {
   private String billingAddress;
   private String shippingAddress;
   private String notes;
+  private String agencyId;
 
   public UUID getId(){ return id; }
   public void setId(UUID id){ this.id=id; }
@@ -31,6 +32,8 @@ public class Client {
   public void setShippingAddress(String a){ this.shippingAddress=a; }
   public String getNotes(){ return notes; }
   public void setNotes(String notes){ this.notes=notes; }
+  public String getAgencyId(){ return agencyId; }
+  public void setAgencyId(String agencyId){ this.agencyId = agencyId; }
   @Override public String toString(){ return name; }
 }
 

--- a/client/src/main/java/com/materiel/suite/client/model/Intervention.java
+++ b/client/src/main/java/com/materiel/suite/client/model/Intervention.java
@@ -44,6 +44,7 @@ public class Intervention {
   private String craneName;
   private String truckName;
   private String driverName;
+  private String agencyId;
   private String agency;
   private String status; // PLANNED, CONFIRMED, DONE, CANCELED...
   private boolean favorite;
@@ -297,6 +298,8 @@ public class Intervention {
   public void setTruckName(String truckName){ this.truckName = truckName; }
   public String getDriverName(){ return driverName; }
   public void setDriverName(String driverName){ this.driverName = driverName; }
+  public String getAgencyId(){ return agencyId; }
+  public void setAgencyId(String agencyId){ this.agencyId = agencyId; }
   public String getAgency(){ return agency; }
   public void setAgency(String agency){ this.agency = agency; }
   public String getStatus(){ return status; }

--- a/client/src/main/java/com/materiel/suite/client/model/Resource.java
+++ b/client/src/main/java/com/materiel/suite/client/model/Resource.java
@@ -14,6 +14,7 @@ public class Resource {
   private String notes;
   private String state;
   private String email;
+  private String agencyId;
   private final List<Unavailability> unavailabilities = new ArrayList<>();
   // === CRM-INJECT BEGIN: resource-advanced-fields ===
   private Integer capacity = 1;
@@ -39,6 +40,8 @@ public class Resource {
   public void setState(String state){ this.state=state; }
   public String getEmail(){ return email; }
   public void setEmail(String email){ this.email=email; }
+  public String getAgencyId(){ return agencyId; }
+  public void setAgencyId(String agencyId){ this.agencyId = agencyId; }
   public List<Unavailability> getUnavailabilities(){ return unavailabilities; }
   public void setUnavailabilities(List<Unavailability> list){
     unavailabilities.clear();

--- a/client/src/main/java/com/materiel/suite/client/net/RestClient.java
+++ b/client/src/main/java/com/materiel/suite/client/net/RestClient.java
@@ -1,5 +1,7 @@
 package com.materiel.suite.client.net;
 
+import com.materiel.suite.client.agency.AgencyHttp;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -62,9 +64,11 @@ public class RestClient {
 	private String request(String method, String path, String json, Map<String, String> headers)
 			throws IOException, InterruptedException {
 
-		final HttpRequest.Builder b = HttpRequest.newBuilder()
-				.uri(URI.create(baseUrl + path))
-				.header("Accept", "application/json");
+                final HttpRequest.Builder b = HttpRequest.newBuilder()
+                                .uri(URI.create(baseUrl + path))
+                                .header("Accept", "application/json");
+
+                AgencyHttp.apply(b);
 
 		switch (method) {
 		case "GET"     -> b.GET();

--- a/client/src/main/java/com/materiel/suite/client/service/api/ApiClientService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/api/ApiClientService.java
@@ -71,6 +71,7 @@ public class ApiClientService implements ClientService {
     m.put("billingAddress", c.getBillingAddress());
     m.put("shippingAddress", c.getShippingAddress());
     m.put("notes", c.getNotes());
+    m.put("agencyId", c.getAgencyId());
     return m;
   }
   private Client fromMap(Map<String,Object> m){
@@ -84,6 +85,7 @@ public class ApiClientService implements ClientService {
     c.setBillingAddress(SimpleJson.str(m.get("billingAddress")));
     c.setShippingAddress(SimpleJson.str(m.get("shippingAddress")));
     c.setNotes(SimpleJson.str(m.get("notes")));
+    c.setAgencyId(SimpleJson.str(m.get("agencyId")));
     return c;
   }
   private Map<String,Object> toMapC(Contact c){

--- a/client/src/main/java/com/materiel/suite/client/service/api/ApiPlanningService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/api/ApiPlanningService.java
@@ -68,6 +68,7 @@ public class ApiPlanningService implements PlanningService {
       m.put("color", r.getColor());
       m.put("notes", r.getNotes());
       m.put("email", r.getEmail());
+      m.put("agencyId", r.getAgencyId());
       // === CRM-INJECT BEGIN: resource-api-write ===
       m.put("capacity", r.getCapacity());
       m.put("tags", r.getTags());
@@ -304,6 +305,7 @@ public class ApiPlanningService implements PlanningService {
     }
     // === CRM-INJECT BEGIN: planning-api-client-id ===
     m.put("clientId", it.getClientId()!=null? it.getClientId().toString() : null);
+    m.put("agencyId", it.getAgencyId());
     // === CRM-INJECT END ===
     m.put("label", it.getLabel());
     m.put("color", it.getColor());
@@ -365,6 +367,10 @@ public class ApiPlanningService implements PlanningService {
     if (cid!=null && !cid.isBlank()) it.setClientId(UUID.fromString(cid));
     String cname = SimpleJson.str(m.get("clientName"));
     if (cname!=null) it.setClientName(cname);
+    String agencyId = SimpleJson.str(m.get("agencyId"));
+    if (agencyId!=null) it.setAgencyId(agencyId);
+    String agencyLabel = SimpleJson.str(m.get("agency"));
+    if (agencyLabel!=null) it.setAgency(agencyLabel);
     // === CRM-INJECT END ===
     it.setLabel(SimpleJson.str(m.get("label")));
     it.setColor(SimpleJson.str(m.get("color")));
@@ -522,6 +528,7 @@ public class ApiPlanningService implements PlanningService {
     target.setNotes(SimpleJson.str(data.get("notes")));
     target.setState(SimpleJson.str(data.get("state")));
     target.setEmail(SimpleJson.str(data.get("email")));
+    target.setAgencyId(SimpleJson.str(data.get("agencyId")));
     // === CRM-INJECT BEGIN: resource-api-fill ===
     Object cap = data.get("capacity");
     if (cap instanceof Number n){

--- a/client/src/main/java/com/materiel/suite/client/service/api/ApiSalesService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/api/ApiSalesService.java
@@ -84,6 +84,7 @@ public class ApiSalesService implements SalesService {
     firstField = appendStringField(sb, firstField, "title", intervention.getLabel());
     String clientId = intervention.getClientId() == null ? null : intervention.getClientId().toString();
     firstField = appendStringField(sb, firstField, "clientId", clientId);
+    firstField = appendStringField(sb, firstField, "agencyId", intervention.getAgencyId());
     if (!firstField){
       sb.append(',');
     }

--- a/client/src/main/java/com/materiel/suite/client/service/mock/MockClientService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/mock/MockClientService.java
@@ -48,6 +48,7 @@ public class MockClientService implements ClientService {
       "Martin", "Bernard", "Thomas", "Petit", "Robert", "Richard", "Durand", "Dubois", "Moreau", "Laurent",
       "Simon", "Michel", "Lefebvre", "Leroy", "Roux", "David", "Bertrand", "Morel", "Fournier", "Girard"
   };
+  private static final String[] AGENCY_IDS = { "A1", "A2" };
 
   private final Map<UUID, Client> clients = new ConcurrentHashMap<>();
   private final Map<UUID, Map<UUID, Contact>> contacts = new ConcurrentHashMap<>();
@@ -126,6 +127,9 @@ public class MockClientService implements ClientService {
       client.setBillingAddress(address);
       client.setShippingAddress(address);
       client.setNotes(pick(rnd, COMPANY_NOTES));
+      if (AGENCY_IDS.length > 0){
+        client.setAgencyId(AGENCY_IDS[i % AGENCY_IDS.length]);
+      }
       clients.put(client.getId(), client);
 
       Map<UUID, Contact> map = ctMap(client.getId());

--- a/client/src/main/java/com/materiel/suite/client/service/mock/MockPlanningService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/mock/MockPlanningService.java
@@ -30,6 +30,7 @@ public class MockPlanningService implements PlanningService {
   private static final String[] RESOURCE_COLORS = { "#5E81AC", "#A3BE8C", "#EBCB8B", "#D08770", "#88C0D0", "#B48EAD", "#BF616A" };
   private static final String[] INTERVENTION_STATUSES = { "PLANNED", "CONFIRMED", "TENTATIVE", "DONE" };
   private static final String[] INTERVENTION_AGENCIES = { "Agence Lyon", "Agence Paris" };
+  private static final String[] INTERVENTION_AGENCY_IDS = { "A1", "A2" };
   private static final String[] CLIENT_NAMES = { "Durand BTP", "MontBlanc Levage", "Atelier Urbain", "Sogena Logistique", "Structura", "BTP Horizon", "EuroChantier" };
   private static final String[] SITE_KINDS = { "Chantier", "Zone logistique", "Usine", "Site portuaire", "Parc expo", "Plateforme" };
   private static final String[] CITY_NAMES = { "Lyon", "Villeurbanne", "Grenoble", "Saint-Étienne", "Valence", "Chambéry", "Dijon", "Annecy" };
@@ -115,6 +116,9 @@ public class MockPlanningService implements PlanningService {
     resource.setWeeklyUnavailability(weeklyPattern(rnd));
     resource.setColor(RESOURCE_COLORS[globalIndex % RESOURCE_COLORS.length]);
     resource.setEmail(emailFor(resource));
+    if (INTERVENTION_AGENCY_IDS.length > 0){
+      resource.setAgencyId(INTERVENTION_AGENCY_IDS[globalIndex % INTERVENTION_AGENCY_IDS.length]);
+    }
     if (rnd.nextInt(4) == 0){
       LocalDate lastCheck = LocalDate.now().minusDays(rnd.nextInt(180));
       resource.setNotes("Dernier contrôle: " + lastCheck);
@@ -276,7 +280,11 @@ public class MockPlanningService implements PlanningService {
     intervention.setClientName(client);
     intervention.setSiteLabel(site);
     intervention.setAddress(sampleAddress(rnd, city));
-    intervention.setAgency(INTERVENTION_AGENCIES[rnd.nextInt(INTERVENTION_AGENCIES.length)]);
+    int agencyIndex = rnd.nextInt(INTERVENTION_AGENCIES.length);
+    intervention.setAgency(INTERVENTION_AGENCIES[agencyIndex]);
+    if (INTERVENTION_AGENCY_IDS.length > 0){
+      intervention.setAgencyId(INTERVENTION_AGENCY_IDS[agencyIndex % INTERVENTION_AGENCY_IDS.length]);
+    }
     String status = INTERVENTION_STATUSES[rnd.nextInt(INTERVENTION_STATUSES.length)];
     intervention.setStatus(status);
     intervention.setDescription("Opération " + type.getLabel() + " pour " + client + ".");

--- a/client/src/main/java/com/materiel/suite/client/ui/interventions/InterventionDialog.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/interventions/InterventionDialog.java
@@ -2278,7 +2278,7 @@ public class InterventionDialog extends JDialog {
       intervention.setAgency(id);
     }
     if (id != null && !id.isBlank()){
-      invokeAgencySetter(intervention, "setAgencyId", id);
+      intervention.setAgencyId(id);
       invokeAgencySetter(intervention, "setAgencyCode", id);
     }
     if (label != null && !label.isBlank()){


### PR DESCRIPTION
## Summary
- add a reusable AgencyHttp helper and call it from RestClient so HTTP requests carry the X-Agency-Id header
- extend client, resource and intervention models plus API mappings and mocks to expose an agencyId field
- ensure the intervention dialog writes the current agency id directly when saving changes

## Testing
- mvn -pl client -am test *(fails: repository download blocked in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd1a6b01883308e1b604db42b68a1