### PR TITLE
Handle planning board zoom compatibility

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
@@ -849,10 +849,28 @@ public class PlanningPanel extends JPanel {
 
   private void applyZoom(){
     int width = sliderToSlotWidth(zoomSlider.getValue());
-    board.setZoom(width);
+    // Préférence : API setSlotWidth (zone centrale). Fallback : setZoom si c'est ta version.
+    boolean applied = false;
+    try {
+      var method = board.getClass().getMethod("setSlotWidth", int.class);
+      method.invoke(board, width);
+      applied = true;
+    } catch (Exception ignore) {
+      try {
+        var fallback = board.getClass().getMethod("setZoom", int.class);
+        fallback.invoke(board, width);
+        applied = true;
+      } catch (Exception ignore2) {
+        // no-op
+      }
+    }
+    // Largeur de journée côté vue agenda (si utilisée)
     agenda.setDayWidth(width * 10);
-    board.revalidate();
-    board.repaint();
+    // Forcer un relayout/repaint du board et des entêtes
+    if (applied){
+      board.revalidate();
+      board.repaint();
+    }
     pushVisibleWindowToBoard();
     revalidate();
     repaint();


### PR DESCRIPTION
## Summary
- update the planning zoom logic to prefer the new setSlotWidth API with a reflection fallback to setZoom
- keep agenda day width updates while only revalidating the board when a zoom change was applied

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d298b52c34833090cabbd40893d829