### PR TITLE
test: cover pdf, mail and template controllers

### DIFF
--- a/backend/src/test/java/com/materiel/suite/backend/web/MailControllerTest.java
+++ b/backend/src/test/java/com/materiel/suite/backend/web/MailControllerTest.java
@@ -1,0 +1,51 @@
+package com.materiel.suite.backend.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MailControllerTest {
+
+  private final MailController controller = new MailController();
+
+  @Test
+  void sendWithAttachmentsReturnsQueued(){
+    String pdfBase64 = Base64.getEncoder().encodeToString("demo".getBytes(StandardCharsets.UTF_8));
+    MailController.MailPayload payload = new MailController.MailPayload(
+        List.of("to@example.test"),
+        List.of("cc@example.test"),
+        List.of("bcc@example.test"),
+        "Subject",
+        "<p>Body</p>",
+        List.of(new MailController.MailPayload.Attachment("doc.pdf", "application/pdf", pdfBase64))
+    );
+
+    ResponseEntity<String> response = controller.send(payload);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals("queued", response.getBody());
+  }
+
+  @Test
+  void sendIgnoresInvalidBase64(){
+    MailController.MailPayload payload = new MailController.MailPayload(
+        List.of("to@example.test"),
+        List.of(),
+        List.of(),
+        "Sujet",
+        "Body",
+        List.of(new MailController.MailPayload.Attachment("broken.txt", "text/plain", "???invalid???"))
+    );
+
+    ResponseEntity<String> response = controller.send(payload);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals("queued", response.getBody());
+  }
+}

--- a/backend/src/test/java/com/materiel/suite/backend/web/PdfRenderControllerTest.java
+++ b/backend/src/test/java/com/materiel/suite/backend/web/PdfRenderControllerTest.java
@@ -1,0 +1,47 @@
+package com.materiel.suite.backend.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PdfRenderControllerTest {
+
+  private final PdfRenderController controller = new PdfRenderController();
+
+  @Test
+  void renderMinimalHtmlProducesPdfHeader(){
+    PdfRenderController.RenderPayload payload = new PdfRenderController.RenderPayload(
+        "<html><body><h1>Test</h1></body></html>", Map.of(), null);
+
+    ResponseEntity<byte[]> response = controller.render(payload);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode(), "render should succeed");
+    byte[] body = response.getBody();
+    assertNotNull(body, "pdf body");
+    assertTrue(body.length > 4, "pdf must not be empty");
+    assertEquals('%', body[0], "PDF signature 0");
+    assertEquals('P', body[1], "PDF signature 1");
+    assertEquals('D', body[2], "PDF signature 2");
+    assertEquals('F', body[3], "PDF signature 3");
+  }
+
+  @Test
+  void renderSupportsInlineImages(){
+    String html = "<html><body><img src=\"cid:logo\"/></body></html>";
+    Map<String, String> inline = Map.of(
+        "logo", "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wIAAgMBAp0NtwAAAABJRU5ErkJggg=="
+    );
+    PdfRenderController.RenderPayload payload = new PdfRenderController.RenderPayload(html, inline, null);
+
+    ResponseEntity<byte[]> response = controller.render(payload);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode(), "render should succeed with inline images");
+    byte[] body = response.getBody();
+    assertNotNull(body);
+    assertTrue(body.length > 4);
+  }
+}

--- a/backend/src/test/java/com/materiel/suite/backend/web/TemplateControllerTest.java
+++ b/backend/src/test/java/com/materiel/suite/backend/web/TemplateControllerTest.java
@@ -1,0 +1,80 @@
+package com.materiel.suite.backend.web;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TemplateControllerTest {
+
+  private final TemplateController controller = new TemplateController();
+
+  @BeforeEach
+  void clearBefore(){
+    clearStore();
+  }
+
+  @AfterEach
+  void clearAfter(){
+    clearStore();
+  }
+
+  @Test
+  void listIsEmptyByDefault(){
+    List<TemplateController.TemplateDto> all = controller.list(null, null);
+    assertTrue(all.isEmpty(), "store should start empty");
+  }
+
+  @Test
+  void upsertStoresTemplateForAgencyAndType(){
+    TemplateController.TemplateDto input = new TemplateController.TemplateDto(
+        null,
+        "agency-A",
+        TemplateController.TemplateType.QUOTE,
+        "default",
+        "Devis par défaut",
+        "<h1>Quote</h1>"
+    );
+
+    TemplateController.TemplateDto saved = controller.upsert("agency-A", input);
+
+    assertNotNull(saved.id(), "id generated");
+    assertEquals("agency-A", saved.agencyId(), "agency resolved");
+
+    List<TemplateController.TemplateDto> sameAgency = controller.list("agency-A", TemplateController.TemplateType.QUOTE);
+    assertEquals(1, sameAgency.size(), "template visible for matching agency/type");
+
+    List<TemplateController.TemplateDto> otherAgency = controller.list("agency-B", TemplateController.TemplateType.QUOTE);
+    assertTrue(otherAgency.isEmpty(), "other agencies should not see template");
+
+    controller.delete(saved.id());
+
+    assertTrue(controller.list("agency-A", TemplateController.TemplateType.QUOTE).isEmpty(), "template removed after delete");
+  }
+
+  @Test
+  void upsertUsesHeaderAgencyWhenBodyMissing(){
+    TemplateController.TemplateDto input = new TemplateController.TemplateDto(
+        null,
+        null,
+        TemplateController.TemplateType.EMAIL,
+        "newsletter",
+        "Newsletter",
+        "<h1>Bonjour</h1>"
+    );
+
+    TemplateController.TemplateDto saved = controller.upsert("agency-Z", input);
+    assertEquals("agency-Z", saved.agencyId(), "agency comes from header when body missing");
+  }
+
+  private void clearStore(){
+    controller.list(null, null).forEach(t -> {
+      if (t != null && t.id() != null){
+        controller.delete(t.id());
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add unit tests for the PDF rendering controller to ensure successful output and inline image handling
- cover the template API with scenarios around filtering, agency resolution and deletion
- add mail controller tests that verify attachment decoding and resilience to invalid payloads

## Testing
- `mvn -pl backend test` *(fails: unable to download Spring Boot dependencies in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2cd30f60c83309155a94f96e924bd