### PR TITLE
feat: support template partials and settings fallbacks

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/ui/sales/TemplateManagerDialog.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/sales/TemplateManagerDialog.java
@@ -16,7 +16,7 @@ import java.util.Locale;
  * Dialog simple pour gérer les modèles HTML (devis, factures, emails) par agence.
  */
 public class TemplateManagerDialog extends JDialog {
-  private final JComboBox<String> typeCombo = new JComboBox<>(new String[]{"QUOTE", "INVOICE", "EMAIL"});
+  private final JComboBox<String> typeCombo = new JComboBox<>(new String[]{"QUOTE", "INVOICE", "EMAIL", "PARTIAL"});
   private final DefaultListModel<TemplatesGateway.Template> listModel = new DefaultListModel<>();
   private final JList<TemplatesGateway.Template> list = new JList<>(listModel);
   private final JTextField keyField = new JTextField();
@@ -236,7 +236,11 @@ public class TemplateManagerDialog extends JDialog {
     if (selectedType == null){
       return "default";
     }
-    return "EMAIL".equalsIgnoreCase(selectedType) ? "email" : "default";
+    return switch (selectedType.toUpperCase(Locale.ROOT)) {
+      case "EMAIL" -> "email";
+      case "PARTIAL" -> "partial";
+      default -> "default";
+    };
   }
 
   private String defaultName(){
@@ -248,6 +252,7 @@ public class TemplateManagerDialog extends JDialog {
       case "QUOTE" -> "Modèle devis";
       case "INVOICE" -> "Modèle facture";
       case "EMAIL" -> "Modèle email";
+      case "PARTIAL" -> "Bloc partiel";
       default -> "Modèle";
     };
   }

--- a/client/src/main/java/com/materiel/suite/client/ui/settings/TemplatesSettingsPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/settings/TemplatesSettingsPanel.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * Panneau d'administration des modèles HTML (devis, factures, emails).
  */
 public class TemplatesSettingsPanel extends JPanel {
-  private final JComboBox<String> type = new JComboBox<>(new String[]{"QUOTE", "INVOICE", "EMAIL"});
+  private final JComboBox<String> type = new JComboBox<>(new String[]{"QUOTE", "INVOICE", "EMAIL", "PARTIAL"});
   private final DefaultListModel<TemplatesGateway.Template> listModel = new DefaultListModel<>();
   private final JList<TemplatesGateway.Template> list = new JList<>(listModel);
   private final JTextField key = new JTextField(16);
@@ -295,10 +295,17 @@ public class TemplatesSettingsPanel extends JPanel {
     varsList.add("logo.cdi");
     varsList.add("lines.rows");
     varsList.add("lines.tableHtml");
-    if ("QUOTE".equalsIgnoreCase(selectedType) || "EMAIL".equalsIgnoreCase(selectedType)){
+    varsList.add(">partial:cgv");
+    boolean includeQuote = "QUOTE".equalsIgnoreCase(selectedType)
+        || "EMAIL".equalsIgnoreCase(selectedType)
+        || "PARTIAL".equalsIgnoreCase(selectedType);
+    boolean includeInvoice = "INVOICE".equalsIgnoreCase(selectedType)
+        || "EMAIL".equalsIgnoreCase(selectedType)
+        || "PARTIAL".equalsIgnoreCase(selectedType);
+    if (includeQuote){
       varsList.addAll(List.of("quote.reference", "quote.date", "quote.totalHt", "quote.totalTtc"));
     }
-    if ("INVOICE".equalsIgnoreCase(selectedType) || "EMAIL".equalsIgnoreCase(selectedType)){
+    if (includeInvoice){
       varsList.addAll(List.of("invoice.number", "invoice.date", "invoice.totalHt", "invoice.totalTtc", "invoice.status"));
     }
     vars.setVariables(varsList);
@@ -407,6 +414,7 @@ public class TemplatesSettingsPanel extends JPanel {
     }
     return switch (selectedType.toUpperCase(Locale.ROOT)) {
       case "EMAIL" -> "email";
+      case "PARTIAL" -> "partial";
       default -> "default";
     };
   }
@@ -420,12 +428,20 @@ public class TemplatesSettingsPanel extends JPanel {
       case "QUOTE" -> "Modèle devis";
       case "INVOICE" -> "Modèle facture";
       case "EMAIL" -> "Modèle email";
+      case "PARTIAL" -> "Bloc partiel";
       default -> "Modèle";
     };
   }
 
   private String sampleForType(){
     String selectedType = (String) type.getSelectedItem();
+    if ("PARTIAL".equalsIgnoreCase(selectedType)){
+      return """
+<div>
+  <p>Contenu partiel…</p>
+</div>
+""";
+    }
     if ("INVOICE".equalsIgnoreCase(selectedType)){
       return """
 <!DOCTYPE html><html><body>


### PR DESCRIPTION
## Summary
- expand PDF template rendering to resolve `{{>partial:...}}` placeholders and fall back to agency defaults from general settings
- allow template editors to manage a new PARTIAL type and expose the partial token in the variable palette
- reuse general settings VAT/CGV values when agency config is incomplete

## Testing
- mvn -pl client test *(fails: unable to reach repo.maven.apache.org to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d38fa3233883308830fe5620aa2c62