### PR TITLE
Add planning cards view enhancements

### DIFF
--- a/client/src/main/java/com/materiel/suite/client/service/ServiceLocator.java
+++ b/client/src/main/java/com/materiel/suite/client/service/ServiceLocator.java
@@ -4,6 +4,7 @@ import com.materiel.suite.client.agency.AgencyContext;
 import com.materiel.suite.client.auth.AuthService;
 import com.materiel.suite.client.model.InterventionType;
 import com.materiel.suite.client.model.Resource;
+import com.materiel.suite.client.model.ResourceType;
 import com.materiel.suite.client.net.ServiceFactory;
 import com.materiel.suite.client.service.AgencyConfigGateway;
 import com.materiel.suite.client.service.DocumentTemplateService;
@@ -104,6 +105,11 @@ public final class ServiceLocator {
     public List<Resource> listAll(){
       PlanningService svc = ServiceFactory.planning();
       return svc != null ? svc.listResources() : List.of();
+    }
+
+    public List<ResourceType> listTypes(){
+      PlanningService svc = ServiceFactory.planning();
+      return svc != null ? svc.listResourceTypes() : List.of();
     }
 
     public Resource save(Resource resource){

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/IconUtil.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/IconUtil.java
@@ -1,0 +1,83 @@
+package com.materiel.suite.client.ui.planning;
+
+import com.materiel.suite.client.ui.icons.IconRegistry;
+
+import javax.swing.*;
+import java.util.Locale;
+
+/**
+ * Small helper used by planning tiles to retrieve icons based on loose keys.
+ * It normalizes common resource labels (ex: "grue", "truck") to the
+ * {@link IconRegistry} vocabulary while keeping the dependency optional.
+ */
+final class IconUtil {
+  private IconUtil(){
+  }
+
+  static Icon colored(String key, int size){
+    if (key == null || key.isBlank() || size <= 0){
+      return null;
+    }
+    String normalized = normalize(key);
+    if (normalized == null || normalized.isBlank()){
+      return null;
+    }
+    Icon icon = IconRegistry.load(normalized, size);
+    if (icon != null){
+      return icon;
+    }
+    String fallback = key.trim().toLowerCase(Locale.ROOT);
+    if (!fallback.equals(normalized)){
+      icon = IconRegistry.load(fallback, size);
+    }
+    return icon;
+  }
+
+  private static String normalize(String key){
+    String lower = key.trim().toLowerCase(Locale.ROOT);
+    if (lower.isEmpty()){
+      return "";
+    }
+    if (lower.contains("grue") || lower.contains("crane")){
+      return "crane";
+    }
+    if (lower.contains("camion") || lower.contains("truck")){
+      return "truck";
+    }
+    if (lower.contains("chariot") || lower.contains("forklift")){
+      return "forklift";
+    }
+    if (lower.contains("pelle") || lower.contains("excavator")){
+      return "excavator";
+    }
+    if (lower.contains("generator") || lower.contains("générateur") || lower.contains("generateur")){
+      return "generator";
+    }
+    if (lower.contains("hook") || lower.contains("crochet")){
+      return "hook";
+    }
+    if (lower.contains("casque") || lower.contains("helmet") || lower.contains("ouvrier")
+        || lower.contains("worker") || lower.contains("tech") || lower.contains("chauffeur")){
+      return "helmet";
+    }
+    if (lower.contains("pallet") || lower.contains("palette")){
+      return "pallet";
+    }
+    if (lower.contains("badge")){
+      return "badge";
+    }
+    if (lower.contains("wrench") || lower.contains("outil") || lower.contains("maintenance")){
+      return "wrench";
+    }
+    if (lower.contains("container")){
+      return "container";
+    }
+    if (lower.contains("info")){
+      return "info";
+    }
+    if (lower.contains("file")){
+      return "file";
+    }
+    return lower.replaceAll("[^a-z0-9_-]", "");
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionTilePanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/InterventionTilePanel.java
@@ -1,0 +1,407 @@
+package com.materiel.suite.client.ui.planning;
+
+import com.materiel.suite.client.model.Intervention;
+import com.materiel.suite.client.model.InterventionType;
+import com.materiel.suite.client.model.ResourceRef;
+import org.apache.commons.text.StringEscapeUtils;
+
+import javax.imageio.ImageIO;
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseWheelEvent;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Lightweight panel used in the planning module to display an intervention as a "card".
+ * It exposes a listener for common actions (open, edit, mark done, adjust time).
+ */
+public class InterventionTilePanel extends JPanel {
+  public interface Listener {
+    void onOpen(Intervention intervention);
+    void onEdit(Intervention intervention);
+    void onMarkDone(Intervention intervention);
+    void onTimeAdjust(Intervention intervention, boolean start, int minutesDelta);
+  }
+
+  private static final DateTimeFormatter DAY_FORMAT =
+      DateTimeFormatter.ofPattern("EEEE d MMMM", Locale.FRENCH);
+  private static final DateTimeFormatter DATE_SHORT =
+      DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.FRENCH);
+  private static final DateTimeFormatter DATE_TIME =
+      DateTimeFormatter.ofPattern("dd/MM HH:mm", Locale.FRENCH);
+
+  private static final Color STATUS_DEFAULT = new Color(0x1F4ED8);
+  private static final Color STATUS_DONE = new Color(0x2E7D32);
+  private static final Color STATUS_IN_PROGRESS = new Color(0xF59E0B);
+  private static final Color STATUS_CANCELLED = new Color(0xB91C1C);
+
+  private final Intervention intervention;
+  private final Listener listener;
+  private boolean compact;
+
+  public InterventionTilePanel(Intervention intervention, Listener listener){
+    this.intervention = intervention;
+    this.listener = listener;
+    setOpaque(true);
+    setBackground(Color.WHITE);
+    setLayout(new BorderLayout(0, 8));
+    setToolTipText("Ctrl + molette : ajuster début · Maj + molette : ajuster fin");
+    buildUI();
+    installInteractions();
+  }
+
+  private void installInteractions(){
+    addMouseListener(new MouseAdapter(){
+      @Override public void mouseClicked(MouseEvent e){
+        if (listener != null && SwingUtilities.isLeftMouseButton(e) && e.getClickCount() == 2){
+          listener.onOpen(intervention);
+        }
+      }
+    });
+    addMouseWheelListener(this::onMouseWheel);
+  }
+
+  private void onMouseWheel(MouseWheelEvent event){
+    if (listener == null){
+      return;
+    }
+    boolean ctrl = event.isControlDown();
+    boolean shift = event.isShiftDown();
+    if (!ctrl && !shift){
+      return;
+    }
+    int rotation = event.getWheelRotation();
+    if (rotation == 0){
+      return;
+    }
+    int minutes = (rotation > 0 ? 1 : -1) * 15;
+    if (ctrl){
+      listener.onTimeAdjust(intervention, true, minutes);
+      event.consume();
+    } else if (shift){
+      listener.onTimeAdjust(intervention, false, minutes);
+      event.consume();
+    }
+  }
+
+  private void buildUI(){
+    removeAll();
+    setBorder(new EmptyBorder(compact ? 6 : 10, compact ? 8 : 12, compact ? 6 : 10, compact ? 8 : 12));
+    add(buildHeader(), BorderLayout.NORTH);
+    add(buildBody(), BorderLayout.CENTER);
+    add(buildFooter(), BorderLayout.SOUTH);
+    revalidate();
+    repaint();
+  }
+
+  private JComponent buildHeader(){
+    JPanel header = new JPanel(new BorderLayout(8, 0));
+    header.setOpaque(false);
+
+    String client = escape(nonBlank(intervention != null ? intervention.getClientName() : null, "Client"));
+    String title = escape(nonBlank(intervention != null ? intervention.getLabel() : null, "Intervention"));
+    JLabel label = new JLabel("<html><b>" + client + "</b> — " + title + "</html>");
+    label.setFont(label.getFont().deriveFont(Font.PLAIN, adjustFont(label.getFont().getSize2D(), compact ? -0.5f : 0f)));
+    header.add(label, BorderLayout.CENTER);
+
+    JPanel right = new JPanel(new FlowLayout(FlowLayout.RIGHT, 6, 0));
+    right.setOpaque(false);
+
+    JLabel dot = new JLabel("●");
+    dot.setForeground(colorForStatus(intervention != null ? intervention.getStatus() : null));
+    right.add(dot);
+
+    JLabel status = new JLabel(escape(statusLabel()));
+    Font statusFont = status.getFont();
+    if (statusFont != null){
+      status.setFont(statusFont.deriveFont(Font.BOLD, adjustFont(statusFont.getSize2D(), compact ? -1f : 0f)));
+    }
+    right.add(status);
+
+    String badgeText = badgeText();
+    if (!badgeText.isEmpty()){
+      JLabel badge = new JLabel(badgeText);
+      badge.setOpaque(true);
+      badge.setForeground(new Color(0x0F172A));
+      badge.setBackground(new Color(0xE2E8F0));
+      badge.setBorder(new EmptyBorder(1, 6, 1, 6));
+      right.add(badge);
+    }
+
+    header.add(right, BorderLayout.EAST);
+    return header;
+  }
+
+  private JComponent buildBody(){
+    JPanel body = new JPanel(new GridBagLayout());
+    body.setOpaque(false);
+    GridBagConstraints gc = new GridBagConstraints();
+    gc.gridx = 0;
+    gc.gridy = 0;
+    gc.anchor = GridBagConstraints.WEST;
+    gc.insets = new Insets(compact ? 2 : 4, 0, compact ? 2 : 4, 0);
+
+    body.add(row("Date", formatDateRange()), gc);
+    gc.gridy++;
+    body.add(row("Horaire", formatTimeRange()), gc);
+    gc.gridy++;
+    body.add(row("Ressources", formatResources()), gc);
+    gc.gridy++;
+    body.add(row("Infos", formatInfos()), gc);
+
+    return body;
+  }
+
+  private JPanel buildFooter(){
+    JPanel footer = new JPanel(new FlowLayout(FlowLayout.RIGHT, 8, 0));
+    footer.setOpaque(false);
+
+    JButton open = new JButton("Ouvrir");
+    JButton edit = new JButton("Éditer");
+    JButton done = new JButton("Terminer");
+
+    if (compact){
+      Dimension dim = new Dimension(80, 24);
+      open.setPreferredSize(dim);
+      edit.setPreferredSize(dim);
+      done.setPreferredSize(new Dimension(90, 24));
+      float size = adjustFont(open.getFont().getSize2D(), -1f);
+      open.setFont(open.getFont().deriveFont(size));
+      edit.setFont(edit.getFont().deriveFont(size));
+      done.setFont(done.getFont().deriveFont(size));
+    }
+
+    open.addActionListener(e -> {
+      if (listener != null){
+        listener.onOpen(intervention);
+      }
+    });
+    edit.addActionListener(e -> {
+      if (listener != null){
+        listener.onEdit(intervention);
+      }
+    });
+    done.addActionListener(e -> {
+      if (listener != null){
+        listener.onMarkDone(intervention);
+      }
+    });
+
+    footer.add(open);
+    footer.add(edit);
+    footer.add(done);
+    return footer;
+  }
+
+  private JPanel row(String label, String valueHtml){
+    JPanel row = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 0));
+    row.setOpaque(false);
+    String escapedLabel = escape(label);
+    JLabel l = new JLabel("<html><span style='color:#666666'>" + escapedLabel + "</span>: " + valueHtml + "</html>");
+    if (compact){
+      l.setFont(l.getFont().deriveFont(adjustFont(l.getFont().getSize2D(), -1f)));
+    }
+    row.add(l);
+    return row;
+  }
+
+  private String formatDateRange(){
+    LocalDate start = toLocalDate(intervention != null ? intervention.getDateHeureDebut() : null);
+    LocalDate end = toLocalDate(intervention != null ? intervention.getDateHeureFin() : null);
+    if (start == null && end == null){
+      return "<i>—</i>";
+    }
+    if (start != null && end != null && start.equals(end)){
+      return escape(DAY_FORMAT.format(start));
+    }
+    String from = start != null ? escape(DATE_SHORT.format(start)) : "—";
+    String to = end != null ? escape(DATE_SHORT.format(end)) : "—";
+    return from + " → " + to;
+  }
+
+  private String formatTimeRange(){
+    LocalDateTime start = intervention != null ? intervention.getDateHeureDebut() : null;
+    LocalDateTime end = intervention != null ? intervention.getDateHeureFin() : null;
+    if (start == null && end == null){
+      return "<i>—</i>";
+    }
+    if (start != null && end != null){
+      return escape(start.format(DATE_TIME)) + " → " + escape(end.format(DATE_TIME));
+    }
+    if (start != null){
+      return escape(start.format(DATE_TIME));
+    }
+    return escape(end.format(DATE_TIME));
+  }
+
+  private String formatResources(){
+    if (intervention == null){
+      return "<i>Aucune</i>";
+    }
+    List<ResourceRef> refs = intervention.getResources();
+    if (refs == null || refs.isEmpty()){
+      return "<i>Aucune</i>";
+    }
+    List<String> parts = new ArrayList<>();
+    for (ResourceRef ref : refs){
+      if (ref == null){
+        continue;
+      }
+      String label = escape(nonBlank(ref.getName(), "Ressource"));
+      Icon icon = IconUtil.colored(nonBlank(ref.getIcon(), label), compact ? 14 : 16);
+      if (icon != null){
+        parts.add(img(icon) + " " + label);
+      } else {
+        parts.add("🔧 " + label);
+      }
+    }
+    return String.join("  •  ", parts);
+  }
+
+  private String formatInfos(){
+    List<String> parts = new ArrayList<>();
+    parts.add("⏱ " + escape(formatDuration()));
+    InterventionType type = intervention != null ? intervention.getType() : null;
+    if (type != null){
+      String label = nonBlank(type.getLabel(), type.getCode());
+      if (!label.isEmpty()){
+        parts.add("🧾 " + escape(label));
+      }
+    }
+    String agency = intervention != null ? nonBlank(intervention.getAgency(), intervention.getAgencyId()) : "";
+    if (!agency.isEmpty()){
+      parts.add("🏢 " + escape(agency));
+    }
+    return String.join("   •   ", parts);
+  }
+
+  private String formatDuration(){
+    LocalDateTime start = intervention != null ? intervention.getDateHeureDebut() : null;
+    LocalDateTime end = intervention != null ? intervention.getDateHeureFin() : null;
+    if (start == null || end == null){
+      return "Durée inconnue";
+    }
+    long minutes = Duration.between(start, end).toMinutes();
+    if (minutes <= 0){
+      return "< 15 min";
+    }
+    long hours = minutes / 60;
+    long rest = minutes % 60;
+    if (hours > 0 && rest > 0){
+      return hours + "h" + String.format(Locale.FRENCH, "%02d", rest);
+    }
+    if (hours > 0){
+      return hours + "h";
+    }
+    return minutes + " min";
+  }
+
+  private String statusLabel(){
+    if (intervention == null){
+      return "Planifiée";
+    }
+    String status = intervention.getStatus();
+    if (status != null && !status.isBlank()){
+      return status;
+    }
+    return "Planifiée";
+  }
+
+  private Color colorForStatus(String status){
+    if (status == null){
+      return STATUS_DEFAULT;
+    }
+    String value = status.toLowerCase(Locale.ROOT);
+    if (value.contains("done") || value.contains("term")){
+      return STATUS_DONE;
+    }
+    if (value.contains("cours") || value.contains("progress")){
+      return STATUS_IN_PROGRESS;
+    }
+    if (value.contains("annul") || value.contains("cancel")){
+      return STATUS_CANCELLED;
+    }
+    return STATUS_DEFAULT;
+  }
+
+  private String badgeText(){
+    if (intervention == null){
+      return "";
+    }
+    StringBuilder sb = new StringBuilder();
+    if (intervention.isFavorite()){
+      sb.append('★');
+    }
+    if (intervention.isLocked()){
+      if (sb.length() > 0){
+        sb.append(' ');
+      }
+      sb.append('🔒');
+    }
+    return sb.toString();
+  }
+
+  private String img(Icon icon){
+    if (icon == null){
+      return "";
+    }
+    int width = Math.max(1, icon.getIconWidth());
+    int height = Math.max(1, icon.getIconHeight());
+    BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+    Graphics2D g2 = image.createGraphics();
+    try {
+      g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+      icon.paintIcon(null, g2, 0, 0);
+    } finally {
+      g2.dispose();
+    }
+    try {
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      ImageIO.write(image, "png", baos);
+      String b64 = Base64.getEncoder().encodeToString(baos.toByteArray());
+      return "<img src='data:image/png;base64," + b64 + "' height='" + height + "' valign='middle'/>";
+    } catch (Exception ex){
+      return "";
+    }
+  }
+
+  private static String escape(String text){
+    return StringEscapeUtils.escapeHtml4(text == null ? "" : text);
+  }
+
+  private static String nonBlank(String value, String fallback){
+    if (value != null && !value.isBlank()){
+      return value;
+    }
+    return fallback != null ? fallback : "";
+  }
+
+  private static float adjustFont(float base, float delta){
+    float size = base + delta;
+    return Math.max(10f, size);
+  }
+
+  private static LocalDate toLocalDate(LocalDateTime dateTime){
+    return dateTime != null ? dateTime.toLocalDate() : null;
+  }
+
+  public void setCompact(boolean compact){
+    if (this.compact == compact){
+      return;
+    }
+    this.compact = compact;
+    buildUI();
+  }
+}

--- a/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
+++ b/client/src/main/java/com/materiel/suite/client/ui/planning/PlanningPanel.java
@@ -19,6 +19,13 @@ import java.awt.Insets;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetAdapter;
+import java.awt.dnd.DropTargetDropEvent;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
@@ -43,9 +50,11 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.nio.charset.StandardCharsets;
@@ -54,12 +63,14 @@ import java.util.Objects;
 import javax.swing.AbstractAction;
 import javax.swing.ActionMap;
 import javax.swing.Box;
+import javax.swing.BoxLayout;
 import javax.swing.DefaultListModel;
 import javax.swing.JButton;
 import javax.swing.JFileChooser;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JDialog;
+import javax.swing.JCheckBox;
 import javax.swing.InputMap;
 import javax.swing.JLabel;
 import javax.swing.JList;
@@ -71,6 +82,7 @@ import javax.swing.JViewport;
 import javax.swing.JSeparator;
 import javax.swing.JSlider;
 import javax.swing.JSpinner;
+import javax.swing.DefaultComboBoxModel;
 import javax.swing.JTabbedPane;
 import javax.swing.JToggleButton;
 import javax.swing.JTextArea;
@@ -81,6 +93,7 @@ import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 import javax.swing.SwingConstants;
 import javax.swing.JPopupMenu;
+import javax.swing.TransferHandler;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
@@ -177,6 +190,15 @@ public class PlanningPanel extends JPanel {
   private List<Intervention> allInterventions = List.of();
   private List<Intervention> currentSelection = List.of();
   private boolean kanbanHasError;
+  private JPanel cardsPanel;
+  private JPanel cardsContainer;
+  private JComboBox<String> cardsStatusFilter;
+  private JCheckBox cardsToQuoteFilter;
+  private JComboBox<String> cardsResourceTypeFilter;
+  private JComboBox<String> cardsAgencyFilter;
+  private JToggleButton cardsDensityToggle;
+  private List<Intervention> cardItems = List.of();
+  private final Map<UUID, Resource> resourceCatalog = new HashMap<>();
 
   public PlanningPanel(){
     super(new BorderLayout());
@@ -277,6 +299,8 @@ public class PlanningPanel extends JPanel {
     tabs.addTab("Calendrier", IconRegistry.small("calendar"), calendarView.getComponent());
     tabs.addTab("Liste", IconRegistry.small("file"), tableView.getComponent());
     tabs.addTab("Pipeline", IconRegistry.small("invoice"), kanbanView);
+    cardsPanel = buildCardsTab();
+    tabs.addTab("Cartes", IconRegistry.small("info"), cardsPanel);
     tabs.addChangeListener(e -> updateModeToggleState());
     add(tabs, BorderLayout.CENTER);
     kanbanView.setListener(new KanbanPanel.Listener(){
@@ -305,6 +329,8 @@ public class PlanningPanel extends JPanel {
       @Override public void removeUpdate(DocumentEvent e){ applySearch(); }
       @Override public void changedUpdate(DocumentEvent e){ applySearch(); }
     });
+    installCardDropTarget();
+    reloadCardFilters();
     updateModeToggleState();
 
     // Injecte un renderer « propre » si le board expose l’API.
@@ -1704,6 +1730,18 @@ public class PlanningPanel extends JPanel {
     return value == null ? "" : value.trim();
   }
 
+  private static String firstNonBlank(String... values){
+    if (values == null){
+      return "";
+    }
+    for (String value : values){
+      if (value != null && !value.isBlank()){
+        return value;
+      }
+    }
+    return "";
+  }
+
   private static String csvRow(String[] values){
     if (values == null || values.length == 0){
       return "";
@@ -1981,6 +2019,7 @@ public class PlanningPanel extends JPanel {
     }
     calendarView.setMode(isMonthSelected() ? "Mois" : "Semaine");
     allInterventions = sanitizeInterventions(list);
+    reloadCardFilters();
     updateFilteredSimpleViews();
     if (success){
       Toasts.info(this, allInterventions.size() + " intervention(s) chargée(s)");
@@ -2047,9 +2086,431 @@ public class PlanningPanel extends JPanel {
       calendarView.setData(filtered);
       tableView.setData(filtered);
     }
+    updateCardDataset(dataset);
     if (!kanbanHasError){
       kanbanView.setData(dataset);
       applySearch();
+    }
+  }
+
+  private JPanel buildCardsTab(){
+    JPanel panel = new JPanel(new BorderLayout());
+    panel.setOpaque(false);
+
+    JPanel filterBar = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 8));
+    filterBar.setOpaque(false);
+    cardsStatusFilter = new JComboBox<>(new String[]{"Tous", "Planifié", "En cours", "Terminé", "Annulé", "Brouillon"});
+    cardsToQuoteFilter = new JCheckBox("À deviser");
+    cardsResourceTypeFilter = new JComboBox<>(new String[]{"Tous"});
+    cardsAgencyFilter = new JComboBox<>(new String[]{"Toutes"});
+    cardsDensityToggle = new JToggleButton("Mode compact");
+    cardsDensityToggle.setToolTipText("Réduire l'espacement des cartes");
+
+    filterBar.add(new JLabel("Statut"));
+    filterBar.add(cardsStatusFilter);
+    filterBar.add(cardsToQuoteFilter);
+    filterBar.add(new JLabel("Type res."));
+    filterBar.add(cardsResourceTypeFilter);
+    filterBar.add(new JLabel("Agence"));
+    filterBar.add(cardsAgencyFilter);
+    filterBar.add(cardsDensityToggle);
+
+    cardsContainer = new JPanel();
+    cardsContainer.setOpaque(false);
+    cardsContainer.setLayout(new BoxLayout(cardsContainer, BoxLayout.Y_AXIS));
+    cardsContainer.setBorder(new EmptyBorder(12, 12, 12, 12));
+
+    JScrollPane scroll = new JScrollPane(cardsContainer,
+        JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+        JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+    scroll.getVerticalScrollBar().setUnitIncrement(24);
+    scroll.getViewport().setBackground(Color.WHITE);
+    scroll.setBorder(null);
+
+    panel.add(filterBar, BorderLayout.NORTH);
+    panel.add(scroll, BorderLayout.CENTER);
+
+    cardsStatusFilter.addActionListener(e -> applyCardFilters());
+    cardsToQuoteFilter.addActionListener(e -> applyCardFilters());
+    cardsResourceTypeFilter.addActionListener(e -> applyCardFilters());
+    cardsAgencyFilter.addActionListener(e -> applyCardFilters());
+    cardsDensityToggle.addActionListener(e -> applyCardFilters());
+
+    return panel;
+  }
+
+  private void updateCardDataset(List<Intervention> dataset){
+    cardItems = dataset == null ? List.of() : List.copyOf(dataset);
+    applyCardFilters();
+  }
+
+  private void applyCardFilters(){
+    if (cardsContainer == null){
+      return;
+    }
+    List<Intervention> base = cardItems != null ? cardItems : List.of();
+    String status = cardsStatusFilter != null ? String.valueOf(cardsStatusFilter.getSelectedItem()) : "Tous";
+    boolean onlyToQuote = cardsToQuoteFilter != null && cardsToQuoteFilter.isSelected();
+    String resourceType = cardsResourceTypeFilter != null ? String.valueOf(cardsResourceTypeFilter.getSelectedItem()) : "Tous";
+    String agency = cardsAgencyFilter != null ? String.valueOf(cardsAgencyFilter.getSelectedItem()) : "Toutes";
+    boolean compact = cardsDensityToggle != null && cardsDensityToggle.isSelected();
+
+    List<Intervention> filtered = new ArrayList<>();
+    for (Intervention intervention : base){
+      if (intervention == null){
+        continue;
+      }
+      if (!"Tous".equals(status) && !matchesStatus(intervention, status)){
+        continue;
+      }
+      if (onlyToQuote && intervention.hasQuote()){
+        continue;
+      }
+      if (!"Tous".equals(resourceType) && !resourceType.isBlank() && !hasResourceType(intervention, resourceType)){
+        continue;
+      }
+      if (!"Toutes".equals(agency) && !matchesAgency(intervention, agency)){
+        continue;
+      }
+      filtered.add(intervention);
+    }
+    renderCards(filtered, compact);
+  }
+
+  private boolean matchesStatus(Intervention intervention, String filter){
+    String status = intervention.getStatus();
+    if (status == null){
+      return "Planifié".equals(filter) || "Tous".equals(filter);
+    }
+    String lower = status.toLowerCase(Locale.ROOT);
+    return switch (filter) {
+      case "Planifié" -> lower.contains("plan");
+      case "En cours" -> lower.contains("cours") || lower.contains("progress");
+      case "Terminé" -> lower.contains("term") || lower.contains("done");
+      case "Annulé" -> lower.contains("annul") || lower.contains("cancel");
+      case "Brouillon" -> lower.contains("brou") || lower.contains("draft");
+      default -> true;
+    };
+  }
+
+  private boolean matchesAgency(Intervention intervention, String filter){
+    if (filter == null || filter.isBlank()){
+      return true;
+    }
+    String agencyName = intervention.getAgency();
+    if (agencyName != null && agencyName.equalsIgnoreCase(filter)){
+      return true;
+    }
+    String agencyId = intervention.getAgencyId();
+    return agencyId != null && agencyId.equalsIgnoreCase(filter);
+  }
+
+  private boolean hasResourceType(Intervention intervention, String filter){
+    if (intervention == null || filter == null || filter.isBlank()){
+      return false;
+    }
+    String expected = filter.trim().toLowerCase(Locale.ROOT);
+    List<ResourceRef> refs = intervention.getResources();
+    if (refs == null || refs.isEmpty()){
+      return false;
+    }
+    for (ResourceRef ref : refs){
+      if (ref == null){
+        continue;
+      }
+      Resource resource = ref.getId() != null ? resourceCatalog.get(ref.getId()) : null;
+      if (resource != null){
+        String label = resource.getTypeLabel();
+        if (label != null && label.trim().equalsIgnoreCase(filter)){
+          return true;
+        }
+        String code = resource.getTypeCode();
+        if (code != null && code.trim().equalsIgnoreCase(expected)){
+          return true;
+        }
+      }
+      String icon = ref.getIcon();
+      if (icon != null && icon.trim().equalsIgnoreCase(expected)){
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void renderCards(List<Intervention> items, boolean compact){
+    cardsContainer.removeAll();
+    if (items == null || items.isEmpty()){
+      JLabel empty = new JLabel("Aucune intervention ne correspond aux filtres.");
+      empty.setForeground(UiTokens.textMuted());
+      empty.setBorder(new EmptyBorder(20, 12, 20, 12));
+      cardsContainer.add(empty);
+    } else {
+      boolean first = true;
+      for (Intervention intervention : items){
+        if (!first){
+          cardsContainer.add(Box.createVerticalStrut(compact ? 6 : 12));
+        }
+        first = false;
+        Intervention current = intervention;
+        InterventionTilePanel tile = new InterventionTilePanel(current, new InterventionTilePanel.Listener(){
+          @Override public void onOpen(Intervention it){ openInterventionEditor(it); }
+          @Override public void onEdit(Intervention it){ openInterventionEditor(it); }
+          @Override public void onMarkDone(Intervention it){ markInterventionDone(it); }
+          @Override public void onTimeAdjust(Intervention it, boolean start, int minutesDelta){
+            adjustInterventionTime(it, start, minutesDelta);
+          }
+        });
+        tile.setCompact(compact);
+        tile.setAlignmentX(Component.LEFT_ALIGNMENT);
+        tile.setMaximumSize(new Dimension(Integer.MAX_VALUE, tile.getPreferredSize().height));
+        tile.setTransferHandler(new TransferHandler(){
+          @Override public int getSourceActions(JComponent c){
+            return MOVE;
+          }
+          @Override protected Transferable createTransferable(JComponent c){
+            if (current == null || current.getId() == null){
+              return null;
+            }
+            return new StringSelection(current.getId().toString());
+          }
+        });
+        tile.addMouseListener(new MouseAdapter(){
+          @Override public void mousePressed(MouseEvent e){
+            JComponent src = (JComponent) e.getSource();
+            TransferHandler handler = src.getTransferHandler();
+            if (handler != null){
+              handler.exportAsDrag(src, e, TransferHandler.MOVE);
+            }
+          }
+        });
+        cardsContainer.add(tile);
+      }
+    }
+    cardsContainer.revalidate();
+    cardsContainer.repaint();
+  }
+
+  private void reloadCardFilters(){
+    if (cardsResourceTypeFilter != null){
+      String selection = String.valueOf(cardsResourceTypeFilter.getSelectedItem());
+      List<String> options = new ArrayList<>();
+      options.add("Tous");
+      try {
+        var gateway = ServiceLocator.resources();
+        if (gateway != null){
+          for (var type : gateway.listTypes()){
+            if (type == null){
+              continue;
+            }
+            String label = firstNonBlank(type.getName(), type.getLabel(), type.getCode());
+            if (!label.isBlank() && !options.contains(label)){
+              options.add(label);
+            }
+          }
+        }
+      } catch (Exception ignore){
+      }
+      cardsResourceTypeFilter.setModel(new DefaultComboBoxModel<>(options.toArray(new String[0])));
+      if (selection != null && options.contains(selection)){
+        cardsResourceTypeFilter.setSelectedItem(selection);
+      }
+    }
+    if (cardsAgencyFilter != null){
+      String selection = String.valueOf(cardsAgencyFilter.getSelectedItem());
+      Set<String> agencies = new LinkedHashSet<>();
+      agencies.add("Toutes");
+      if (allInterventions != null){
+        for (Intervention intervention : allInterventions){
+          if (intervention == null){
+            continue;
+          }
+          String label = firstNonBlank(intervention.getAgency(), intervention.getAgencyId());
+          if (!label.isBlank()){
+            agencies.add(label);
+          }
+        }
+      }
+      cardsAgencyFilter.setModel(new DefaultComboBoxModel<>(agencies.toArray(new String[0])));
+      if (selection != null && agencies.contains(selection)){
+        cardsAgencyFilter.setSelectedItem(selection);
+      }
+    }
+    loadResourceCatalog();
+    applyCardFilters();
+  }
+
+  private void loadResourceCatalog(){
+    resourceCatalog.clear();
+    PlanningService planning = ServiceFactory.planning();
+    if (planning == null){
+      return;
+    }
+    try {
+      List<Resource> resources = planning.listResources();
+      if (resources != null){
+        for (Resource resource : resources){
+          if (resource != null && resource.getId() != null){
+            resourceCatalog.put(resource.getId(), resource);
+          }
+        }
+      }
+    } catch (Exception ignore){
+    }
+  }
+
+  private void installCardDropTarget(){
+    try {
+      new DropTarget(board, new DropTargetAdapter(){
+        @Override public void drop(DropTargetDropEvent dtde){
+          if (!dtde.isDataFlavorSupported(DataFlavor.stringFlavor)){
+            dtde.rejectDrop();
+            return;
+          }
+          try {
+            dtde.acceptDrop(DnDConstants.ACTION_MOVE);
+            Transferable transferable = dtde.getTransferable();
+            String id = (String) transferable.getTransferData(DataFlavor.stringFlavor);
+            Point location = dtde.getLocation();
+            LocalDateTime when = boardTimeAt(location);
+            if (id != null && when != null){
+              moveInterventionStart(id, when);
+              dtde.dropComplete(true);
+            } else {
+              dtde.dropComplete(false);
+            }
+          } catch (Exception ex){
+            dtde.dropComplete(false);
+          }
+        }
+      });
+    } catch (Exception ignore){
+    }
+  }
+
+  private LocalDateTime boardTimeAt(Point point){
+    if (point == null){
+      return null;
+    }
+    int slotWidth = Math.max(1, board.getSlotWidth());
+    int slotMinutes = Math.max(1, board.getSlotMinutes());
+    int slotsPerDay = Math.max(1, board.getSlotsPerDay());
+    int x = Math.max(0, point.x);
+    int slot = x / slotWidth;
+    int dayIndex = slot / slotsPerDay;
+    int slotInDay = slot % slotsPerDay;
+    LocalDate startDate = board.getStartDate();
+    if (startDate == null){
+      startDate = LocalDate.now().with(DayOfWeek.MONDAY);
+    }
+    LocalDate day = startDate.plusDays(dayIndex);
+    int minutes = slotInDay * slotMinutes;
+    return day.atStartOfDay().plusMinutes(minutes);
+  }
+
+  private void moveInterventionStart(String id, LocalDateTime newStart){
+    if (id == null || id.isBlank() || newStart == null){
+      return;
+    }
+    UUID uuid;
+    try {
+      uuid = UUID.fromString(id);
+    } catch (IllegalArgumentException ex){
+      return;
+    }
+    Intervention target = null;
+    for (Intervention intervention : allInterventions){
+      if (intervention != null && uuid.equals(intervention.getId())){
+        target = intervention;
+        break;
+      }
+    }
+    if (target == null){
+      return;
+    }
+    PlanningService planning = ServiceFactory.planning();
+    if (planning == null){
+      Toasts.error(this, "Service planning indisponible.");
+      return;
+    }
+    try {
+      LocalDateTime oldStart = target.getDateHeureDebut();
+      LocalDateTime oldEnd = target.getDateHeureFin();
+      long duration = 60;
+      if (oldStart != null && oldEnd != null){
+        duration = Duration.between(oldStart, oldEnd).toMinutes();
+        if (duration <= 0){
+          duration = 15;
+        }
+      }
+      LocalDateTime newEnd = newStart.plusMinutes(duration);
+      target.setDateHeureDebut(newStart);
+      target.setDateHeureFin(newEnd);
+      planning.saveIntervention(target);
+      Toasts.success(this, "Intervention déplacée à " + newStart.format(SIMPLE_DAY_TIME_FORMAT));
+      refreshPlanning();
+    } catch (Exception ex){
+      Toasts.error(this, "Déplacement impossible : " + ex.getMessage());
+    }
+  }
+
+  private void adjustInterventionTime(Intervention intervention, boolean start, int minutesDelta){
+    if (intervention == null || minutesDelta == 0){
+      return;
+    }
+    PlanningService planning = ServiceFactory.planning();
+    if (planning == null){
+      Toasts.error(this, "Service planning indisponible.");
+      return;
+    }
+    try {
+      if (start){
+        LocalDateTime base = intervention.getDateHeureDebut();
+        if (base == null){
+          base = intervention.getStartDateTime();
+        }
+        LocalDateTime updated = base.plusMinutes(minutesDelta);
+        intervention.setDateHeureDebut(updated);
+        LocalDateTime end = intervention.getDateHeureFin();
+        if (end != null && !end.isAfter(updated)){
+          intervention.setDateHeureFin(updated.plusMinutes(15));
+        }
+      } else {
+        LocalDateTime base = intervention.getDateHeureFin();
+        if (base == null){
+          base = intervention.getEndDateTime();
+        }
+        LocalDateTime updated = base.plusMinutes(minutesDelta);
+        LocalDateTime startDt = intervention.getDateHeureDebut();
+        if (startDt != null && !updated.isAfter(startDt)){
+          updated = startDt.plusMinutes(15);
+        }
+        intervention.setDateHeureFin(updated);
+      }
+      planning.saveIntervention(intervention);
+      String delta = minutesDelta > 0 ? "+" + minutesDelta : String.valueOf(minutesDelta);
+      Toasts.success(this, (start ? "Début" : "Fin") + " ajusté(e) de " + delta + " min");
+      refreshPlanning();
+    } catch (Exception ex){
+      Toasts.error(this, "Ajustement impossible : " + ex.getMessage());
+    }
+  }
+
+  private void markInterventionDone(Intervention intervention){
+    if (intervention == null){
+      return;
+    }
+    PlanningService planning = ServiceFactory.planning();
+    if (planning == null){
+      Toasts.error(this, "Service planning indisponible.");
+      return;
+    }
+    try {
+      intervention.setStatus("DONE");
+      planning.saveIntervention(intervention);
+      Toasts.success(this, "Intervention marquée comme terminée");
+      refreshPlanning();
+    } catch (Exception ex){
+      Toasts.error(this, "Impossible de mettre à jour l'intervention : " + ex.getMessage());
     }
   }
 


### PR DESCRIPTION
## Summary
- add a reusable IconUtil helper and an InterventionTilePanel component powering planning cards
- extend ServiceLocator to expose resource types and wire a new cards tab with filters, DnD and time adjustments in PlanningPanel

## Testing
- mvn -pl client -am -DskipTests compile *(fails: dependency download blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d39d3fc6e88330b4f05379831267ae