### PR TITLE
Add agency support to sales documents

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/model/DeliveryNote.java
+++ b/client/src/main/java/com/materiel/suite/client/model/DeliveryNote.java
@@ -11,6 +11,7 @@ public class DeliveryNote {
   private LocalDate date;
   private String customerName;
   private String status; // Brouillon, Signé, Verrouillé
+  private String agencyId;
   private List<DocumentLine> lines = new ArrayList<>();
   private DocumentTotals totals = new DocumentTotals();
   // === CRM-INJECT BEGIN: delivery-client-link ===
@@ -27,6 +28,8 @@ public class DeliveryNote {
   public void setCustomerName(String v){ customerName=v; }
   public String getStatus(){ return status; }
   public void setStatus(String v){ status=v; }
+  public String getAgencyId(){ return agencyId; }
+  public void setAgencyId(String agencyId){ this.agencyId = agencyId; }
   // === CRM-INJECT BEGIN: delivery-client-accessors ===
   public UUID getClientId(){ return clientId; }
   public void setClientId(UUID v){ clientId=v; }

--- a/client/src/main/java/com/materiel/suite/client/model/Invoice.java
+++ b/client/src/main/java/com/materiel/suite/client/model/Invoice.java
@@ -11,6 +11,7 @@ public class Invoice {
   private LocalDate date;
   private String customerName;
   private String status; // Brouillon, Envoyée, Partiellement payée, Payée, Annulée
+  private String agencyId;
   private List<DocumentLine> lines = new ArrayList<>();
   private DocumentTotals totals = new DocumentTotals();
   // === CRM-INJECT BEGIN: invoice-client-link ===
@@ -27,6 +28,8 @@ public class Invoice {
   public void setCustomerName(String v){ customerName=v; }
   public String getStatus(){ return status; }
   public void setStatus(String v){ status=v; }
+  public String getAgencyId(){ return agencyId; }
+  public void setAgencyId(String agencyId){ this.agencyId = agencyId; }
   // === CRM-INJECT BEGIN: invoice-client-accessors ===
   public UUID getClientId(){ return clientId; }
   public void setClientId(UUID v){ clientId=v; }

--- a/client/src/main/java/com/materiel/suite/client/model/Order.java
+++ b/client/src/main/java/com/materiel/suite/client/model/Order.java
@@ -11,6 +11,7 @@ public class Order {
   private LocalDate date;
   private String customerName;
   private String status; // Brouillon, Confirmé, Annulé
+  private String agencyId;
   private List<DocumentLine> lines = new ArrayList<>();
   private DocumentTotals totals = new DocumentTotals();
   // === CRM-INJECT BEGIN: order-client-link ===
@@ -27,6 +28,8 @@ public class Order {
   public void setCustomerName(String v){ customerName=v; }
   public String getStatus(){ return status; }
   public void setStatus(String v){ status=v; }
+  public String getAgencyId(){ return agencyId; }
+  public void setAgencyId(String agencyId){ this.agencyId = agencyId; }
   // === CRM-INJECT BEGIN: order-client-accessors ===
   public UUID getClientId(){ return clientId; }
   public void setClientId(UUID v){ clientId=v; }

--- a/client/src/main/java/com/materiel/suite/client/model/Quote.java
+++ b/client/src/main/java/com/materiel/suite/client/model/Quote.java
@@ -11,6 +11,7 @@ public class Quote {
   private LocalDate date;
   private String customerName;
   private String status; // Brouillon, Envoyé, Accepté, Refusé, Expiré
+  private String agencyId;
   private List<DocumentLine> lines = new ArrayList<>();
   private DocumentTotals totals = new DocumentTotals();
   // === CRM-INJECT BEGIN: quote-client-link ===
@@ -32,6 +33,8 @@ public class Quote {
   public void setCustomerName(String v){ customerName=v; }
   public String getStatus(){ return status; }
   public void setStatus(String v){ status=v; }
+  public String getAgencyId(){ return agencyId; }
+  public void setAgencyId(String agencyId){ this.agencyId = agencyId; }
   // === CRM-INJECT BEGIN: quote-client-accessors ===
   public UUID getClientId(){ return clientId; }
   public void setClientId(UUID v){ clientId=v; }

--- a/client/src/main/java/com/materiel/suite/client/service/api/ApiSupport.java
+++ b/client/src/main/java/com/materiel/suite/client/service/api/ApiSupport.java
@@ -20,6 +20,7 @@ final class ApiSupport {
     q.setId(parseUUID(m.get("id")));
     q.setNumber(SimpleJson.str(m.get("number")));
     q.setCustomerName(SimpleJson.str(m.get("customerName")));
+    setAgency(q, m);
     // === CRM-INJECT BEGIN: quote-client-mapping ===
     q.setClientId(parseUUID(m.get("clientId")));
     q.setContactId(parseUUID(m.get("contactId")));
@@ -44,6 +45,7 @@ final class ApiSupport {
     o.setId(parseUUID(m.get("id")));
     setIfPresent(o, "setNumber", m.get("number"));
     setIfPresent(o, "setCustomerName", m.get("customerName"));
+    setAgency(o, m);
     // === CRM-INJECT BEGIN: order-client-mapping ===
     setIfPresent(o, "setClientId", parseUUID(m.get("clientId")));
     setIfPresent(o, "setContactId", parseUUID(m.get("contactId")));
@@ -61,6 +63,7 @@ final class ApiSupport {
     d.setId(parseUUID(m.get("id")));
     setIfPresent(d, "setNumber", m.get("number"));
     setIfPresent(d, "setCustomerName", m.get("customerName"));
+    setAgency(d, m);
     // === CRM-INJECT BEGIN: delivery-client-mapping ===
     setIfPresent(d, "setClientId", parseUUID(m.get("clientId")));
     setIfPresent(d, "setContactId", parseUUID(m.get("contactId")));
@@ -78,6 +81,7 @@ final class ApiSupport {
     i.setId(parseUUID(m.get("id")));
     setIfPresent(i, "setNumber", m.get("number"));
     setIfPresent(i, "setCustomerName", m.get("customerName"));
+    setAgency(i, m);
     // === CRM-INJECT BEGIN: invoice-client-mapping ===
     setIfPresent(i, "setClientId", parseUUID(m.get("clientId")));
     setIfPresent(i, "setContactId", parseUUID(m.get("contactId")));
@@ -130,6 +134,7 @@ final class ApiSupport {
     sb.append("{");
     field(sb,"id", q.getId()==null? null : q.getId().toString()); comma(sb);
     field(sb,"number", q.getNumber()); comma(sb);
+    field(sb,"agencyId", readString(q,"getAgencyId","getAgency","getAgencyCode")); comma(sb);
     // === CRM-INJECT BEGIN: quote-client-json ===
     field(sb,"clientId", q.getClientId()==null? null : q.getClientId().toString()); comma(sb);
     field(sb,"contactId", q.getContactId()==null? null : q.getContactId().toString()); comma(sb);
@@ -152,6 +157,7 @@ final class ApiSupport {
     sb.append("{");
     field(sb,"id", o.getId()==null? null : o.getId().toString()); comma(sb);
     field(sb,"number", o.getNumber()); comma(sb);
+    field(sb,"agencyId", readString(o,"getAgencyId","getAgency","getAgencyCode")); comma(sb);
     // === CRM-INJECT BEGIN: order-client-json ===
     field(sb,"clientId", o.getClientId()==null? null : o.getClientId().toString()); comma(sb);
     field(sb,"contactId", o.getContactId()==null? null : o.getContactId().toString()); comma(sb);
@@ -172,6 +178,7 @@ final class ApiSupport {
     sb.append("{");
     field(sb,"id", d.getId()==null? null : d.getId().toString()); comma(sb);
     field(sb,"number", d.getNumber()); comma(sb);
+    field(sb,"agencyId", readString(d,"getAgencyId","getAgency","getAgencyCode")); comma(sb);
     // === CRM-INJECT BEGIN: delivery-client-json ===
     field(sb,"clientId", d.getClientId()==null? null : d.getClientId().toString()); comma(sb);
     field(sb,"contactId", d.getContactId()==null? null : d.getContactId().toString()); comma(sb);
@@ -192,6 +199,7 @@ final class ApiSupport {
     sb.append("{");
     field(sb,"id", i.getId()==null? null : i.getId().toString()); comma(sb);
     field(sb,"number", i.getNumber()); comma(sb);
+    field(sb,"agencyId", readString(i,"getAgencyId","getAgency","getAgencyCode")); comma(sb);
     // === CRM-INJECT BEGIN: invoice-client-json ===
     field(sb,"clientId", i.getClientId()==null? null : i.getClientId().toString()); comma(sb);
     field(sb,"contactId", i.getContactId()==null? null : i.getContactId().toString()); comma(sb);
@@ -231,6 +239,32 @@ final class ApiSupport {
   }
 
   /* ================= helpers ================= */
+  private static void setAgency(Object target, Map<String,Object> data){
+    if (target == null || data == null){
+      return;
+    }
+    Object value = firstNonBlank(data.get("agencyId"), data.get("agency"), data.get("agencyCode"));
+    if (value != null){
+      setIfPresent(target, "setAgencyId", value);
+    }
+  }
+
+  private static Object firstNonBlank(Object... values){
+    if (values == null){
+      return null;
+    }
+    for (Object value : values){
+      if (value == null){
+        continue;
+      }
+      if (value instanceof CharSequence sequence && sequence.toString().isBlank()){
+        continue;
+      }
+      return value;
+    }
+    return null;
+  }
+
   private static void field(StringBuilder sb, String k, String v){
     sb.append("\"").append(k).append("\":");
     if (v==null) sb.append("null");

--- a/client/src/main/java/com/materiel/suite/client/service/mock/MockData.java
+++ b/client/src/main/java/com/materiel/suite/client/service/mock/MockData.java
@@ -12,6 +12,7 @@ public final class MockData {
   public static final List<Order> ORDERS = new ArrayList<>();
   public static final List<DeliveryNote> DELIVERY_NOTES = new ArrayList<>();
   public static final List<Invoice> INVOICES = new ArrayList<>();
+  private static final String[] AGENCY_IDS = { "A1", "A2" };
   private static final AtomicInteger seqQuote = new AtomicInteger(1);
   private static final AtomicInteger seqOrder = new AtomicInteger(1);
   private static final AtomicInteger seqDN = new AtomicInteger(1);
@@ -20,12 +21,14 @@ public final class MockData {
   public static void seedIfEmpty(){
     if (!QUOTES.isEmpty()) return;
     var q1 = new Quote(UUID.randomUUID(), nextNumber("DEV", seqQuote), LocalDate.now().minusDays(2), "Société Alpha", "Brouillon");
+    q1.setAgencyId(AGENCY_IDS.length > 0 ? AGENCY_IDS[0] : null);
     q1.getLines().add(new DocumentLine("Location grue", 1, "j", 520, 0, 20));
     q1.getLines().add(new DocumentLine("Transport", 1, "forfait", 120, 0, 20));
     q1.recomputeTotals();
     QUOTES.add(q1);
 
     var q2 = new Quote(UUID.randomUUID(), nextNumber("DEV", seqQuote), LocalDate.now().minusDays(1), "BTP Béton", "Envoyé");
+    q2.setAgencyId(AGENCY_IDS.length > 1 ? AGENCY_IDS[1] : (AGENCY_IDS.length > 0 ? AGENCY_IDS[0] : null));
     q2.getLines().add(new DocumentLine("Levage charpente", 1, "forfait", 1800, 5, 20));
     q2.recomputeTotals();
     QUOTES.add(q2);
@@ -72,6 +75,7 @@ public final class MockData {
     o.setNumber(nextNumber("CMD", seqOrder));
     o.setDate(LocalDate.now());
     o.setCustomerName(q.getCustomerName());
+    o.setAgencyId(q.getAgencyId());
     // === CRM-INJECT BEGIN: order-from-quote-client ===
     o.setClientId(q.getClientId());
     o.setContactId(q.getContactId());
@@ -87,6 +91,7 @@ public final class MockData {
     d.setNumber(nextNumber("BL", seqDN));
     d.setDate(LocalDate.now());
     d.setCustomerName(o.getCustomerName());
+    d.setAgencyId(o.getAgencyId());
     // === CRM-INJECT BEGIN: delivery-from-order-client ===
     d.setClientId(o.getClientId());
     d.setContactId(o.getContactId());
@@ -102,6 +107,7 @@ public final class MockData {
     i.setNumber(nextNumber("FAC", seqInv));
     i.setDate(LocalDate.now());
     i.setCustomerName(q.getCustomerName());
+    i.setAgencyId(q.getAgencyId());
     // === CRM-INJECT BEGIN: invoice-from-quote-client ===
     i.setClientId(q.getClientId());
     i.setContactId(q.getContactId());
@@ -117,6 +123,9 @@ public final class MockData {
     i.setNumber(nextNumber("FAC", seqInv));
     i.setDate(LocalDate.now());
     i.setCustomerName(dns.isEmpty() ? "" : dns.get(0).getCustomerName());
+    if (!dns.isEmpty()){
+      i.setAgencyId(dns.get(0).getAgencyId());
+    }
     // === CRM-INJECT BEGIN: invoice-from-dn-client ===
     if (!dns.isEmpty()) {
       i.setClientId(dns.get(0).getClientId());


### PR DESCRIPTION
## Summary
- add an agencyId property to quote, order, delivery note and invoice models
- propagate the agency identifier through the REST JSON mapping helpers
- seed mock sales data with sample agency identifiers for consistency

## Testing
- `mvn -pl client -am -DskipTests compile` *(fails: unable to download dependencies because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d01c7e91f48330930ac1bba9240bc4