### PR TITLE
feat: add detailed PDF rendering and email enhancements

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -32,6 +32,17 @@
       <artifactId>h2</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <!-- HTML -> PDF -->
+    <dependency>
+      <groupId>com.openhtmltopdf</groupId>
+      <artifactId>openhtmltopdf-pdfbox</artifactId>
+      <version>1.0.10</version>
+    </dependency>
+    <dependency>
+      <groupId>com.openhtmltopdf</groupId>
+      <artifactId>openhtmltopdf-slf4j</artifactId>
+      <version>1.0.10</version>
+    </dependency>
     <!-- JACKSON -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/backend/src/main/java/com/materiel/suite/backend/web/MailController.java
+++ b/backend/src/main/java/com/materiel/suite/backend/web/MailController.java
@@ -9,32 +9,41 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Base64;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v2/mail")
 public class MailController {
   private static final Logger LOGGER = LoggerFactory.getLogger(MailController.class);
 
-  public record MailPayload(
-      String to,
-      String subject,
-      String body,
-      String attachmentName,
-      String attachmentBase64,
-      String contentType
-  ){}
+  public record MailPayload(List<String> to,
+                            List<String> cc,
+                            List<String> bcc,
+                            String subject,
+                            String body,
+                            List<Attachment> attachments){
+    public record Attachment(String name, String contentType, String base64){}
+  }
 
   @PostMapping("/send")
   public ResponseEntity<String> send(@RequestBody MailPayload payload){
-    int size = 0;
-    if (payload.attachmentBase64() != null && !payload.attachmentBase64().isBlank()){
-      try {
-        size = Base64.getDecoder().decode(payload.attachmentBase64()).length;
-      } catch (IllegalArgumentException ignore){
-        size = 0;
+    int totalBytes = 0;
+    List<MailPayload.Attachment> attachments = payload.attachments();
+    if (attachments != null){
+      for (MailPayload.Attachment attachment : attachments){
+        if (attachment == null || attachment.base64() == null){
+          continue;
+        }
+        try {
+          totalBytes += Base64.getDecoder().decode(attachment.base64()).length;
+        } catch (IllegalArgumentException ignore){
+          // ignore invalid attachment
+        }
       }
     }
-    LOGGER.info("[MAIL] to={} subject={} attachment={} size={}B", payload.to(), payload.subject(), payload.attachmentName(), size);
+    LOGGER.info("[MAIL] to={} cc={} bcc={} subject={} attCount={} bytes={}",
+        payload.to(), payload.cc(), payload.bcc(), payload.subject(),
+        attachments == null ? 0 : attachments.size(), totalBytes);
     return ResponseEntity.ok("queued");
   }
 }

--- a/backend/src/main/java/com/materiel/suite/backend/web/PdfRenderController.java
+++ b/backend/src/main/java/com/materiel/suite/backend/web/PdfRenderController.java
@@ -1,0 +1,58 @@
+package com.materiel.suite.backend.web;
+
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/** Rendu HTML -> PDF pour l'API v2. */
+@RestController
+@RequestMapping("/api/v2/pdf")
+public class PdfRenderController {
+  public record RenderPayload(String html, Map<String, String> inlineImages, String baseUrl){}
+
+  @PostMapping("/render")
+  public ResponseEntity<byte[]> render(@RequestBody RenderPayload payload){
+    try {
+      String html = payload.html() == null ? "<html><body></body></html>" : payload.html();
+      Map<String, String> images = payload.inlineImages();
+      if (images != null && !images.isEmpty()){
+        for (var entry : images.entrySet()){
+          String cid = entry.getKey();
+          String b64 = entry.getValue();
+          if (cid != null && b64 != null){
+            html = html.replace("cid:" + cid, "data:image/png;base64," + b64);
+          }
+        }
+      }
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      PdfRendererBuilder builder = new PdfRendererBuilder();
+      builder.useFastMode();
+      if (payload.baseUrl() != null && !payload.baseUrl().isBlank()){
+        builder.withHtmlContent(html, payload.baseUrl());
+      } else {
+        builder.withHtmlContent(html, null);
+      }
+      builder.toStream(out);
+      builder.run();
+      byte[] pdf = out.toByteArray();
+      return ResponseEntity.ok()
+          .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=document.pdf")
+          .contentType(MediaType.APPLICATION_PDF)
+          .body(pdf);
+    } catch (Exception ex){
+      String message = "PDF render error: " + ex.getMessage();
+      return ResponseEntity.badRequest()
+          .contentType(MediaType.TEXT_PLAIN)
+          .body(message.getBytes(StandardCharsets.UTF_8));
+    }
+  }
+}

--- a/backend/src/main/java/com/materiel/suite/backend/web/TemplateController.java
+++ b/backend/src/main/java/com/materiel/suite/backend/web/TemplateController.java
@@ -1,0 +1,54 @@
+package com.materiel.suite.backend.web;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/** Gestion simple des templates HTML pour devis/factures/emails (API v2). */
+@RestController
+@RequestMapping("/api/v2/templates")
+public class TemplateController {
+  public enum TemplateType { QUOTE, INVOICE, EMAIL }
+
+  public record TemplateDto(String id, String agencyId, TemplateType type, String key, String name, String content){}
+
+  private static final Map<String, TemplateDto> STORE = new ConcurrentHashMap<>();
+
+  @GetMapping
+  public List<TemplateDto> list(@RequestHeader(value = "X-Agency-Id", required = false) String agencyId,
+                                @RequestParam(value = "type", required = false) TemplateType type){
+    return STORE.values().stream()
+        .filter(t -> agencyId == null || agencyId.isBlank() || agencyId.equals(t.agencyId()))
+        .filter(t -> type == null || type == t.type())
+        .collect(Collectors.toList());
+  }
+
+  @PostMapping
+  public TemplateDto upsert(@RequestHeader(value = "X-Agency-Id", required = false) String agencyId,
+                            @RequestBody TemplateDto template){
+    String id = template.id() == null || template.id().isBlank() ? UUID.randomUUID().toString() : template.id();
+    String resolvedAgency = template.agencyId() == null || template.agencyId().isBlank() ? agencyId : template.agencyId();
+    TemplateDto stored = new TemplateDto(id, resolvedAgency, template.type(), template.key(), template.name(), template.content());
+    STORE.put(id, stored);
+    return stored;
+  }
+
+  @DeleteMapping("/{id}")
+  public void delete(@PathVariable String id){
+    if (id != null){
+      STORE.remove(id);
+    }
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/net/ServiceFactory.java
+++ b/client/src/main/java/com/materiel/suite/client/net/ServiceFactory.java
@@ -26,6 +26,8 @@ public class ServiceFactory {
   private static AuthService authService;
   private static UserService userService;
   private static MailService mailService;
+  private static DocumentTemplateService documentTemplateService;
+  private static PdfService pdfService;
 
   public static void init(AppConfig c) {
     cfg = c;
@@ -36,6 +38,8 @@ public class ServiceFactory {
     salesService = null;
     timelineService = null;
     mailService = null;
+    documentTemplateService = null;
+    pdfService = null;
     switch (cfg.getMode()) {
       case "mock" -> initMock();
       case "backend" -> initBackend();
@@ -59,6 +63,8 @@ public class ServiceFactory {
     templateService = new MockTemplateService();
     timelineService = new MockTimelineService();
     mailService = new MockMailService();
+    documentTemplateService = new MockDocumentTemplateService();
+    pdfService = new MockPdfService();
     MockUserService mockUsers = new MockUserService();
     userService = mockUsers;
     authService = new MockAuthService(mockUsers);
@@ -83,6 +89,8 @@ public class ServiceFactory {
     templateService = new ApiTemplateService(rc, new MockTemplateService());
     timelineService = new ApiTimelineService(rc, new MockTimelineService());
     mailService = new ApiMailService(rc, new MockMailService());
+    documentTemplateService = new ApiDocumentTemplateService(rc, new MockDocumentTemplateService());
+    pdfService = new ApiPdfService(rc, new MockPdfService());
     MockUserService mockUsers = new MockUserService();
     userService = new ApiUserService(rc, mockUsers);
     authService = new ApiAuthService(rc, new MockAuthService(mockUsers));
@@ -101,6 +109,8 @@ public class ServiceFactory {
   public static TemplateService templates(){ return templateService; }
   public static TimelineService timeline(){ return timelineService; }
   public static MailService mail(){ return mailService; }
+  public static DocumentTemplateService documentTemplates(){ return documentTemplateService; }
+  public static PdfService pdf(){ return pdfService; }
   public static RestClient http(){ return restClient; }
   public static AuthService auth(){ return authService; }
   public static UserService users(){ return userService; }

--- a/client/src/main/java/com/materiel/suite/client/service/DocumentTemplateService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/DocumentTemplateService.java
@@ -1,0 +1,69 @@
+package com.materiel.suite.client.service;
+
+import java.util.List;
+
+/** Gestion des templates HTML pour devis/factures/emails. */
+public interface DocumentTemplateService {
+  class Template {
+    private String id;
+    private String agencyId;
+    private String type;
+    private String key;
+    private String name;
+    private String content;
+
+    public String getId(){
+      return id;
+    }
+
+    public void setId(String id){
+      this.id = id;
+    }
+
+    public String getAgencyId(){
+      return agencyId;
+    }
+
+    public void setAgencyId(String agencyId){
+      this.agencyId = agencyId;
+    }
+
+    public String getType(){
+      return type;
+    }
+
+    public void setType(String type){
+      this.type = type;
+    }
+
+    public String getKey(){
+      return key;
+    }
+
+    public void setKey(String key){
+      this.key = key;
+    }
+
+    public String getName(){
+      return name;
+    }
+
+    public void setName(String name){
+      this.name = name;
+    }
+
+    public String getContent(){
+      return content;
+    }
+
+    public void setContent(String content){
+      this.content = content;
+    }
+  }
+
+  List<Template> list(String type);
+
+  Template save(Template template);
+
+  void delete(String id);
+}

--- a/client/src/main/java/com/materiel/suite/client/service/MailService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/MailService.java
@@ -2,6 +2,12 @@ package com.materiel.suite.client.service;
 
 /** Service minimal pour l'envoi d'emails avec pièce jointe. */
 public interface MailService {
-  void sendWithAttachment(String to, String subject, String body,
-                          String attachmentName, byte[] attachmentBytes, String contentType);
+  void sendWithAttachments(java.util.List<String> to,
+                           java.util.List<String> cc,
+                           java.util.List<String> bcc,
+                           String subject,
+                           String body,
+                           java.util.List<Attachment> attachments);
+
+  record Attachment(String name, String contentType, byte[] bytes){}
 }

--- a/client/src/main/java/com/materiel/suite/client/service/PdfService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/PdfService.java
@@ -1,0 +1,8 @@
+package com.materiel.suite.client.service;
+
+import java.util.Map;
+
+/** Façade client pour le rendu HTML -> PDF via l'API backend. */
+public interface PdfService {
+  byte[] render(String html, Map<String, String> inlineImages, String baseUrl);
+}

--- a/client/src/main/java/com/materiel/suite/client/service/ServiceLocator.java
+++ b/client/src/main/java/com/materiel/suite/client/service/ServiceLocator.java
@@ -5,7 +5,9 @@ import com.materiel.suite.client.auth.AuthService;
 import com.materiel.suite.client.model.InterventionType;
 import com.materiel.suite.client.model.Resource;
 import com.materiel.suite.client.net.ServiceFactory;
+import com.materiel.suite.client.service.DocumentTemplateService;
 import com.materiel.suite.client.service.MailService;
+import com.materiel.suite.client.service.PdfService;
 import com.materiel.suite.client.service.impl.LocalSettingsService;
 import com.materiel.suite.client.service.TimelineService;
 import com.materiel.suite.client.settings.EmailSettings;
@@ -68,6 +70,14 @@ public final class ServiceLocator {
 
   public static MailService mail(){
     return ServiceFactory.mail();
+  }
+
+  public static DocumentTemplateService documentTemplates(){
+    return ServiceFactory.documentTemplates();
+  }
+
+  public static PdfService pdf(){
+    return ServiceFactory.pdf();
   }
 
   /** Identifiant d'agence actuellement sélectionné, peut être {@code null}. */

--- a/client/src/main/java/com/materiel/suite/client/service/api/ApiDocumentTemplateService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/api/ApiDocumentTemplateService.java
@@ -1,0 +1,123 @@
+package com.materiel.suite.client.service.api;
+
+import com.materiel.suite.client.net.RestClient;
+import com.materiel.suite.client.net.SimpleJson;
+import com.materiel.suite.client.service.DocumentTemplateService;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/** Client REST léger pour la gestion des templates HTML. */
+public class ApiDocumentTemplateService implements DocumentTemplateService {
+  private final RestClient rc;
+  private final DocumentTemplateService fallback;
+
+  public ApiDocumentTemplateService(RestClient rc, DocumentTemplateService fallback){
+    this.rc = rc;
+    this.fallback = fallback;
+  }
+
+  @Override
+  public List<Template> list(String type){
+    try {
+      String path = "/api/v2/templates";
+      if (type != null && !type.isBlank()){
+        path += "?type=" + URLEncoder.encode(type, StandardCharsets.UTF_8);
+      }
+      String json = rc.get(path);
+      Object parsed = SimpleJson.parse(json);
+      List<Object> arr = SimpleJson.asArr(parsed);
+      List<Template> result = new ArrayList<>();
+      for (Object item : arr){
+        result.add(fromMap(SimpleJson.asObj(item)));
+      }
+      return result;
+    } catch (Exception ex){
+      if (fallback != null){
+        return fallback.list(type);
+      }
+      throw new RuntimeException(ex);
+    }
+  }
+
+  @Override
+  public Template save(Template template){
+    try {
+      String json = rc.post("/api/v2/templates", toJson(template));
+      return fromMap(SimpleJson.asObj(SimpleJson.parse(json)));
+    } catch (Exception ex){
+      if (fallback != null){
+        return fallback.save(template);
+      }
+      throw new RuntimeException(ex);
+    }
+  }
+
+  @Override
+  public void delete(String id){
+    try {
+      rc.delete("/api/v2/templates/" + id);
+    } catch (Exception ex){
+      if (fallback != null){
+        fallback.delete(id);
+        return;
+      }
+      throw new RuntimeException(ex);
+    }
+  }
+
+  private Template fromMap(Map<String, Object> map){
+    Template t = new Template();
+    t.setId(SimpleJson.str(map.get("id")));
+    t.setAgencyId(SimpleJson.str(map.get("agencyId")));
+    t.setType(SimpleJson.str(map.get("type")));
+    t.setKey(SimpleJson.str(map.get("key")));
+    t.setName(SimpleJson.str(map.get("name")));
+    t.setContent(SimpleJson.str(map.get("content")));
+    return t;
+  }
+
+  private String toJson(Template template){
+    StringBuilder sb = new StringBuilder("{");
+    boolean first = true;
+    first = append(sb, first, "id", template.getId());
+    first = append(sb, first, "agencyId", template.getAgencyId());
+    first = append(sb, first, "type", template.getType());
+    first = append(sb, first, "key", template.getKey());
+    first = append(sb, first, "name", template.getName());
+    append(sb, first, "content", template.getContent());
+    sb.append('}');
+    return sb.toString();
+  }
+
+  private boolean append(StringBuilder sb, boolean first, String name, String value){
+    if (!first){
+      sb.append(',');
+    }
+    sb.append('"').append(name).append('"').append(':');
+    if (value == null){
+      sb.append("null");
+    } else {
+      sb.append('"').append(escape(value)).append('"');
+    }
+    return false;
+  }
+
+  private String escape(String value){
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < value.length(); i++){
+      char c = value.charAt(i);
+      if (c == '\\' || c == '"'){
+        sb.append('\\').append(c);
+      } else if (c < 0x20){
+        sb.append(String.format("\\u%04x", (int) c));
+      } else {
+        sb.append(c);
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/service/api/ApiMailService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/api/ApiMailService.java
@@ -4,8 +4,9 @@ import com.materiel.suite.client.net.RestClient;
 import com.materiel.suite.client.service.MailService;
 
 import java.util.Base64;
+import java.util.List;
 
-/** Client REST simple pour l'envoi d'email avec pièce jointe. */
+/** Client REST simple pour l'envoi d'email avec pièces jointes multiples. */
 public class ApiMailService implements MailService {
   private final RestClient rc;
   private final MailService fallback;
@@ -16,33 +17,63 @@ public class ApiMailService implements MailService {
   }
 
   @Override
-  public void sendWithAttachment(String to, String subject, String body,
-                                 String attachmentName, byte[] attachmentBytes, String contentType){
+  public void sendWithAttachments(List<String> to,
+                                  List<String> cc,
+                                  List<String> bcc,
+                                  String subject,
+                                  String body,
+                                  List<Attachment> attachments){
     try {
-      String payload = toJson(to, subject, body, attachmentName, attachmentBytes, contentType);
+      String payload = toJson(to, cc, bcc, subject, body, attachments);
       rc.post("/api/v2/mail/send", payload);
     } catch (Exception ex){
       if (fallback != null){
-        fallback.sendWithAttachment(to, subject, body, attachmentName, attachmentBytes, contentType);
+        fallback.sendWithAttachments(to, cc, bcc, subject, body, attachments);
       }
     }
   }
 
-  private String toJson(String to, String subject, String body,
-                        String attachmentName, byte[] attachmentBytes, String contentType){
+  private String toJson(List<String> to,
+                        List<String> cc,
+                        List<String> bcc,
+                        String subject,
+                        String body,
+                        List<Attachment> attachments){
     StringBuilder sb = new StringBuilder("{");
     boolean first = true;
-    first = appendStringField(sb, first, "to", to);
+    first = appendArray(sb, first, "to", to);
+    first = appendArray(sb, first, "cc", cc);
+    first = appendArray(sb, first, "bcc", bcc);
     first = appendStringField(sb, first, "subject", subject);
     first = appendStringField(sb, first, "body", body);
-    first = appendStringField(sb, first, "attachmentName", attachmentName);
-    first = appendStringField(sb, first, "contentType", contentType == null || contentType.isBlank() ? "application/octet-stream" : contentType);
-    String base64 = attachmentBytes == null || attachmentBytes.length == 0
-        ? ""
-        : Base64.getEncoder().encodeToString(attachmentBytes);
-    appendStringField(sb, first, "attachmentBase64", base64);
+    appendAttachments(sb, first, attachments);
     sb.append('}');
     return sb.toString();
+  }
+
+  private boolean appendArray(StringBuilder sb, boolean first, String name, List<String> values){
+    if (!first){
+      sb.append(',');
+    }
+    sb.append('"').append(name).append('"').append(':');
+    if (values == null){
+      sb.append("null");
+    } else {
+      sb.append('[');
+      for (int i = 0; i < values.size(); i++){
+        if (i > 0){
+          sb.append(',');
+        }
+        String value = values.get(i);
+        if (value == null){
+          sb.append("null");
+        } else {
+          sb.append('"').append(escape(value)).append('"');
+        }
+      }
+      sb.append(']');
+    }
+    return false;
   }
 
   private boolean appendStringField(StringBuilder sb, boolean first, String name, String value){
@@ -56,6 +87,43 @@ public class ApiMailService implements MailService {
       sb.append('"').append(escape(value)).append('"');
     }
     return false;
+  }
+
+  private void appendAttachments(StringBuilder sb, boolean first, List<Attachment> attachments){
+    if (!first){
+      sb.append(',');
+    }
+    sb.append("\"attachments\":");
+    if (attachments == null){
+      sb.append("null");
+      return;
+    }
+    sb.append('[');
+    for (int i = 0; i < attachments.size(); i++){
+      if (i > 0){
+        sb.append(',');
+      }
+      Attachment att = attachments.get(i);
+      if (att == null){
+        sb.append("null");
+        continue;
+      }
+      sb.append('{');
+      sb.append("\"name\":");
+      sb.append(att.name() == null ? "null" : '"' + escape(att.name()) + '"');
+      sb.append(',');
+      String ct = att.contentType() == null || att.contentType().isBlank()
+          ? "application/octet-stream" : att.contentType();
+      sb.append("\"contentType\":");
+      sb.append('"').append(escape(ct)).append('"');
+      sb.append(',');
+      sb.append("\"base64\":");
+      byte[] bytes = att.bytes();
+      String base64 = bytes == null || bytes.length == 0 ? "" : Base64.getEncoder().encodeToString(bytes);
+      sb.append('"').append(escape(base64)).append('"');
+      sb.append('}');
+    }
+    sb.append(']');
   }
 
   private String escape(String value){

--- a/client/src/main/java/com/materiel/suite/client/service/api/ApiPdfService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/api/ApiPdfService.java
@@ -1,0 +1,96 @@
+package com.materiel.suite.client.service.api;
+
+import com.materiel.suite.client.net.RestClient;
+import com.materiel.suite.client.service.PdfService;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Client REST pour le rendu PDF via l'API backend. */
+public class ApiPdfService implements PdfService {
+  private final RestClient rc;
+  private final PdfService fallback;
+
+  public ApiPdfService(RestClient rc, PdfService fallback){
+    this.rc = rc;
+    this.fallback = fallback;
+  }
+
+  @Override
+  public byte[] render(String html, Map<String, String> inlineImages, String baseUrl){
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("html", html == null ? "<html><body></body></html>" : html);
+    payload.put("inlineImages", inlineImages == null ? Map.of() : inlineImages);
+    if (baseUrl != null && !baseUrl.isBlank()){
+      payload.put("baseUrl", baseUrl);
+    }
+    try {
+      String json = toJson(payload);
+      return rc.postForBytes("/api/v2/pdf/render", json, "application/pdf");
+    } catch (Exception ex){
+      if (fallback != null){
+        return fallback.render(html, inlineImages, baseUrl);
+      }
+      throw new RuntimeException(ex);
+    }
+  }
+
+  private String toJson(Map<String, Object> payload){
+    StringBuilder sb = new StringBuilder("{");
+    boolean first = true;
+    for (Map.Entry<String, Object> entry : payload.entrySet()){
+      if (!first){
+        sb.append(',');
+      }
+      first = false;
+      sb.append('"').append(entry.getKey()).append('"').append(':');
+      Object value = entry.getValue();
+      if (value == null){
+        sb.append("null");
+      } else if (value instanceof String s){
+        sb.append('"').append(escape(s)).append('"');
+      } else if (value instanceof Map<?, ?> map){
+        appendMap(sb, map);
+      } else {
+        sb.append(value);
+      }
+    }
+    sb.append('}');
+    return sb.toString();
+  }
+
+  private void appendMap(StringBuilder sb, Map<?, ?> map){
+    sb.append('{');
+    boolean first = true;
+    for (Map.Entry<?, ?> e : map.entrySet()){
+      if (!first){
+        sb.append(',');
+      }
+      first = false;
+      Object key = e.getKey();
+      Object value = e.getValue();
+      sb.append('"').append(escape(key == null ? "" : key.toString())).append('"').append(':');
+      if (value == null){
+        sb.append("null");
+      } else {
+        sb.append('"').append(escape(value.toString())).append('"');
+      }
+    }
+    sb.append('}');
+  }
+
+  private String escape(String value){
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < value.length(); i++){
+      char c = value.charAt(i);
+      if (c == '\\' || c == '"'){
+        sb.append('\\').append(c);
+      } else if (c < 0x20){
+        sb.append(String.format("\\u%04x", (int) c));
+      } else {
+        sb.append(c);
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/service/mock/MockDocumentTemplateService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/mock/MockDocumentTemplateService.java
@@ -1,0 +1,72 @@
+package com.materiel.suite.client.service.mock;
+
+import com.materiel.suite.client.service.DocumentTemplateService;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Stockage en mémoire de templates HTML avec valeurs par défaut. */
+public class MockDocumentTemplateService implements DocumentTemplateService {
+  private final Map<String, Template> store = new ConcurrentHashMap<>();
+
+  public MockDocumentTemplateService(){
+    saveInternal(defaultTemplate("QUOTE", "default", "Modèle devis"));
+    saveInternal(defaultTemplate("INVOICE", "default", "Modèle facture"));
+  }
+
+  @Override
+  public List<Template> list(String type){
+    List<Template> result = new ArrayList<>();
+    for (Template t : store.values()){
+      if (type == null || type.equalsIgnoreCase(t.getType())){
+        result.add(copy(t));
+      }
+    }
+    return result;
+  }
+
+  @Override
+  public Template save(Template template){
+    Template copy = template == null ? new Template() : copy(template);
+    if (copy.getId() == null || copy.getId().isBlank()){
+      copy.setId(UUID.randomUUID().toString());
+    }
+    saveInternal(copy);
+    return copy(copy);
+  }
+
+  @Override
+  public void delete(String id){
+    if (id != null){
+      store.remove(id);
+    }
+  }
+
+  private void saveInternal(Template template){
+    store.put(template.getId(), copy(template));
+  }
+
+  private Template copy(Template src){
+    Template t = new Template();
+    t.setId(src.getId());
+    t.setAgencyId(src.getAgencyId());
+    t.setType(src.getType());
+    t.setKey(src.getKey());
+    t.setName(src.getName());
+    t.setContent(src.getContent());
+    return t;
+  }
+
+  private Template defaultTemplate(String type, String key, String name){
+    Template t = new Template();
+    t.setId(type.toLowerCase() + "-" + key);
+    t.setType(type);
+    t.setKey(key);
+    t.setName(name);
+    t.setContent("<html><body><h1>" + name + "</h1><p>{{agency.name}}</p></body></html>");
+    return t;
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/service/mock/MockMailService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/mock/MockMailService.java
@@ -2,12 +2,27 @@ package com.materiel.suite.client.service.mock;
 
 import com.materiel.suite.client.service.MailService;
 
+import java.util.List;
+
 /** Implémentation mock qui trace l'envoi d'email dans la console. */
 public class MockMailService implements MailService {
   @Override
-  public void sendWithAttachment(String to, String subject, String body,
-                                 String attachmentName, byte[] attachmentBytes, String contentType){
-    int size = attachmentBytes == null ? 0 : attachmentBytes.length;
-    System.out.println("[MOCK MAIL] to=" + to + " subject=" + subject + " attachment=" + attachmentName + " size=" + size);
+  public void sendWithAttachments(List<String> to,
+                                  List<String> cc,
+                                  List<String> bcc,
+                                  String subject,
+                                  String body,
+                                  List<Attachment> attachments){
+    int size = 0;
+    if (attachments != null){
+      for (Attachment att : attachments){
+        if (att != null && att.bytes() != null){
+          size += att.bytes().length;
+        }
+      }
+    }
+    System.out.println("[MOCK MAIL] to=" + to + " cc=" + cc + " bcc=" + bcc
+        + " subject=" + subject + " attachments=" + (attachments == null ? 0 : attachments.size())
+        + " size=" + size);
   }
 }

--- a/client/src/main/java/com/materiel/suite/client/service/mock/MockPdfService.java
+++ b/client/src/main/java/com/materiel/suite/client/service/mock/MockPdfService.java
@@ -1,0 +1,37 @@
+package com.materiel.suite.client.service.mock;
+
+import com.materiel.suite.client.service.PdfService;
+import com.materiel.suite.client.ui.sales.pdf.PdfMini;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Map;
+
+/** Implémentation mock : convertit grossièrement le HTML en PDF texte. */
+public class MockPdfService implements PdfService {
+  @Override
+  public byte[] render(String html, Map<String, String> inlineImages, String baseUrl){
+    try {
+      PdfMini pdf = new PdfMini();
+      pdf.addTitle("Aperçu PDF (mock)");
+      pdf.addParagraph(strip(html));
+      File tmp = File.createTempFile("mock-pdf-", ".pdf");
+      try {
+        pdf.save(tmp);
+        return Files.readAllBytes(tmp.toPath());
+      } finally {
+        //noinspection ResultOfMethodCallIgnored
+        tmp.delete();
+      }
+    } catch (Exception ex){
+      return new byte[0];
+    }
+  }
+
+  private String strip(String html){
+    if (html == null){
+      return "";
+    }
+    return html.replaceAll("<[^>]+>", " ").replaceAll("\\s+", " ").trim();
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/sales/EmailPrompt.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/sales/EmailPrompt.java
@@ -2,10 +2,14 @@ package com.materiel.suite.client.ui.sales;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
 
-/** Boîte de dialogue minimale pour saisir les informations d'envoi d'email. */
+/** Boîte de dialogue pour saisir les informations d'envoi d'email. */
 public class EmailPrompt extends JDialog {
   private final JTextField toField = new JTextField(28);
+  private final JTextField ccField = new JTextField(28);
+  private final JTextField bccField = new JTextField(28);
   private final JTextField subjectField = new JTextField(28);
   private final JTextArea bodyArea = new JTextArea(6, 28);
   private boolean confirmed;
@@ -18,11 +22,27 @@ public class EmailPrompt extends JDialog {
     gc.gridx = 0;
     gc.gridy = 0;
     gc.anchor = GridBagConstraints.LINE_END;
-    add(new JLabel("À"), gc);
+    add(new JLabel("À (séparés par ,)"), gc);
     gc.gridx = 1;
     gc.anchor = GridBagConstraints.LINE_START;
     gc.fill = GridBagConstraints.HORIZONTAL;
     add(toField, gc);
+
+    gc.gridx = 0;
+    gc.gridy++;
+    gc.anchor = GridBagConstraints.LINE_END;
+    add(new JLabel("CC"), gc);
+    gc.gridx = 1;
+    gc.anchor = GridBagConstraints.LINE_START;
+    add(ccField, gc);
+
+    gc.gridx = 0;
+    gc.gridy++;
+    gc.anchor = GridBagConstraints.LINE_END;
+    add(new JLabel("BCC"), gc);
+    gc.gridx = 1;
+    gc.anchor = GridBagConstraints.LINE_START;
+    add(bccField, gc);
 
     gc.gridx = 0;
     gc.gridy++;
@@ -67,7 +87,7 @@ public class EmailPrompt extends JDialog {
     setLocationRelativeTo(owner);
   }
 
-  public record Result(String to, String subject, String body){}
+  public record Result(List<String> to, List<String> cc, List<String> bcc, String subject, String body){}
 
   public static Result ask(Component parent, String title){
     Window window = parent == null ? null : SwingUtilities.getWindowAncestor(parent);
@@ -76,6 +96,24 @@ public class EmailPrompt extends JDialog {
     if (!dialog.confirmed){
       return null;
     }
-    return new Result(dialog.toField.getText().trim(), dialog.subjectField.getText().trim(), dialog.bodyArea.getText());
+    return new Result(split(dialog.toField.getText()),
+        split(dialog.ccField.getText()),
+        split(dialog.bccField.getText()),
+        dialog.subjectField.getText().trim(),
+        dialog.bodyArea.getText());
+  }
+
+  private static List<String> split(String value){
+    List<String> out = new ArrayList<>();
+    if (value == null){
+      return out;
+    }
+    for (String part : value.split(",")){
+      String trimmed = part.trim();
+      if (!trimmed.isEmpty()){
+        out.add(trimmed);
+      }
+    }
+    return out;
   }
 }

--- a/client/src/main/java/com/materiel/suite/client/ui/sales/PdfTemplateEngine.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/sales/PdfTemplateEngine.java
@@ -1,0 +1,178 @@
+package com.materiel.suite.client.ui.sales;
+
+import com.materiel.suite.client.model.InvoiceV2;
+import com.materiel.suite.client.model.QuoteV2;
+import com.materiel.suite.client.service.DocumentTemplateService;
+import com.materiel.suite.client.service.PdfService;
+import com.materiel.suite.client.service.ServiceLocator;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+
+/** Fusion très simple {{var}} + appel backend HTML->PDF. */
+public final class PdfTemplateEngine {
+  private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ISO_LOCAL_DATE;
+
+  private PdfTemplateEngine(){
+  }
+
+  public static byte[] renderQuote(QuoteV2 quote, String logoBase64){
+    String html = loadTemplate("QUOTE", "default", defaultQuoteTemplate());
+    html = merge(html, Map.of(
+        "agency.name", nz(ServiceLocator.agencyLabel()),
+        "client.name", nz(quote == null ? null : quote.getClientName()),
+        "quote.reference", nz(quote == null ? null : quote.getReference()),
+        "quote.date", formatDate(quote == null ? null : quote.getDate()),
+        "quote.totalHt", formatAmount(quote == null ? null : quote.getTotalHt()),
+        "quote.totalTtc", formatAmount(quote == null ? null : quote.getTotalTtc())
+    ));
+    html = html.replace("{{logo.cdi}}", logoBase64 == null ? "" : "cid:logo");
+    return renderHtml(html, logoBase64);
+  }
+
+  public static byte[] renderInvoice(InvoiceV2 invoice, String logoBase64){
+    String html = loadTemplate("INVOICE", "default", defaultInvoiceTemplate());
+    html = merge(html, Map.of(
+        "agency.name", nz(ServiceLocator.agencyLabel()),
+        "client.name", nz(invoice == null ? null : invoice.getClientName()),
+        "invoice.number", nz(invoice == null ? null : nz(invoice.getNumber(), invoice.getId())),
+        "invoice.date", formatDate(invoice == null ? null : invoice.getDate()),
+        "invoice.totalHt", formatAmount(invoice == null ? null : invoice.getTotalHt()),
+        "invoice.totalTtc", formatAmount(invoice == null ? null : invoice.getTotalTtc()),
+        "invoice.status", nz(invoice == null ? null : invoice.getStatus())
+    ));
+    html = html.replace("{{logo.cdi}}", logoBase64 == null ? "" : "cid:logo");
+    return renderHtml(html, logoBase64);
+  }
+
+  private static String loadTemplate(String type, String key, String fallback){
+    DocumentTemplateService svc = ServiceLocator.documentTemplates();
+    if (svc != null){
+      try {
+        List<DocumentTemplateService.Template> list = svc.list(type);
+        for (DocumentTemplateService.Template template : list){
+          if (template.getKey() != null && template.getKey().equalsIgnoreCase(key)){
+            String content = template.getContent();
+            if (content != null && !content.isBlank()){
+              return content;
+            }
+          }
+        }
+      } catch (Exception ignore){
+        // fallback below
+      }
+    }
+    return fallback;
+  }
+
+  private static String merge(String template, Map<String, String> values){
+    String out = template;
+    for (Map.Entry<String, String> entry : values.entrySet()){
+      out = out.replace("{{" + entry.getKey() + "}}", entry.getValue() == null ? "" : entry.getValue());
+    }
+    return out;
+  }
+
+  private static byte[] renderHtml(String html, String logoBase64){
+    PdfService svc = ServiceLocator.pdf();
+    if (svc == null){
+      throw new IllegalStateException("Service PDF indisponible");
+    }
+    Map<String, String> images = (logoBase64 == null || logoBase64.isBlank())
+        ? Map.of()
+        : Map.of("logo", logoBase64);
+    return svc.render(html, images, null);
+  }
+
+  private static String formatAmount(BigDecimal amount){
+    if (amount == null){
+      return "0.00";
+    }
+    return amount.setScale(2, java.math.RoundingMode.HALF_UP).toPlainString();
+  }
+
+  private static String formatDate(LocalDate date){
+    return date == null ? "" : DATE_FMT.format(date);
+  }
+
+  private static String nz(String value){
+    return value == null ? "" : value;
+  }
+
+  private static String nz(String value, String fallback){
+    if (value == null || value.isBlank()){
+      return fallback == null ? "" : fallback;
+    }
+    return value;
+  }
+
+  private static String defaultQuoteTemplate(){
+    return """
+<!DOCTYPE html><html><head><meta charset=\"UTF-8\">
+<style>
+  body{ font-family: DejaVu Sans, Arial, sans-serif; font-size: 12px; }
+  .header{ display:flex; justify-content:space-between; align-items:center; }
+  .title{ font-size:20px; font-weight:bold; }
+  table{ width:100%; border-collapse:collapse; margin-top:14px;}
+  th,td{ border:1px solid #ddd; padding:6px; }
+  th{ background:#f5f5f5; text-align:left; }
+  .totals{ margin-top:12px; float:right; width:40%; }
+  .totals td{ border:none; }
+</style></head><body>
+  <div class=\"header\">
+    <div><div class=\"title\">Devis {{quote.reference}}</div><div>Agence: {{agency.name}}</div></div>
+    <div><img src=\"{{logo.cdi}}\" style=\"height:60px\" /></div>
+  </div>
+  <div>Client: <b>{{client.name}}</b></div>
+  <div>Date: {{quote.date}}</div>
+  <table>
+    <thead><tr><th>Désignation</th><th>Qté</th><th>PU HT</th><th>Total HT</th></tr></thead>
+    <tbody>
+      <tr><td>Ligne exemple</td><td>1</td><td>100.00</td><td>100.00</td></tr>
+    </tbody>
+  </table>
+  <table class=\"totals\">
+    <tr><td>Total HT</td><td style=\"text-align:right\">{{quote.totalHt}} €</td></tr>
+    <tr><td>Total TTC</td><td style=\"text-align:right\"><b>{{quote.totalTtc}} €</b></td></tr>
+  </table>
+</body></html>
+""";
+  }
+
+  private static String defaultInvoiceTemplate(){
+    return """
+<!DOCTYPE html><html><head><meta charset=\"UTF-8\">
+<style>
+  body{ font-family: DejaVu Sans, Arial, sans-serif; font-size: 12px; }
+  .header{ display:flex; justify-content:space-between; align-items:center; }
+  .title{ font-size:20px; font-weight:bold; }
+  table{ width:100%; border-collapse:collapse; margin-top:14px;}
+  th,td{ border:1px solid #ddd; padding:6px; }
+  th{ background:#f5f5f5; text-align:left; }
+  .totals{ margin-top:12px; float:right; width:40%; }
+  .totals td{ border:none; }
+</style></head><body>
+  <div class=\"header\">
+    <div><div class=\"title\">Facture {{invoice.number}}</div><div>Agence: {{agency.name}}</div></div>
+    <div><img src=\"{{logo.cdi}}\" style=\"height:60px\" /></div>
+  </div>
+  <div>Client: <b>{{client.name}}</b></div>
+  <div>Date: {{invoice.date}}</div>
+  <table>
+    <thead><tr><th>Désignation</th><th>Qté</th><th>PU HT</th><th>Total HT</th></tr></thead>
+    <tbody>
+      <tr><td>Ligne exemple</td><td>1</td><td>100.00</td><td>100.00</td></tr>
+    </tbody>
+  </table>
+  <table class=\"totals\">
+    <tr><td>Total HT</td><td style=\"text-align:right\">{{invoice.totalHt}} €</td></tr>
+    <tr><td>Total TTC</td><td style=\"text-align:right\"><b>{{invoice.totalTtc}} €</b></td></tr>
+    <tr><td>Statut</td><td style=\"text-align:right\">{{invoice.status}}</td></tr>
+  </table>
+</body></html>
+""";
+  }
+}


### PR DESCRIPTION
## Summary
- add backend HTML-to-PDF rendering and template management endpoints backed by OpenHTMLToPDF
- extend client services for PDF rendering, template storage, and multi-recipient mail payloads
- expose detailed PDF exports and CC/BCC email options in the sales UI

## Testing
- mvn -pl backend -am test *(fails: cannot download dependencies because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ecf6406c8330a31312908a2ab56a