### PR TITLE
feat: add html validation and mobile preview options

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/ui/common/HtmlEditorPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/common/HtmlEditorPanel.java
@@ -21,6 +21,8 @@ public class HtmlEditorPanel extends JPanel {
   private final JTextArea source = new JTextArea();
   private final HTMLEditorKit kit = new HTMLEditorKit();
   private final JToolBar toolbar = new JToolBar();
+  private final JButton validateBtn = new JButton("Valider HTML");
+  private final JLabel validationLabel = new JLabel(" ");
 
   public HtmlEditorPanel(){
     super(new BorderLayout());
@@ -65,6 +67,12 @@ public class HtmlEditorPanel extends JPanel {
     toolbar.add(action("Lien", e -> insert("<a href=\"https://\">lien</a>"), "Insérer un lien"));
     toolbar.add(action("Image", e -> insert("<img src=\"cid:logo\" style=\"max-width:200px\"/>")
         , "Insérer une image (cid)"));
+    toolbar.add(Box.createHorizontalStrut(16));
+    toolbar.add(validateBtn);
+    toolbar.add(Box.createHorizontalStrut(8));
+    validationLabel.setForeground(new java.awt.Color(0x33, 0x66, 0x33));
+    toolbar.add(validationLabel);
+    validateBtn.addActionListener(e -> runValidation());
   }
 
   private AbstractAction action(String label, Consumer<ActionEvent> fn, String tip){
@@ -143,6 +151,20 @@ public class HtmlEditorPanel extends JPanel {
       return source.getText();
     }
     return readDesignHtml();
+  }
+
+  private void runValidation(){
+    String html = getHtml();
+    HtmlValidation.Result r = HtmlValidation.validate(html);
+    if (r.ok){
+      validationLabel.setForeground(new java.awt.Color(0x2e, 0x7d, 0x32));
+      validationLabel.setText("HTML valide");
+      validationLabel.setToolTipText(null);
+    } else {
+      validationLabel.setForeground(new java.awt.Color(0xc6, 0x28, 0x28));
+      validationLabel.setText("⚠ " + r.message);
+      validationLabel.setToolTipText(r.details);
+    }
   }
 
   /** Ouvre un éditeur HTML modal en mode plein écran. */

--- a/client/src/main/java/com/materiel/suite/client/ui/common/HtmlValidation.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/common/HtmlValidation.java
@@ -1,0 +1,69 @@
+package com.materiel.suite.client.ui.common;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Validation HTML très simple : équilibre des balises / imbrication. */
+public final class HtmlValidation {
+  private HtmlValidation(){
+  }
+
+  public static class Result {
+    public final boolean ok;
+    public final String message;
+    public final String details;
+
+    public Result(boolean ok, String message, String details){
+      this.ok = ok;
+      this.message = message;
+      this.details = details;
+    }
+  }
+
+  private static final Set<String> VOID = Set.of(
+      "br", "hr", "img", "input", "meta", "link", "area", "base", "col", "embed", "param",
+      "source", "track", "wbr");
+  private static final Pattern TAG = Pattern.compile("<\\s*(/)?\\s*([A-Za-z0-9]+)([^>]*)>");
+
+  public static Result validate(String html){
+    if (html == null || html.isBlank()){
+      return new Result(true, "Vide", "Document vide");
+    }
+    Deque<String> stack = new ArrayDeque<>();
+    StringBuilder problems = new StringBuilder();
+    Matcher matcher = TAG.matcher(html);
+    while (matcher.find()){
+      boolean closing = matcher.group(1) != null;
+      String name = matcher.group(2).toLowerCase(Locale.ROOT);
+      String tail = matcher.group(3) == null ? "" : matcher.group(3);
+      boolean selfClose = tail.contains("/>");
+      if (VOID.contains(name) || selfClose){
+        continue;
+      }
+      if (!closing){
+        stack.push(name);
+      } else if (stack.isEmpty()){
+        problems.append("Balise fermante sans ouvrante: </").append(name).append(">\n");
+      } else {
+        String open = stack.pop();
+        if (!open.equals(name)){
+          problems.append("Imbrication incohérente: attendu </").append(open).append(">, trouvé </")
+              .append(name).append(">\n");
+        }
+      }
+    }
+    if (!stack.isEmpty()){
+      problems.append("Balises non fermées: ").append(String.join(", ", stack)).append("\n");
+    }
+    String issues = problems.toString();
+    if (!issues.isEmpty()){
+      issues = issues.stripTrailing();
+    }
+    boolean ok = issues.isEmpty();
+    return new Result(ok, ok ? "OK" : "Erreurs HTML", issues);
+  }
+}


### PR DESCRIPTION
## Summary
- add a validation button and status indicator to the reusable HTML editor toolbar
- introduce a lightweight HtmlValidation helper to detect common tag nesting errors
- enhance the email prompt preview with validation, mobile viewport toggle, and viewport meta tag

## Testing
- mvn -pl client -am -DskipTests compile *(fails: unable to reach repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d1114e29208330b07ecf3976a17164