### PR TITLE
Add separator around selection counters in planning context bar

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
@@ -328,11 +328,15 @@ public class PlanningPanel extends JPanel {
     contextWeekPill.setToolTipText("Période active");
     bulkBar.add(contextWeekPill);
     bulkBar.add(Box.createHorizontalStrut(14));
+    JSeparator selectionSeparator = new JSeparator(SwingConstants.VERTICAL);
+    selectionSeparator.setPreferredSize(new Dimension(1, 20));
+    bulkBar.add(selectionSeparator);
+    bulkBar.add(Box.createHorizontalStrut(14));
     bulkBar.add(selCountLabel);
     bulkBar.add(Box.createHorizontalStrut(12));
-    JSeparator bulkSep = new JSeparator(SwingConstants.VERTICAL);
-    bulkSep.setPreferredSize(new Dimension(1, 24));
-    bulkBar.add(bulkSep);
+    JSeparator actionsSeparator = new JSeparator(SwingConstants.VERTICAL);
+    actionsSeparator.setPreferredSize(new Dimension(1, 24));
+    bulkBar.add(actionsSeparator);
     bulkBar.add(Box.createHorizontalStrut(12));
     bulkBar.add(dryRunBtn);
     bulkBar.add(bulkQuoteBtn);


### PR DESCRIPTION
## Summary
- insert a dedicated vertical separator between the active week pill and the selection counters in the planning context bar
- keep the actions block visually isolated by renaming the separator for clarity

## Testing
- `mvn -pl client -am -DskipTests package` *(fails: cannot reach Maven Central from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b68e7ba48330bf1a9c8c289f6800