### PR TITLE
Handle blanks in PDF render payload

### DIFF
--- a/server/src/main/java/com/materiel/suite/server/api/v2/pdf/PdfRenderControllerV2.java
+++ b/server/src/main/java/com/materiel/suite/server/api/v2/pdf/PdfRenderControllerV2.java
@@ -1,0 +1,52 @@
+package com.materiel.suite.server.api.v2.pdf;
+
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v2/pdf")
+public class PdfRenderControllerV2 {
+
+  public record RenderPayload(String html, Map<String,String> inlineImages, String baseUrl){}
+
+  @PostMapping("/render")
+  public ResponseEntity<byte[]> render(@RequestBody RenderPayload p){
+    try{
+      String html = (p.html()==null || p.html().isBlank()) ? "<html><body></body></html>" : p.html();
+      String base = (p.baseUrl()==null || p.baseUrl().isBlank()) ? null : p.baseUrl();
+      if(p.inlineImages()!=null && !p.inlineImages().isEmpty()){
+        for(var e : p.inlineImages().entrySet()){
+          String id = e.getKey();
+          String b64 = e.getValue();
+          if(id==null || id.isBlank() || b64==null || b64.isBlank()) continue;
+          html = html.replace("cid:"+id, "data:image/png;base64,"+b64);
+        }
+      }
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      PdfRendererBuilder b = new PdfRendererBuilder();
+      b.useFastMode();
+      b.withHtmlContent(html, base);
+      b.toStream(baos);
+      b.run();
+      byte[] pdf = baos.toByteArray();
+      return ResponseEntity.ok()
+          .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=document.pdf")
+          .contentType(MediaType.APPLICATION_PDF)
+          .body(pdf);
+    }catch(Exception ex){
+      return ResponseEntity.badRequest()
+          .contentType(MediaType.TEXT_PLAIN)
+          .body(("PDF render error: "+ex.getMessage()).getBytes(StandardCharsets.UTF_8));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add the v2 PDF render controller with safer defaults for empty HTML and base URLs
- ignore inline image entries that are null or blank when inlining
- keep PDF rendering logic in place while returning a predictable fallback document

## Testing
- `mvn -pl backend -am -DskipTests package` *(fails: unable to reach Maven Central from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d100392c948330858d37ce4d329600