### PR TITLE
Add email template support to sales emails

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/service/ServiceLocator.java
+++ b/client/src/main/java/com/materiel/suite/client/service/ServiceLocator.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 public final class ServiceLocator {
   private static final ResourcesGateway RESOURCES = new ResourcesGateway();
   private static final InterventionTypesGateway INTERVENTION_TYPES = new InterventionTypesGateway();
+  private static final TemplatesGateway TEMPLATES = new TemplatesGateway();
 
   private static SettingsService SETTINGS;
 
@@ -74,6 +75,10 @@ public final class ServiceLocator {
 
   public static DocumentTemplateService documentTemplates(){
     return ServiceFactory.documentTemplates();
+  }
+
+  public static TemplatesGateway templates(){
+    return TEMPLATES;
   }
 
   public static PdfService pdf(){

--- a/client/src/main/java/com/materiel/suite/client/service/TemplatesGateway.java
+++ b/client/src/main/java/com/materiel/suite/client/service/TemplatesGateway.java
@@ -1,0 +1,58 @@
+package com.materiel.suite.client.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Accès simplifié aux templates HTML depuis l'interface. */
+public final class TemplatesGateway {
+
+  public List<Template> list(String type){
+    DocumentTemplateService svc = ServiceLocator.documentTemplates();
+    if (svc == null){
+      return List.of();
+    }
+    try {
+      List<DocumentTemplateService.Template> templates = svc.list(type);
+      if (templates == null || templates.isEmpty()){
+        return List.of();
+      }
+      List<Template> out = new ArrayList<>();
+      for (DocumentTemplateService.Template template : templates){
+        Template copy = copy(template);
+        if (copy != null){
+          out.add(copy);
+        }
+      }
+      return out.isEmpty() ? List.of() : List.copyOf(out);
+    } catch (Exception ignore){
+      return List.of();
+    }
+  }
+
+  private Template copy(DocumentTemplateService.Template template){
+    if (template == null){
+      return null;
+    }
+    return new Template(
+        template.getId(),
+        template.getAgencyId(),
+        template.getType(),
+        template.getKey(),
+        template.getName(),
+        template.getContent()
+    );
+  }
+
+  public record Template(String id, String agencyId, String type, String key, String name, String content) {
+    @Override
+    public String toString(){
+      if (name != null && !name.isBlank()){
+        return name;
+      }
+      if (key != null && !key.isBlank()){
+        return key;
+      }
+      return id == null ? "" : id;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a TemplatesGateway and expose it via the service locator
- extend the email prompt to load templates and merge context variables
- use the new prompt in the sales panel to prefill quote and invoice emails

## Testing
- mvn -pl client -am -DskipTests compile *(fails: unable to reach Maven Central in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1035614dc8330b0380de7b447571b