### PR TITLE
Improve top alignment utilities for settings forms

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/ui/common/TopAligned.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/common/TopAligned.java
@@ -33,4 +33,40 @@ public final class TopAligned {
     scrollPane.getViewport().setBackground(formPanel.getBackground());
     return scrollPane;
   }
+
+  /**
+   * Force l'alignement haut d'un formulaire déjà inséré dans un conteneur.
+   *
+   * <p>Si le panneau est déjà placé dans une {@link JScrollPane}, aucune action n'est effectuée.
+   * Dans le cas contraire, la zone {@link BorderLayout#CENTER} est remplacée par la variante
+   * scrollable produite par {@link #wrap(JComponent)}.</p>
+   *
+   * @param root conteneur parent, supposé utiliser un {@link BorderLayout}
+   * @param formPanel panneau de formulaire à réaligner
+   */
+  public static void enforceOn(Container root, JComponent formPanel){
+    if (root == null){
+      throw new IllegalArgumentException("root cannot be null");
+    }
+    if (formPanel == null){
+      throw new IllegalArgumentException("formPanel cannot be null");
+    }
+    if (SwingUtilities.getAncestorOfClass(JScrollPane.class, formPanel) != null){
+      return;
+    }
+
+    JComponent wrapped = wrap(formPanel);
+    if (root.getLayout() instanceof BorderLayout layout){
+      for (Component component : root.getComponents()){
+        Object constraint = layout.getConstraints(component);
+        if (constraint == null || BorderLayout.CENTER.equals(constraint)){
+          root.remove(component);
+          break;
+        }
+      }
+      root.add(wrapped, BorderLayout.CENTER);
+      root.revalidate();
+      root.repaint();
+    }
+  }
 }

--- a/client/src/main/java/com/materiel/suite/client/ui/settings/GeneralSettingsPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/settings/GeneralSettingsPanel.java
@@ -220,6 +220,19 @@ public class GeneralSettingsPanel extends JPanel {
     form.add(new JScrollPane(cgvTextArea), gc);
     gc.fill = GridBagConstraints.HORIZONTAL;
 
+    row++;
+    gc.gridx = 0;
+    gc.gridy = row;
+    gc.gridwidth = 2;
+    gc.weightx = 1;
+    gc.weighty = 1;
+    gc.fill = GridBagConstraints.BOTH;
+    form.add(Box.createVerticalGlue(), gc);
+    gc.gridwidth = 1;
+    gc.weighty = 0;
+    gc.weightx = 0;
+    gc.fill = GridBagConstraints.HORIZONTAL;
+
     JButton save = new JButton("Enregistrer");
     boolean canEdit = AccessControl.canEditSettings();
     timeoutSpinner.setEnabled(canEdit);

--- a/client/src/main/java/com/materiel/suite/client/ui/settings/SettingsPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/settings/SettingsPanel.java
@@ -30,6 +30,7 @@ public class SettingsPanel extends JPanel {
     }
 
     JTabbedPane tabs = new JTabbedPane();
+    // Formulaires scrollables alignés en haut pour éviter l'espace vide excessif
     tabs.addTab("Général", IconRegistry.small("lock"), TopAligned.wrap(new GeneralSettingsPanel()));
     tabs.addTab("Email", IconRegistry.small("info"), TopAligned.wrap(new EmailSettingsPanel()));
     tabs.addTab("Modèles", IconRegistry.small("file"), TopAligned.wrap(new TemplatesSettingsPanel()));


### PR DESCRIPTION
## Summary
- add a `TopAligned.enforceOn` helper to retrofit scrollable top alignment on existing containers
- ensure the general settings form keeps its content glued to the top when extra space is available
- document the intent to keep settings forms top-aligned within the tabbed pane

## Testing
- mvn -pl client -am test *(fails: network is unreachable when downloading spring-boot-dependencies from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d25d75d584833081ccbf54a9568979