### PR TITLE
feat(client): add live PDF preview for HTML editors

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.apache.pdfbox</groupId>
       <artifactId>pdfbox</artifactId>
-      <version>2.0.29</version>
+      <version>2.0.30</version>
     </dependency>
     <dependency>
       <groupId>com.google.zxing</groupId>

--- a/client/src/main/java/com/materiel/suite/client/ui/common/PdfPreviewPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/common/PdfPreviewPanel.java
@@ -1,0 +1,62 @@
+package com.materiel.suite.client.ui.common;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.rendering.PDFRenderer;
+
+import javax.swing.BorderFactory;
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.GridLayout;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+
+/**
+ * Render a PDF (in bytes) to images for quick previews inside Swing dialogs.
+ */
+public class PdfPreviewPanel extends JPanel {
+  private final JPanel pages;
+  private double dpi = 110d;
+
+  public PdfPreviewPanel() {
+    super(new BorderLayout());
+    pages = new JPanel(new GridLayout(0, 1, 0, 8));
+    pages.setOpaque(true);
+    pages.setBackground(Color.WHITE);
+    add(new JScrollPane(pages), BorderLayout.CENTER);
+  }
+
+  /** Adjust rendering density (min 72 DPI). */
+  public void setDpi(double dpi) {
+    this.dpi = Math.max(72d, dpi);
+  }
+
+  /** Display the provided PDF bytes as images. */
+  public void setPdf(byte[] pdf) {
+    pages.removeAll();
+    if (pdf == null || pdf.length == 0) {
+      revalidate();
+      repaint();
+      return;
+    }
+    try (PDDocument document = PDDocument.load(new ByteArrayInputStream(pdf))) {
+      PDFRenderer renderer = new PDFRenderer(document);
+      int count = document.getNumberOfPages();
+      for (int index = 0; index < count; index++) {
+        BufferedImage image = renderer.renderImageWithDPI(index, (float) dpi);
+        JLabel label = new JLabel(new ImageIcon(image));
+        label.setBorder(BorderFactory.createLineBorder(new Color(230, 230, 230)));
+        pages.add(label);
+      }
+    } catch (Exception ex) {
+      JLabel error = new JLabel("Erreur preview PDF : " + ex.getMessage());
+      error.setForeground(Color.RED.darker());
+      pages.add(error);
+    }
+    revalidate();
+    repaint();
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/common/RichHtmlToolbar.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/common/RichHtmlToolbar.java
@@ -1,0 +1,98 @@
+package com.materiel.suite.client.ui.common;
+
+import javax.swing.Action;
+import javax.swing.JButton;
+import javax.swing.JEditorPane;
+import javax.swing.JOptionPane;
+import javax.swing.JToolBar;
+import javax.swing.text.StyledEditorKit;
+
+/**
+ * Small toolbar with basic rich-text helpers for {@link JEditorPane} HTML editors.
+ */
+public class RichHtmlToolbar extends JToolBar {
+  private final JEditorPane editor;
+
+  public RichHtmlToolbar(JEditorPane editor) {
+    super();
+    this.editor = editor;
+    setFloatable(false);
+    if (editor != null && (editor.getContentType() == null || !editor.getContentType().equalsIgnoreCase("text/html"))) {
+      editor.setContentType("text/html");
+    }
+    add(actionButton(new StyledEditorKit.BoldAction(), "B"));
+    add(actionButton(new StyledEditorKit.ItalicAction(), "I"));
+    add(actionButton(new StyledEditorKit.UnderlineAction(), "U"));
+    addSeparator();
+    add(wrapButton("H1", "<h1>", "</h1>", "Titre"));
+    add(wrapButton("H2", "<h2>", "</h2>", "Sous-titre"));
+    add(insertButton("UL", "<ul><li>Élément</li></ul>"));
+    add(insertButton("OL", "<ol><li>Élément</li></ol>"));
+    addSeparator();
+    add(linkButton());
+  }
+
+  private JButton actionButton(Action action, String label) {
+    JButton button = new JButton(action);
+    button.setText(label);
+    button.setFocusable(false);
+    return button;
+  }
+
+  private JButton wrapButton(String label, String openTag, String closeTag, String fallbackText) {
+    JButton button = new JButton(label);
+    button.setFocusable(false);
+    button.addActionListener(e -> {
+      if (editor == null) {
+        return;
+      }
+      String selected = editor.getSelectedText();
+      if (selected == null || selected.isBlank()) {
+        selected = fallbackText == null ? "" : fallbackText;
+      }
+      editor.replaceSelection(openTag + selected + closeTag);
+      focusEditor();
+    });
+    return button;
+  }
+
+  private JButton insertButton(String label, String markup) {
+    JButton button = new JButton(label);
+    button.setFocusable(false);
+    button.addActionListener(e -> {
+      if (editor == null) {
+        return;
+      }
+      editor.replaceSelection(markup);
+      focusEditor();
+    });
+    return button;
+  }
+
+  private JButton linkButton() {
+    JButton button = new JButton("Lien");
+    button.setFocusable(false);
+    button.addActionListener(e -> {
+      if (editor == null) {
+        return;
+      }
+      String url = JOptionPane.showInputDialog(editor, "URL:", "https://");
+      if (url == null || url.isBlank()) {
+        return;
+      }
+      String selected = editor.getSelectedText();
+      if (selected == null || selected.isBlank()) {
+        selected = url;
+      }
+      editor.replaceSelection("<a href=\"" + url + "\">" + selected + "</a>");
+      focusEditor();
+    });
+    return button;
+  }
+
+  private void focusEditor() {
+    if (editor != null) {
+      editor.requestFocusInWindow();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable PdfPreviewPanel to render PDF bytes into Swing previews
- provide a RichHtmlToolbar with basic HTML editing helpers for JEditorPane editors
- enhance template and settings editors with HTML panes, live PDF previews, and updated toolbar support
- bump the client pdfbox dependency to 2.0.30 to support the new previews

## Testing
- `mvn -pl client test` *(fails: Non-resolvable import POM because Maven Central is unreachable in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d3931806f483308da030f0f5250772