### PR TITLE
feat: add inline sales management with v2 API mock

### DIFF
--- a/backend/src/main/java/com/materiel/suite/backend/sales/InvoiceCrudV2Controller.java
+++ b/backend/src/main/java/com/materiel/suite/backend/sales/InvoiceCrudV2Controller.java
@@ -1,0 +1,104 @@
+package com.materiel.suite.backend.sales;
+
+import com.materiel.suite.backend.sales.dto.InvoiceV2Dto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v2/invoices")
+public class InvoiceCrudV2Controller {
+
+  @GetMapping
+  public List<InvoiceV2Dto> list(@RequestHeader(value = "X-Agency-Id", required = false) String agencyId){
+    Comparator<InvoiceV2Dto> comparator = Comparator
+        .comparing(InvoiceV2Dto::getDate, Comparator.nullsLast(Comparator.naturalOrder()))
+        .reversed();
+    return SalesMemoryStore.listInvoices().stream()
+        .filter(f -> agencyId == null || agencyId.isBlank() || agencyId.equals(f.getAgencyId()))
+        .sorted(comparator)
+        .map(this::copyInvoice)
+        .toList();
+  }
+
+  @PostMapping
+  public InvoiceV2Dto create(@RequestHeader(value = "X-Agency-Id", required = false) String agencyId,
+                             @RequestBody InvoiceV2Dto input){
+    InvoiceV2Dto invoice = copyInvoice(input);
+    if (invoice.getId() == null || invoice.getId().isBlank()){
+      invoice.setId(UUID.randomUUID().toString());
+    }
+    if (invoice.getNumber() == null || invoice.getNumber().isBlank()){
+      invoice.setNumber(SalesMemoryStore.nextInvoiceNumber());
+    }
+    if (invoice.getDate() == null){
+      invoice.setDate(LocalDate.now());
+    }
+    if (invoice.getAgencyId() == null || invoice.getAgencyId().isBlank()){
+      invoice.setAgencyId(agencyId);
+    }
+    SalesMemoryStore.putInvoice(invoice);
+    return copyInvoice(invoice);
+  }
+
+  @PutMapping
+  public InvoiceV2Dto update(@RequestHeader(value = "X-Agency-Id", required = false) String agencyId,
+                             @RequestBody InvoiceV2Dto input){
+    if (input == null || input.getId() == null || input.getId().isBlank()){
+      throw new IllegalArgumentException("id required");
+    }
+    InvoiceV2Dto invoice = copyInvoice(input);
+    InvoiceV2Dto existing = SalesMemoryStore.getInvoice(invoice.getId());
+    if (invoice.getNumber() == null || invoice.getNumber().isBlank()){
+      invoice.setNumber(existing != null && existing.getNumber() != null
+          ? existing.getNumber()
+          : SalesMemoryStore.nextInvoiceNumber());
+    }
+    if (invoice.getDate() == null){
+      invoice.setDate(existing != null && existing.getDate() != null ? existing.getDate() : LocalDate.now());
+    }
+    if (invoice.getAgencyId() == null || invoice.getAgencyId().isBlank()){
+      invoice.setAgencyId(agencyId != null && !agencyId.isBlank()
+          ? agencyId
+          : existing == null ? null : existing.getAgencyId());
+    }
+    SalesMemoryStore.putInvoice(invoice);
+    return copyInvoice(invoice);
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> delete(@PathVariable String id){
+    SalesMemoryStore.removeInvoice(id);
+    return ResponseEntity.noContent().build();
+  }
+
+  private InvoiceV2Dto copyInvoice(InvoiceV2Dto src){
+    InvoiceV2Dto copy = new InvoiceV2Dto();
+    if (src == null){
+      return copy;
+    }
+    copy.setId(src.getId());
+    copy.setNumber(src.getNumber());
+    copy.setClientId(src.getClientId());
+    copy.setClientName(src.getClientName());
+    copy.setDate(src.getDate());
+    copy.setTotalHt(src.getTotalHt());
+    copy.setTotalTtc(src.getTotalTtc());
+    copy.setStatus(src.getStatus());
+    copy.setAgencyId(src.getAgencyId());
+    copy.setLines(src.getLines());
+    return copy;
+  }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/sales/QuoteCrudV2Controller.java
+++ b/backend/src/main/java/com/materiel/suite/backend/sales/QuoteCrudV2Controller.java
@@ -1,0 +1,108 @@
+package com.materiel.suite.backend.sales;
+
+import com.materiel.suite.backend.sales.dto.QuoteV2Dto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v2/quotes")
+public class QuoteCrudV2Controller {
+
+  @GetMapping
+  public List<QuoteV2Dto> list(@RequestHeader(value = "X-Agency-Id", required = false) String agencyId){
+    Comparator<QuoteV2Dto> comparator = Comparator
+        .comparing(QuoteV2Dto::getDate, Comparator.nullsLast(Comparator.naturalOrder()))
+        .reversed();
+    return SalesMemoryStore.listQuotes().stream()
+        .filter(q -> agencyId == null || agencyId.isBlank() || agencyId.equals(q.getAgencyId()))
+        .sorted(comparator)
+        .map(this::copyQuote)
+        .toList();
+  }
+
+  @PostMapping
+  public QuoteV2Dto create(@RequestHeader(value = "X-Agency-Id", required = false) String agencyId,
+                           @RequestBody QuoteV2Dto input){
+    QuoteV2Dto quote = copyQuote(input);
+    if (quote.getId() == null || quote.getId().isBlank()){
+      quote.setId(UUID.randomUUID().toString());
+    }
+    if (quote.getReference() == null || quote.getReference().isBlank()){
+      quote.setReference(SalesMemoryStore.nextQuoteReference());
+    }
+    if (quote.getDate() == null){
+      quote.setDate(LocalDate.now());
+    }
+    if (quote.getAgencyId() == null || quote.getAgencyId().isBlank()){
+      quote.setAgencyId(agencyId);
+    }
+    if (quote.getSent() == null){
+      quote.setSent(Boolean.FALSE);
+    }
+    SalesMemoryStore.putQuote(quote);
+    return copyQuote(quote);
+  }
+
+  @PutMapping
+  public QuoteV2Dto update(@RequestHeader(value = "X-Agency-Id", required = false) String agencyId,
+                           @RequestBody QuoteV2Dto input){
+    if (input == null || input.getId() == null || input.getId().isBlank()){
+      throw new IllegalArgumentException("id required");
+    }
+    QuoteV2Dto quote = copyQuote(input);
+    QuoteV2Dto existing = SalesMemoryStore.getQuote(quote.getId());
+    if (quote.getReference() == null || quote.getReference().isBlank()){
+      quote.setReference(existing != null && existing.getReference() != null
+          ? existing.getReference()
+          : SalesMemoryStore.nextQuoteReference());
+    }
+    if (quote.getDate() == null){
+      quote.setDate(existing != null && existing.getDate() != null ? existing.getDate() : LocalDate.now());
+    }
+    if (quote.getAgencyId() == null || quote.getAgencyId().isBlank()){
+      quote.setAgencyId(agencyId != null && !agencyId.isBlank()
+          ? agencyId
+          : existing == null ? null : existing.getAgencyId());
+    }
+    SalesMemoryStore.putQuote(quote);
+    return copyQuote(quote);
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> delete(@PathVariable String id){
+    SalesMemoryStore.removeQuote(id);
+    return ResponseEntity.noContent().build();
+  }
+
+  private QuoteV2Dto copyQuote(QuoteV2Dto src){
+    QuoteV2Dto copy = new QuoteV2Dto();
+    if (src == null){
+      return copy;
+    }
+    copy.setId(src.getId());
+    copy.setReference(src.getReference());
+    copy.setClientId(src.getClientId());
+    copy.setClientName(src.getClientName());
+    copy.setDate(src.getDate());
+    copy.setStatus(src.getStatus());
+    copy.setTotalHt(src.getTotalHt());
+    copy.setTotalTtc(src.getTotalTtc());
+    copy.setSent(src.getSent());
+    copy.setAgencyId(src.getAgencyId());
+    copy.setLines(src.getLines());
+    return copy;
+  }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/sales/SalesMemoryStore.java
+++ b/backend/src/main/java/com/materiel/suite/backend/sales/SalesMemoryStore.java
@@ -1,0 +1,70 @@
+package com.materiel.suite.backend.sales;
+
+import com.materiel.suite.backend.sales.dto.InvoiceV2Dto;
+import com.materiel.suite.backend.sales.dto.QuoteV2Dto;
+
+import java.time.Year;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** Stockage in-memory partagé entre les contrôleurs mock de ventes v2. */
+final class SalesMemoryStore {
+  private static final AtomicInteger QUOTE_SEQ = new AtomicInteger(1);
+  private static final AtomicInteger INVOICE_SEQ = new AtomicInteger(1);
+  private static final Map<String, QuoteV2Dto> QUOTES = new ConcurrentHashMap<>();
+  private static final Map<String, InvoiceV2Dto> INVOICES = new ConcurrentHashMap<>();
+
+  private SalesMemoryStore(){
+  }
+
+  static List<QuoteV2Dto> listQuotes(){
+    return new ArrayList<>(QUOTES.values());
+  }
+
+  static QuoteV2Dto getQuote(String id){
+    return id == null ? null : QUOTES.get(id);
+  }
+
+  static void putQuote(QuoteV2Dto quote){
+    if (quote != null && quote.getId() != null){
+      QUOTES.put(quote.getId(), quote);
+    }
+  }
+
+  static void removeQuote(String id){
+    if (id != null){
+      QUOTES.remove(id);
+    }
+  }
+
+  static String nextQuoteReference(){
+    return String.format("Q%s-%04d", Year.now(), QUOTE_SEQ.getAndIncrement());
+  }
+
+  static List<InvoiceV2Dto> listInvoices(){
+    return new ArrayList<>(INVOICES.values());
+  }
+
+  static InvoiceV2Dto getInvoice(String id){
+    return id == null ? null : INVOICES.get(id);
+  }
+
+  static void putInvoice(InvoiceV2Dto invoice){
+    if (invoice != null && invoice.getId() != null){
+      INVOICES.put(invoice.getId(), invoice);
+    }
+  }
+
+  static void removeInvoice(String id){
+    if (id != null){
+      INVOICES.remove(id);
+    }
+  }
+
+  static String nextInvoiceNumber(){
+    return String.format("F%s-%04d", Year.now(), INVOICE_SEQ.getAndIncrement());
+  }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/sales/dto/InterventionV2Dto.java
+++ b/backend/src/main/java/com/materiel/suite/backend/sales/dto/InterventionV2Dto.java
@@ -8,6 +8,7 @@ public class InterventionV2Dto {
   private String id;
   private String title;
   private String clientId;
+  private String agencyId;
   private List<BillingLineV2Dto> billingLines = new ArrayList<>();
 
   public String getId(){
@@ -32,6 +33,14 @@ public class InterventionV2Dto {
 
   public void setClientId(String clientId){
     this.clientId = clientId;
+  }
+
+  public String getAgencyId(){
+    return agencyId;
+  }
+
+  public void setAgencyId(String agencyId){
+    this.agencyId = agencyId;
   }
 
   public List<BillingLineV2Dto> getBillingLines(){

--- a/backend/src/main/java/com/materiel/suite/backend/sales/dto/InvoiceV2Dto.java
+++ b/backend/src/main/java/com/materiel/suite/backend/sales/dto/InvoiceV2Dto.java
@@ -1,21 +1,20 @@
-package com.materiel.suite.client.model;
+package com.materiel.suite.backend.sales.dto;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
-/** Représentation légère d'un devis retourné par l'API v2. */
-public class QuoteV2 {
+/** DTO mock pour exposer une facture v2. */
+public class InvoiceV2Dto {
   private String id;
-  private String reference;
+  private String number;
   private String clientId;
   private String clientName;
   private LocalDate date;
-  private String status;
   private BigDecimal totalHt;
   private BigDecimal totalTtc;
-  private Boolean sent;
+  private String status;
   private String agencyId;
   private List<Object> lines = new ArrayList<>();
 
@@ -27,12 +26,12 @@ public class QuoteV2 {
     this.id = id;
   }
 
-  public String getReference(){
-    return reference;
+  public String getNumber(){
+    return number;
   }
 
-  public void setReference(String reference){
-    this.reference = reference;
+  public void setNumber(String number){
+    this.number = number;
   }
 
   public String getClientId(){
@@ -59,14 +58,6 @@ public class QuoteV2 {
     this.date = date;
   }
 
-  public String getStatus(){
-    return status;
-  }
-
-  public void setStatus(String status){
-    this.status = status;
-  }
-
   public BigDecimal getTotalHt(){
     return totalHt;
   }
@@ -83,12 +74,12 @@ public class QuoteV2 {
     this.totalTtc = totalTtc;
   }
 
-  public Boolean getSent(){
-    return sent;
+  public String getStatus(){
+    return status;
   }
 
-  public void setSent(Boolean sent){
-    this.sent = sent;
+  public void setStatus(String status){
+    this.status = status;
   }
 
   public String getAgencyId(){

--- a/backend/src/main/java/com/materiel/suite/backend/sales/dto/QuoteV2Dto.java
+++ b/backend/src/main/java/com/materiel/suite/backend/sales/dto/QuoteV2Dto.java
@@ -1,14 +1,23 @@
 package com.materiel.suite.backend.sales.dto;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 /** DTO minimal pour exposer un devis v2 via l'API mock. */
 public class QuoteV2Dto {
   private String id;
   private String reference;
+  private String clientId;
+  private String clientName;
+  private LocalDate date;
   private String status;
   private BigDecimal totalHt;
   private BigDecimal totalTtc;
+  private Boolean sent;
+  private String agencyId;
+  private List<Object> lines = new ArrayList<>();
 
   public String getId(){
     return id;
@@ -24,6 +33,30 @@ public class QuoteV2Dto {
 
   public void setReference(String reference){
     this.reference = reference;
+  }
+
+  public String getClientId(){
+    return clientId;
+  }
+
+  public void setClientId(String clientId){
+    this.clientId = clientId;
+  }
+
+  public String getClientName(){
+    return clientName;
+  }
+
+  public void setClientName(String clientName){
+    this.clientName = clientName;
+  }
+
+  public LocalDate getDate(){
+    return date;
+  }
+
+  public void setDate(LocalDate date){
+    this.date = date;
   }
 
   public String getStatus(){
@@ -48,5 +81,29 @@ public class QuoteV2Dto {
 
   public void setTotalTtc(BigDecimal totalTtc){
     this.totalTtc = totalTtc;
+  }
+
+  public Boolean getSent(){
+    return sent;
+  }
+
+  public void setSent(Boolean sent){
+    this.sent = sent;
+  }
+
+  public String getAgencyId(){
+    return agencyId;
+  }
+
+  public void setAgencyId(String agencyId){
+    this.agencyId = agencyId;
+  }
+
+  public List<Object> getLines(){
+    return lines;
+  }
+
+  public void setLines(List<Object> lines){
+    this.lines = lines == null ? new ArrayList<>() : new ArrayList<>(lines);
   }
 }

--- a/client/src/main/java/com/materiel/suite/client/model/InvoiceV2.java
+++ b/client/src/main/java/com/materiel/suite/client/model/InvoiceV2.java
@@ -5,17 +5,16 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
-/** Représentation légère d'un devis retourné par l'API v2. */
-public class QuoteV2 {
+/** Représentation légère d'une facture retournée par l'API v2. */
+public class InvoiceV2 {
   private String id;
-  private String reference;
+  private String number;
   private String clientId;
   private String clientName;
   private LocalDate date;
-  private String status;
   private BigDecimal totalHt;
   private BigDecimal totalTtc;
-  private Boolean sent;
+  private String status;
   private String agencyId;
   private List<Object> lines = new ArrayList<>();
 
@@ -27,12 +26,12 @@ public class QuoteV2 {
     this.id = id;
   }
 
-  public String getReference(){
-    return reference;
+  public String getNumber(){
+    return number;
   }
 
-  public void setReference(String reference){
-    this.reference = reference;
+  public void setNumber(String number){
+    this.number = number;
   }
 
   public String getClientId(){
@@ -59,14 +58,6 @@ public class QuoteV2 {
     this.date = date;
   }
 
-  public String getStatus(){
-    return status;
-  }
-
-  public void setStatus(String status){
-    this.status = status;
-  }
-
   public BigDecimal getTotalHt(){
     return totalHt;
   }
@@ -83,12 +74,12 @@ public class QuoteV2 {
     this.totalTtc = totalTtc;
   }
 
-  public Boolean getSent(){
-    return sent;
+  public String getStatus(){
+    return status;
   }
 
-  public void setSent(Boolean sent){
-    this.sent = sent;
+  public void setStatus(String status){
+    this.status = status;
   }
 
   public String getAgencyId(){

--- a/client/src/main/java/com/materiel/suite/client/service/SalesService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/SalesService.java
@@ -1,13 +1,34 @@
 package com.materiel.suite.client.service;
 
 import com.materiel.suite.client.model.Intervention;
+import com.materiel.suite.client.model.InvoiceV2;
 import com.materiel.suite.client.model.QuoteV2;
 
-/** Services liés à la génération de devis v2 à partir des interventions. */
+import java.util.List;
+
+/** Services liés à la génération et la gestion des documents de vente v2. */
 public interface SalesService {
   /** Crée un devis à partir d'une intervention (lignes de facturation + méta). */
   QuoteV2 createQuoteFromIntervention(Intervention intervention);
 
   /** Récupère un devis par son identifiant (prévisualisation). */
   QuoteV2 getQuote(String id);
+
+  /** Liste les devis existants. */
+  List<QuoteV2> listQuotes();
+
+  /** Crée ou met à jour un devis. */
+  QuoteV2 saveQuote(QuoteV2 quote);
+
+  /** Supprime un devis. */
+  void deleteQuote(String id);
+
+  /** Liste les factures existantes. */
+  List<InvoiceV2> listInvoices();
+
+  /** Crée ou met à jour une facture. */
+  InvoiceV2 saveInvoice(InvoiceV2 invoice);
+
+  /** Supprime une facture. */
+  void deleteInvoice(String id);
 }

--- a/client/src/main/java/com/materiel/suite/client/service/api/ApiSalesService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/api/ApiSalesService.java
@@ -2,13 +2,22 @@ package com.materiel.suite.client.service.api;
 
 import com.materiel.suite.client.model.BillingLine;
 import com.materiel.suite.client.model.Intervention;
+import com.materiel.suite.client.model.InvoiceV2;
 import com.materiel.suite.client.model.QuoteV2;
 import com.materiel.suite.client.net.RestClient;
 import com.materiel.suite.client.net.SimpleJson;
 import com.materiel.suite.client.service.SalesService;
 
 import java.math.BigDecimal;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /** Client REST minimal pour les opérations de ventes v2. */
 public class ApiSalesService implements SalesService {
@@ -37,25 +46,163 @@ public class ApiSalesService implements SalesService {
       return null;
     }
     try {
-      String body = rc.get("/api/v2/quotes/" + id);
+      String body = rc.get("/api/v2/quotes/" + encode(id));
       return parseQuote(body);
     } catch (Exception e){
       return fallback.getQuote(id);
     }
   }
 
+  @Override public List<QuoteV2> listQuotes(){
+    try {
+      String body = rc.get("/api/v2/quotes");
+      return parseQuoteList(body);
+    } catch (Exception e){
+      return fallback.listQuotes();
+    }
+  }
+
+  @Override public QuoteV2 saveQuote(QuoteV2 quote){
+    if (quote == null){
+      return null;
+    }
+    try {
+      String payload = quoteToJson(quote);
+      String response;
+      if (quote.getId() == null || quote.getId().isBlank()){
+        response = rc.post("/api/v2/quotes", payload);
+      } else {
+        response = rc.put("/api/v2/quotes", payload);
+      }
+      return parseQuote(response);
+    } catch (Exception e){
+      return fallback.saveQuote(quote);
+    }
+  }
+
+  @Override public void deleteQuote(String id){
+    if (id == null || id.isBlank()){
+      return;
+    }
+    try {
+      rc.delete("/api/v2/quotes/" + encode(id));
+    } catch (Exception ignore){
+    }
+    fallback.deleteQuote(id);
+  }
+
+  @Override public List<InvoiceV2> listInvoices(){
+    try {
+      String body = rc.get("/api/v2/invoices");
+      return parseInvoiceList(body);
+    } catch (Exception e){
+      return fallback.listInvoices();
+    }
+  }
+
+  @Override public InvoiceV2 saveInvoice(InvoiceV2 invoice){
+    if (invoice == null){
+      return null;
+    }
+    try {
+      String payload = invoiceToJson(invoice);
+      String response;
+      if (invoice.getId() == null || invoice.getId().isBlank()){
+        response = rc.post("/api/v2/invoices", payload);
+      } else {
+        response = rc.put("/api/v2/invoices", payload);
+      }
+      return parseInvoice(response);
+    } catch (Exception e){
+      return fallback.saveInvoice(invoice);
+    }
+  }
+
+  @Override public void deleteInvoice(String id){
+    if (id == null || id.isBlank()){
+      return;
+    }
+    try {
+      rc.delete("/api/v2/invoices/" + encode(id));
+    } catch (Exception ignore){
+    }
+    fallback.deleteInvoice(id);
+  }
+
+  private List<QuoteV2> parseQuoteList(String body){
+    if (body == null || body.isBlank()){
+      return List.of();
+    }
+    List<Object> arr = SimpleJson.asArr(SimpleJson.parse(body));
+    List<QuoteV2> out = new ArrayList<>();
+    for (Object element : arr){
+      out.add(parseQuote(SimpleJson.asObj(element)));
+    }
+    return out;
+  }
+
+  private List<InvoiceV2> parseInvoiceList(String body){
+    if (body == null || body.isBlank()){
+      return List.of();
+    }
+    List<Object> arr = SimpleJson.asArr(SimpleJson.parse(body));
+    List<InvoiceV2> out = new ArrayList<>();
+    for (Object element : arr){
+      out.add(parseInvoice(SimpleJson.asObj(element)));
+    }
+    return out;
+  }
+
   private QuoteV2 parseQuote(String body){
     if (body == null || body.isBlank()){
       return null;
     }
-    var map = SimpleJson.asObj(SimpleJson.parse(body));
+    return parseQuote(SimpleJson.asObj(SimpleJson.parse(body)));
+  }
+
+  private QuoteV2 parseQuote(Map<String, Object> map){
     QuoteV2 quote = new QuoteV2();
     quote.setId(SimpleJson.str(map.get("id")));
     quote.setReference(SimpleJson.str(map.get("reference")));
+    quote.setClientId(SimpleJson.str(map.get("clientId")));
+    quote.setClientName(SimpleJson.str(map.get("clientName")));
+    quote.setDate(parseLocalDate(map.get("date")));
     quote.setStatus(SimpleJson.str(map.get("status")));
     quote.setTotalHt(parseBigDecimal(map.get("totalHt")));
     quote.setTotalTtc(parseBigDecimal(map.get("totalTtc")));
+    Object sent = map.get("sent");
+    quote.setSent(sent == null ? null : SimpleJson.bool(sent));
+    quote.setAgencyId(SimpleJson.str(map.get("agencyId")));
+    Object lines = map.get("lines");
+    if (lines instanceof List<?> list){
+      quote.setLines(new ArrayList<>(list));
+    }
     return quote;
+  }
+
+  private InvoiceV2 parseInvoice(String body){
+    if (body == null || body.isBlank()){
+      return null;
+    }
+    return parseInvoice(SimpleJson.asObj(SimpleJson.parse(body)));
+  }
+
+  private InvoiceV2 parseInvoice(Map<String, Object> map){
+    InvoiceV2 invoice = new InvoiceV2();
+    invoice.setId(SimpleJson.str(map.get("id")));
+    invoice.setNumber(SimpleJson.str(map.get("number")));
+    invoice.setClientId(SimpleJson.str(map.get("clientId")));
+    invoice.setClientName(SimpleJson.str(map.get("clientName")));
+    invoice.setDate(parseLocalDate(map.get("date")));
+    invoice.setTotalHt(parseBigDecimal(map.get("totalHt")));
+    invoice.setTotalTtc(parseBigDecimal(map.get("totalTtc")));
+    invoice.setStatus(SimpleJson.str(map.get("status")));
+    invoice.setAgencyId(SimpleJson.str(map.get("agencyId")));
+    Object lines = map.get("lines");
+    if (lines instanceof List<?> list){
+      invoice.setLines(new ArrayList<>(list));
+    }
+    return invoice;
   }
 
   private BigDecimal parseBigDecimal(Object value){
@@ -73,6 +220,32 @@ public class ApiSalesService implements SalesService {
     } catch (NumberFormatException ex){
       return null;
     }
+  }
+
+  private LocalDate parseLocalDate(Object value){
+    if (value == null){
+      return null;
+    }
+    if (value instanceof LocalDate localDate){
+      return localDate;
+    }
+    if (value instanceof java.util.Date date){
+      return Instant.ofEpochMilli(date.getTime()).atZone(ZoneId.systemDefault()).toLocalDate();
+    }
+    if (value instanceof Number number){
+      return Instant.ofEpochMilli(number.longValue()).atZone(ZoneId.systemDefault()).toLocalDate();
+    }
+    if (value instanceof String text){
+      if (text.isBlank()){
+        return null;
+      }
+      try {
+        return LocalDate.parse(text);
+      } catch (DateTimeParseException ignore){
+        return null;
+      }
+    }
+    return null;
   }
 
   private String toJson(Intervention intervention){
@@ -114,6 +287,39 @@ public class ApiSalesService implements SalesService {
     return sb.toString();
   }
 
+  private String quoteToJson(QuoteV2 quote){
+    StringBuilder sb = new StringBuilder("{");
+    boolean first = true;
+    first = appendStringField(sb, first, "id", quote.getId());
+    first = appendStringField(sb, first, "reference", quote.getReference());
+    first = appendStringField(sb, first, "clientId", quote.getClientId());
+    first = appendStringField(sb, first, "clientName", quote.getClientName());
+    first = appendStringField(sb, first, "date", quote.getDate() == null ? null : quote.getDate().toString());
+    first = appendStringField(sb, first, "status", quote.getStatus());
+    first = appendNumberField(sb, first, "totalHt", quote.getTotalHt());
+    first = appendNumberField(sb, first, "totalTtc", quote.getTotalTtc());
+    first = appendBooleanField(sb, first, "sent", quote.getSent());
+    first = appendStringField(sb, first, "agencyId", quote.getAgencyId());
+    sb.append('}');
+    return sb.toString();
+  }
+
+  private String invoiceToJson(InvoiceV2 invoice){
+    StringBuilder sb = new StringBuilder("{");
+    boolean first = true;
+    first = appendStringField(sb, first, "id", invoice.getId());
+    first = appendStringField(sb, first, "number", invoice.getNumber());
+    first = appendStringField(sb, first, "clientId", invoice.getClientId());
+    first = appendStringField(sb, first, "clientName", invoice.getClientName());
+    first = appendStringField(sb, first, "date", invoice.getDate() == null ? null : invoice.getDate().toString());
+    first = appendNumberField(sb, first, "totalHt", invoice.getTotalHt());
+    first = appendNumberField(sb, first, "totalTtc", invoice.getTotalTtc());
+    first = appendStringField(sb, first, "status", invoice.getStatus());
+    first = appendStringField(sb, first, "agencyId", invoice.getAgencyId());
+    sb.append('}');
+    return sb.toString();
+  }
+
   private boolean appendStringField(StringBuilder sb, boolean first, String name, String value){
     if (!first){
       sb.append(',');
@@ -127,7 +333,22 @@ public class ApiSalesService implements SalesService {
     return false;
   }
 
-  private boolean appendNumberField(StringBuilder sb, boolean first, String name, BigDecimal value){
+  private boolean appendNumberField(StringBuilder sb, boolean first, String name, Number value){
+    if (!first){
+      sb.append(',');
+    }
+    sb.append('"').append(name).append('"').append(':');
+    if (value == null){
+      sb.append("null");
+    } else if (value instanceof BigDecimal bd){
+      sb.append(bd.toPlainString());
+    } else {
+      sb.append(value.toString());
+    }
+    return false;
+  }
+
+  private boolean appendBooleanField(StringBuilder sb, boolean first, String name, Boolean value){
     if (!first){
       sb.append(',');
     }
@@ -135,7 +356,7 @@ public class ApiSalesService implements SalesService {
     if (value == null){
       sb.append("null");
     } else {
-      sb.append(value.toPlainString());
+      sb.append(value.booleanValue());
     }
     return false;
   }
@@ -150,5 +371,9 @@ public class ApiSalesService implements SalesService {
       out.append(c);
     }
     return out.toString();
+  }
+
+  private String encode(String value){
+    return URLEncoder.encode(value, StandardCharsets.UTF_8);
   }
 }

--- a/client/src/main/java/com/materiel/suite/client/service/mock/MockSalesService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/mock/MockSalesService.java
@@ -2,21 +2,27 @@ package com.materiel.suite.client.service.mock;
 
 import com.materiel.suite.client.model.BillingLine;
 import com.materiel.suite.client.model.Intervention;
+import com.materiel.suite.client.model.InvoiceV2;
 import com.materiel.suite.client.model.QuoteV2;
 import com.materiel.suite.client.service.SalesService;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.Year;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
-/** Implémentation mock en mémoire pour la génération de devis v2. */
+/** Implémentation mock en mémoire pour la génération et la gestion de ventes v2. */
 public class MockSalesService implements SalesService {
-  private final AtomicInteger seq = new AtomicInteger(1);
-  private final Map<String, QuoteV2> store = new ConcurrentHashMap<>();
+  private final AtomicInteger quoteSeq = new AtomicInteger(1);
+  private final AtomicInteger invoiceSeq = new AtomicInteger(1);
+  private final Map<String, QuoteV2> quotes = new ConcurrentHashMap<>();
+  private final Map<String, InvoiceV2> invoices = new ConcurrentHashMap<>();
 
   @Override public QuoteV2 createQuoteFromIntervention(Intervention intervention){
     BigDecimal total = BigDecimal.ZERO;
@@ -40,15 +46,121 @@ public class MockSalesService implements SalesService {
     QuoteV2 quote = new QuoteV2();
     String id = UUID.randomUUID().toString();
     quote.setId(id);
-    quote.setReference(String.format("Q%s-%04d", Year.now(), seq.getAndIncrement()));
+    quote.setReference(String.format("Q%s-%04d", Year.now(), quoteSeq.getAndIncrement()));
     quote.setStatus("DRAFT");
+    quote.setDate(LocalDate.now());
     quote.setTotalHt(total);
     quote.setTotalTtc(total);
-    store.put(id, quote);
-    return quote;
+    quote.setSent(Boolean.FALSE);
+    if (intervention != null){
+      quote.setClientId(intervention.getClientId() == null ? null : intervention.getClientId().toString());
+      quote.setClientName(intervention.getClientName());
+      quote.setAgencyId(intervention.getAgencyId());
+    }
+    quotes.put(id, copyQuote(quote));
+    return copyQuote(quote);
   }
 
   @Override public QuoteV2 getQuote(String id){
-    return id == null ? null : store.get(id);
+    if (id == null){
+      return null;
+    }
+    QuoteV2 quote = quotes.get(id);
+    return quote == null ? null : copyQuote(quote);
+  }
+
+  @Override public List<QuoteV2> listQuotes(){
+    return quotes.values().stream()
+        .sorted(Comparator.comparing(QuoteV2::getDate, Comparator.nullsLast(Comparator.naturalOrder())).reversed())
+        .map(this::copyQuote)
+        .toList();
+  }
+
+  @Override public QuoteV2 saveQuote(QuoteV2 quote){
+    if (quote == null){
+      return null;
+    }
+    QuoteV2 copy = copyQuote(quote);
+    if (copy.getId() == null || copy.getId().isBlank()){
+      copy.setId(UUID.randomUUID().toString());
+    }
+    if (copy.getReference() == null || copy.getReference().isBlank()){
+      copy.setReference(String.format("Q%s-%04d", Year.now(), quoteSeq.getAndIncrement()));
+    }
+    if (copy.getDate() == null){
+      copy.setDate(LocalDate.now());
+    }
+    quotes.put(copy.getId(), copyQuote(copy));
+    return copyQuote(copy);
+  }
+
+  @Override public void deleteQuote(String id){
+    if (id == null){
+      return;
+    }
+    quotes.remove(id);
+  }
+
+  @Override public List<InvoiceV2> listInvoices(){
+    return invoices.values().stream()
+        .sorted(Comparator.comparing(InvoiceV2::getDate, Comparator.nullsLast(Comparator.naturalOrder())).reversed())
+        .map(this::copyInvoice)
+        .toList();
+  }
+
+  @Override public InvoiceV2 saveInvoice(InvoiceV2 invoice){
+    if (invoice == null){
+      return null;
+    }
+    InvoiceV2 copy = copyInvoice(invoice);
+    if (copy.getId() == null || copy.getId().isBlank()){
+      copy.setId(UUID.randomUUID().toString());
+    }
+    if (copy.getNumber() == null || copy.getNumber().isBlank()){
+      copy.setNumber(String.format("F%s-%04d", Year.now(), invoiceSeq.getAndIncrement()));
+    }
+    if (copy.getDate() == null){
+      copy.setDate(LocalDate.now());
+    }
+    invoices.put(copy.getId(), copyInvoice(copy));
+    return copyInvoice(copy);
+  }
+
+  @Override public void deleteInvoice(String id){
+    if (id == null){
+      return;
+    }
+    invoices.remove(id);
+  }
+
+  private QuoteV2 copyQuote(QuoteV2 src){
+    QuoteV2 copy = new QuoteV2();
+    copy.setId(src.getId());
+    copy.setReference(src.getReference());
+    copy.setClientId(src.getClientId());
+    copy.setClientName(src.getClientName());
+    copy.setDate(src.getDate());
+    copy.setStatus(src.getStatus());
+    copy.setTotalHt(src.getTotalHt());
+    copy.setTotalTtc(src.getTotalTtc());
+    copy.setSent(src.getSent());
+    copy.setAgencyId(src.getAgencyId());
+    copy.setLines(src.getLines());
+    return copy;
+  }
+
+  private InvoiceV2 copyInvoice(InvoiceV2 src){
+    InvoiceV2 copy = new InvoiceV2();
+    copy.setId(src.getId());
+    copy.setNumber(src.getNumber());
+    copy.setClientId(src.getClientId());
+    copy.setClientName(src.getClientName());
+    copy.setDate(src.getDate());
+    copy.setTotalHt(src.getTotalHt());
+    copy.setTotalTtc(src.getTotalTtc());
+    copy.setStatus(src.getStatus());
+    copy.setAgencyId(src.getAgencyId());
+    copy.setLines(src.getLines());
+    return copy;
   }
 }

--- a/client/src/main/java/com/materiel/suite/client/ui/MainFrame.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/MainFrame.java
@@ -410,6 +410,11 @@ public class MainFrame extends JFrame implements SessionManager.SessionAware {
     }
   }
 
+  // Expose un openSales si le Sidebar l’utilise
+  public void openSales(){
+    // No-op ici : le Sidebar ouvre déjà la carte correspondante
+  }
+
   @Override
   public void onSessionRefreshed(){
     applyNavigationPolicy();

--- a/client/src/main/java/com/materiel/suite/client/ui/sales/SalesPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/sales/SalesPanel.java
@@ -1,0 +1,531 @@
+package com.materiel.suite.client.ui.sales;
+
+import com.materiel.suite.client.agency.AgencyContext;
+import com.materiel.suite.client.model.InvoiceV2;
+import com.materiel.suite.client.model.QuoteV2;
+import com.materiel.suite.client.service.SalesService;
+import com.materiel.suite.client.service.ServiceLocator;
+import com.materiel.suite.client.ui.common.Toasts;
+
+import javax.swing.*;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.DefaultTableCellRenderer;
+import java.awt.*;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Ecran Devis/Factures (édition inline) avec filtrage agence. */
+public class SalesPanel extends JPanel {
+  private final JTabbedPane tabs = new JTabbedPane();
+  // Devis
+  private final JTable quotesTable = new JTable();
+  private final QuoteTableModel quotesModel = new QuoteTableModel();
+  private final JButton addQuote = new JButton("Nouveau devis");
+  private final JButton delQuote = new JButton("Supprimer");
+  private final JButton saveQuote = new JButton("Enregistrer");
+  private final JButton reloadQuote = new JButton("Recharger");
+  // Factures
+  private final JTable invoicesTable = new JTable();
+  private final InvoiceTableModel invoicesModel = new InvoiceTableModel();
+  private final JButton addInvoice = new JButton("Nouvelle facture");
+  private final JButton delInvoice = new JButton("Supprimer");
+  private final JButton saveInvoice = new JButton("Enregistrer");
+  private final JButton reloadInvoice = new JButton("Recharger");
+
+  public SalesPanel(){
+    super(new BorderLayout());
+    setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
+    // --- Devis tab ---
+    JPanel quotesPane = new JPanel(new BorderLayout());
+    JPanel qbar = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 8));
+    qbar.add(addQuote);
+    qbar.add(delQuote);
+    qbar.add(saveQuote);
+    qbar.add(reloadQuote);
+    quotesTable.setModel(quotesModel);
+    quotesTable.setFillsViewportHeight(true);
+    quotesTable.setRowHeight(24);
+    quotesTable.putClientProperty("terminateEditOnFocusLost", Boolean.TRUE);
+    quotesTable.setDefaultRenderer(LocalDate.class, new LocalDateRenderer());
+    quotesPane.add(qbar, BorderLayout.NORTH);
+    quotesPane.add(new JScrollPane(quotesTable), BorderLayout.CENTER);
+
+    // --- Factures tab ---
+    JPanel invoicesPane = new JPanel(new BorderLayout());
+    JPanel ibar = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 8));
+    ibar.add(addInvoice);
+    ibar.add(delInvoice);
+    ibar.add(saveInvoice);
+    ibar.add(reloadInvoice);
+    invoicesTable.setModel(invoicesModel);
+    invoicesTable.setFillsViewportHeight(true);
+    invoicesTable.setRowHeight(24);
+    invoicesTable.putClientProperty("terminateEditOnFocusLost", Boolean.TRUE);
+    invoicesTable.setDefaultRenderer(LocalDate.class, new LocalDateRenderer());
+    invoicesPane.add(ibar, BorderLayout.NORTH);
+    invoicesPane.add(new JScrollPane(invoicesTable), BorderLayout.CENTER);
+
+    // Tabs
+    tabs.addTab("Devis", quotesPane);
+    tabs.addTab("Factures", invoicesPane);
+    add(tabs, BorderLayout.CENTER);
+
+    // Actions
+    addQuote.addActionListener(e -> onAddQuote());
+    delQuote.addActionListener(e -> onDeleteQuote());
+    saveQuote.addActionListener(e -> onSaveQuote());
+    reloadQuote.addActionListener(e -> reloadQuotes());
+    addInvoice.addActionListener(e -> onAddInvoice());
+    delInvoice.addActionListener(e -> onDeleteInvoice());
+    saveInvoice.addActionListener(e -> onSaveInvoice());
+    reloadInvoice.addActionListener(e -> reloadInvoices());
+
+    reload();
+  }
+
+  public void reload(){
+    reloadQuotes();
+    reloadInvoices();
+  }
+
+  private void reloadQuotes(){
+    SalesService sales = ServiceLocator.sales();
+    if (sales == null){
+      quotesModel.setData(List.of());
+      return;
+    }
+    try {
+      List<QuoteV2> list = new ArrayList<>(sales.listQuotes());
+      String agency = AgencyContext.agencyId();
+      if (agency != null && !agency.isBlank()){
+        list = list.stream().filter(q -> belongsToCurrentAgency(q.getAgencyId())).toList();
+      }
+      quotesModel.setData(list);
+    } catch (Exception ex){
+      Toasts.error(this, "Devis: " + ex.getMessage());
+    }
+  }
+
+  private void onAddQuote(){
+    QuoteV2 q = new QuoteV2();
+    q.setDate(LocalDate.now());
+    q.setClientName("Nouveau client");
+    q.setReference("DRAFT-" + System.currentTimeMillis());
+    q.setTotalHt(BigDecimal.ZERO);
+    q.setTotalTtc(BigDecimal.ZERO);
+    q.setSent(Boolean.FALSE);
+    q.setAgencyId(AgencyContext.agencyId());
+    quotesModel.add(q);
+    int row = quotesModel.getRowCount() - 1;
+    if (row >= 0){
+      quotesTable.setRowSelectionInterval(row, row);
+      quotesTable.editCellAt(row, 1);
+      quotesTable.requestFocusInWindow();
+    }
+  }
+
+  private void onDeleteQuote(){
+    int row = quotesTable.getSelectedRow();
+    if (row < 0){
+      return;
+    }
+    QuoteV2 q = quotesModel.getAt(row);
+    if (q.getId() != null && !q.getId().isBlank()){
+      try {
+        ServiceLocator.sales().deleteQuote(q.getId());
+      } catch (Exception ex){
+        Toasts.error(this, "Suppression devis: " + ex.getMessage());
+      }
+    }
+    quotesModel.remove(row);
+  }
+
+  private void onSaveQuote(){
+    stopEditing(quotesTable);
+    SalesService sales = ServiceLocator.sales();
+    if (sales == null){
+      return;
+    }
+    List<QuoteV2> dirty = quotesModel.getData();
+    int ok = 0;
+    int ko = 0;
+    for (QuoteV2 q : dirty){
+      try {
+        QuoteV2 saved = sales.saveQuote(q);
+        merge(q, saved);
+        ok++;
+      } catch (Exception ex){
+        ko++;
+      }
+    }
+    if (ko == 0){
+      Toasts.success(this, ok + " devis enregistrés");
+    } else {
+      Toasts.error(this, ok + " ok / " + ko + " erreurs");
+    }
+    reloadQuotes();
+  }
+
+  private void reloadInvoices(){
+    SalesService sales = ServiceLocator.sales();
+    if (sales == null){
+      invoicesModel.setData(List.of());
+      return;
+    }
+    try {
+      List<InvoiceV2> list = new ArrayList<>(sales.listInvoices());
+      String agency = AgencyContext.agencyId();
+      if (agency != null && !agency.isBlank()){
+        list = list.stream().filter(f -> belongsToCurrentAgency(f.getAgencyId())).toList();
+      }
+      invoicesModel.setData(list);
+    } catch (Exception ex){
+      Toasts.error(this, "Factures: " + ex.getMessage());
+    }
+  }
+
+  private void onAddInvoice(){
+    InvoiceV2 f = new InvoiceV2();
+    f.setDate(LocalDate.now());
+    f.setClientName("Nouveau client");
+    f.setStatus("DRAFT");
+    f.setTotalHt(BigDecimal.ZERO);
+    f.setTotalTtc(BigDecimal.ZERO);
+    f.setAgencyId(AgencyContext.agencyId());
+    invoicesModel.add(f);
+    int row = invoicesModel.getRowCount() - 1;
+    if (row >= 0){
+      invoicesTable.setRowSelectionInterval(row, row);
+      invoicesTable.editCellAt(row, 1);
+      invoicesTable.requestFocusInWindow();
+    }
+  }
+
+  private void onDeleteInvoice(){
+    int row = invoicesTable.getSelectedRow();
+    if (row < 0){
+      return;
+    }
+    InvoiceV2 f = invoicesModel.getAt(row);
+    if (f.getId() != null && !f.getId().isBlank()){
+      try {
+        ServiceLocator.sales().deleteInvoice(f.getId());
+      } catch (Exception ex){
+        Toasts.error(this, "Suppression facture: " + ex.getMessage());
+      }
+    }
+    invoicesModel.remove(row);
+  }
+
+  private void onSaveInvoice(){
+    stopEditing(invoicesTable);
+    SalesService sales = ServiceLocator.sales();
+    if (sales == null){
+      return;
+    }
+    List<InvoiceV2> dirty = invoicesModel.getData();
+    int ok = 0;
+    int ko = 0;
+    for (InvoiceV2 f : dirty){
+      try {
+        InvoiceV2 saved = sales.saveInvoice(f);
+        merge(f, saved);
+        ok++;
+      } catch (Exception ex){
+        ko++;
+      }
+    }
+    if (ko == 0){
+      Toasts.success(this, ok + " factures enregistrées");
+    } else {
+      Toasts.error(this, ok + " ok / " + ko + " erreurs");
+    }
+    reloadInvoices();
+  }
+
+  private boolean belongsToCurrentAgency(String agencyId){
+    String current = AgencyContext.agencyId();
+    if (current == null || current.isBlank()){
+      return true;
+    }
+    return current.equals(agencyId);
+  }
+
+  private static void stopEditing(JTable table){
+    if (table.isEditing()){
+      table.getCellEditor().stopCellEditing();
+    }
+  }
+
+  private static void merge(QuoteV2 dst, QuoteV2 src){
+    if (dst == null || src == null){
+      return;
+    }
+    dst.setId(src.getId());
+    dst.setReference(src.getReference());
+    dst.setClientId(src.getClientId());
+    dst.setClientName(src.getClientName());
+    dst.setDate(src.getDate());
+    dst.setStatus(src.getStatus());
+    dst.setTotalHt(src.getTotalHt());
+    dst.setTotalTtc(src.getTotalTtc());
+    dst.setSent(src.getSent());
+    dst.setAgencyId(src.getAgencyId());
+    dst.setLines(src.getLines());
+  }
+
+  private static void merge(InvoiceV2 dst, InvoiceV2 src){
+    if (dst == null || src == null){
+      return;
+    }
+    dst.setId(src.getId());
+    dst.setNumber(src.getNumber());
+    dst.setClientId(src.getClientId());
+    dst.setClientName(src.getClientName());
+    dst.setDate(src.getDate());
+    dst.setTotalHt(src.getTotalHt());
+    dst.setTotalTtc(src.getTotalTtc());
+    dst.setStatus(src.getStatus());
+    dst.setAgencyId(src.getAgencyId());
+    dst.setLines(src.getLines());
+  }
+
+  static class QuoteTableModel extends AbstractTableModel {
+    private final String[] cols = {"ID", "Référence", "Client", "Date", "Total HT", "Total TTC", "Envoyé"};
+    private final Class<?>[] types = {String.class, String.class, String.class, LocalDate.class, BigDecimal.class, BigDecimal.class, Boolean.class};
+    private final List<QuoteV2> data = new ArrayList<>();
+
+    public void setData(List<QuoteV2> list){
+      data.clear();
+      if (list != null){
+        data.addAll(list);
+      }
+      fireTableDataChanged();
+    }
+
+    public List<QuoteV2> getData(){
+      return data;
+    }
+
+    public void add(QuoteV2 quote){
+      data.add(quote);
+      int row = data.size() - 1;
+      fireTableRowsInserted(row, row);
+    }
+
+    public void remove(int row){
+      data.remove(row);
+      fireTableRowsDeleted(row, row);
+    }
+
+    public QuoteV2 getAt(int row){
+      return data.get(row);
+    }
+
+    @Override public int getRowCount(){
+      return data.size();
+    }
+
+    @Override public int getColumnCount(){
+      return cols.length;
+    }
+
+    @Override public String getColumnName(int column){
+      return cols[column];
+    }
+
+    @Override public Class<?> getColumnClass(int columnIndex){
+      return types[columnIndex];
+    }
+
+    @Override public boolean isCellEditable(int rowIndex, int columnIndex){
+      return columnIndex != 0;
+    }
+
+    @Override public Object getValueAt(int rowIndex, int columnIndex){
+      QuoteV2 q = data.get(rowIndex);
+      return switch (columnIndex) {
+        case 0 -> q.getId();
+        case 1 -> q.getReference();
+        case 2 -> q.getClientName();
+        case 3 -> q.getDate();
+        case 4 -> q.getTotalHt();
+        case 5 -> q.getTotalTtc();
+        case 6 -> Boolean.TRUE.equals(q.getSent());
+        default -> null;
+      };
+    }
+
+    @Override public void setValueAt(Object aValue, int rowIndex, int columnIndex){
+      QuoteV2 q = data.get(rowIndex);
+      switch (columnIndex) {
+        case 1 -> q.setReference(valueAsString(aValue));
+        case 2 -> q.setClientName(valueAsString(aValue));
+        case 3 -> q.setDate(asLocalDate(aValue));
+        case 4 -> q.setTotalHt(asBigDecimal(aValue));
+        case 5 -> q.setTotalTtc(asBigDecimal(aValue));
+        case 6 -> q.setSent(Boolean.TRUE.equals(aValue));
+        default -> {
+        }
+      }
+      fireTableRowsUpdated(rowIndex, rowIndex);
+    }
+  }
+
+  static class InvoiceTableModel extends AbstractTableModel {
+    private final String[] cols = {"ID", "Numéro", "Client", "Date", "Total HT", "Total TTC", "Statut"};
+    private final Class<?>[] types = {String.class, String.class, String.class, LocalDate.class, BigDecimal.class, BigDecimal.class, String.class};
+    private final List<InvoiceV2> data = new ArrayList<>();
+
+    public void setData(List<InvoiceV2> list){
+      data.clear();
+      if (list != null){
+        data.addAll(list);
+      }
+      fireTableDataChanged();
+    }
+
+    public List<InvoiceV2> getData(){
+      return data;
+    }
+
+    public void add(InvoiceV2 invoice){
+      data.add(invoice);
+      int row = data.size() - 1;
+      fireTableRowsInserted(row, row);
+    }
+
+    public void remove(int row){
+      data.remove(row);
+      fireTableRowsDeleted(row, row);
+    }
+
+    public InvoiceV2 getAt(int row){
+      return data.get(row);
+    }
+
+    @Override public int getRowCount(){
+      return data.size();
+    }
+
+    @Override public int getColumnCount(){
+      return cols.length;
+    }
+
+    @Override public String getColumnName(int column){
+      return cols[column];
+    }
+
+    @Override public Class<?> getColumnClass(int columnIndex){
+      return types[columnIndex];
+    }
+
+    @Override public boolean isCellEditable(int rowIndex, int columnIndex){
+      return columnIndex != 0;
+    }
+
+    @Override public Object getValueAt(int rowIndex, int columnIndex){
+      InvoiceV2 f = data.get(rowIndex);
+      return switch (columnIndex) {
+        case 0 -> f.getId();
+        case 1 -> f.getNumber();
+        case 2 -> f.getClientName();
+        case 3 -> f.getDate();
+        case 4 -> f.getTotalHt();
+        case 5 -> f.getTotalTtc();
+        case 6 -> f.getStatus();
+        default -> null;
+      };
+    }
+
+    @Override public void setValueAt(Object aValue, int rowIndex, int columnIndex){
+      InvoiceV2 f = data.get(rowIndex);
+      switch (columnIndex) {
+        case 1 -> f.setNumber(valueAsString(aValue));
+        case 2 -> f.setClientName(valueAsString(aValue));
+        case 3 -> f.setDate(asLocalDate(aValue));
+        case 4 -> f.setTotalHt(asBigDecimal(aValue));
+        case 5 -> f.setTotalTtc(asBigDecimal(aValue));
+        case 6 -> f.setStatus(valueAsString(aValue));
+        default -> {
+        }
+      }
+      fireTableRowsUpdated(rowIndex, rowIndex);
+    }
+  }
+
+  private static String valueAsString(Object value){
+    return value == null ? null : value.toString();
+  }
+
+  private static BigDecimal asBigDecimal(Object value){
+    if (value == null){
+      return null;
+    }
+    if (value instanceof BigDecimal bd){
+      return bd;
+    }
+    if (value instanceof Number number){
+      try {
+        return new BigDecimal(number.toString());
+      } catch (NumberFormatException ignore){
+        return null;
+      }
+    }
+    if (value instanceof String text){
+      if (text.isBlank()){
+        return null;
+      }
+      try {
+        return new BigDecimal(text.replace(',', '.'));
+      } catch (NumberFormatException ignore){
+        return null;
+      }
+    }
+    return null;
+  }
+
+  private static LocalDate asLocalDate(Object value){
+    if (value == null){
+      return null;
+    }
+    if (value instanceof LocalDate localDate){
+      return localDate;
+    }
+    if (value instanceof java.util.Date date){
+      return Instant.ofEpochMilli(date.getTime()).atZone(ZoneId.systemDefault()).toLocalDate();
+    }
+    if (value instanceof Number number){
+      return Instant.ofEpochMilli(number.longValue()).atZone(ZoneId.systemDefault()).toLocalDate();
+    }
+    if (value instanceof String text){
+      if (text.isBlank()){
+        return null;
+      }
+      try {
+        return LocalDate.parse(text);
+      } catch (DateTimeParseException ignore){
+        return null;
+      }
+    }
+    return null;
+  }
+
+  private static class LocalDateRenderer extends DefaultTableCellRenderer {
+    private static final DateTimeFormatter DF = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+
+    @Override protected void setValue(Object value){
+      if (value instanceof LocalDate localDate){
+        setText(DF.format(localDate));
+      } else {
+        setText(value == null ? "" : value.toString());
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a tabbed sales panel with inline quote and invoice editing tied to the current agency
- extend client-side sales models and services to persist quotes and invoices through the v2 API
- add backend mock controllers, DTOs and shared memory store for CRUD operations on v2 quotes and invoices

## Testing
- mvn -pl client -am test *(fails: unable to reach Maven Central in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d024195b348330bcf18230321ad65d